### PR TITLE
Log path of the toolchain used to opening a document

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -524,7 +524,12 @@ public actor SourceKitLSPServer {
       return nil
     }
 
-    logger.log("Using toolchain \(toolchain.identifier) (\(toolchain.identifier)) for \(uri.forLogging)")
+    logger.log(
+      """
+      Using toolchain at \(toolchain.path?.pathString ?? "<nil>") (\(toolchain.identifier, privacy: .public)) \
+      for \(uri.forLogging)
+      """
+    )
 
     return workspace.documentService.withLock { documentService in
       if let concurrentlySetService = documentService[uri] {


### PR DESCRIPTION
I don’t know why we logged the toolchain’s identifier twice. That didn’t make much sense.