### PR TITLE
[6.0] Allow prefixing of the token for a `WorkDoneProgress` with a custom string

### DIFF
--- a/Sources/SourceKitLSP/IndexProgressManager.swift
+++ b/Sources/SourceKitLSP/IndexProgressManager.swift
@@ -127,6 +127,7 @@ actor IndexProgressManager {
     } else {
       workDoneProgress = await WorkDoneProgressManager(
         server: sourceKitLSPServer,
+        tokenPrefix: "indexing",
         initialDebounce: sourceKitLSPServer.options.workDoneProgressDebounceDuration,
         title: "Indexing",
         message: message,

--- a/Sources/SourceKitLSP/WorkDoneProgressManager.swift
+++ b/Sources/SourceKitLSP/WorkDoneProgressManager.swift
@@ -20,7 +20,7 @@ import SwiftExtensions
 ///
 /// The work done progress is started when the object is created and ended when the object is destroyed.
 /// In between, updates can be sent to the client.
-final actor WorkDoneProgressManager {
+actor WorkDoneProgressManager {
   private enum Status: Equatable {
     case inProgress(message: String?, percentage: Int?)
     case done
@@ -35,6 +35,15 @@ final actor WorkDoneProgressManager {
   private let progressUpdateQueue = AsyncQueue<Serial>()
 
   private weak var server: SourceKitLSPServer?
+
+  /// A string with which the `token` of the generated `WorkDoneProgress` sent to the client starts.
+  ///
+  /// A UUID will be appended to this prefix to make the token unique. The token prefix can be used to classify the work
+  /// done progress into a category, which makes debugging easier because the tokens have semantic meaning and also
+  /// allows clients to interpret what the `WorkDoneProgress` represents (for example Swift for VS Code explicitly
+  /// recognizes work done progress that indicates that sourcekitd has crashed to offer a diagnostic bundle to be
+  /// generated).
+  private let tokenPrefix: String
 
   private let title: String
 
@@ -58,6 +67,7 @@ final actor WorkDoneProgressManager {
 
   init?(
     server: SourceKitLSPServer,
+    tokenPrefix: String,
     initialDebounce: Duration? = nil,
     title: String,
     message: String? = nil,
@@ -69,6 +79,7 @@ final actor WorkDoneProgressManager {
     self.init(
       server: server,
       capabilityRegistry: capabilityRegistry,
+      tokenPrefix: tokenPrefix,
       initialDebounce: initialDebounce,
       title: title,
       message: message,
@@ -79,6 +90,7 @@ final actor WorkDoneProgressManager {
   init?(
     server: SourceKitLSPServer,
     capabilityRegistry: CapabilityRegistry,
+    tokenPrefix: String,
     initialDebounce: Duration? = nil,
     title: String,
     message: String? = nil,
@@ -87,6 +99,7 @@ final actor WorkDoneProgressManager {
     guard capabilityRegistry.clientCapabilities.window?.workDoneProgress ?? false else {
       return nil
     }
+    self.tokenPrefix = tokenPrefix
     self.server = server
     self.title = title
     self.pendingStatus = .inProgress(message: message, percentage: percentage)
@@ -121,7 +134,7 @@ final actor WorkDoneProgressManager {
           )
         )
       } else {
-        let token = ProgressToken.string(UUID().uuidString)
+        let token = ProgressToken.string("\(tokenPrefix).\(UUID().uuidString)")
         do {
           _ = try await server.client.send(CreateWorkDoneProgressRequest(token: token))
         } catch {
@@ -174,6 +187,71 @@ final actor WorkDoneProgressManager {
       if let token {
         server?.sendNotificationToClient(WorkDoneProgress(token: token, value: .end(WorkDoneProgressEnd())))
       }
+    }
+  }
+}
+
+/// A `WorkDoneProgressManager` that essentially has two states. If any operation tracked by this type is currently
+/// running, it displays a work done progress in the client. If multiple operations are running at the same time, it
+/// doesn't show multiple work done progress in the client. For example, we only want to show one progress indicator
+/// when sourcekitd has crashed, not one per `SwiftLanguageService`.
+actor SharedWorkDoneProgressManager {
+  private weak var sourceKitLSPServer: SourceKitLSPServer?
+
+  /// The number of in-progress operations. When greater than 0 `workDoneProgress` non-nil and a work done progress is
+  /// displayed to the user.
+  private var inProgressOperations = 0
+  private var workDoneProgress: WorkDoneProgressManager?
+
+  private let tokenPrefix: String
+  private let title: String
+  private let message: String?
+
+  public init(
+    sourceKitLSPServer: SourceKitLSPServer,
+    tokenPrefix: String,
+    title: String,
+    message: String? = nil
+  ) {
+    self.sourceKitLSPServer = sourceKitLSPServer
+    self.tokenPrefix = tokenPrefix
+    self.title = title
+    self.message = message
+  }
+
+  func start() async {
+    guard let sourceKitLSPServer else {
+      return
+    }
+    // Do all asynchronous operations up-front so that incrementing `inProgressOperations` and setting `workDoneProgress`
+    // cannot be interrupted by an `await` call
+    let initialDebounce = await sourceKitLSPServer.options.workDoneProgressDebounceDuration
+    let capabilityRegistry = await sourceKitLSPServer.capabilityRegistry
+
+    inProgressOperations += 1
+    if let capabilityRegistry, workDoneProgress == nil {
+      workDoneProgress = WorkDoneProgressManager(
+        server: sourceKitLSPServer,
+        capabilityRegistry: capabilityRegistry,
+        tokenPrefix: tokenPrefix,
+        initialDebounce: initialDebounce,
+        title: title,
+        message: message
+      )
+    }
+  }
+
+  func end() async {
+    if inProgressOperations > 0 {
+      inProgressOperations -= 1
+    } else {
+      logger.fault(
+        "Unbalanced calls to SharedWorkDoneProgressManager.start and end for \(self.tokenPrefix, privacy: .public)"
+      )
+    }
+    if inProgressOperations == 0, let workDoneProgress {
+      self.workDoneProgress = nil
+      await workDoneProgress.end()
     }
   }
 }


### PR DESCRIPTION
- **Explanation**: This allows VS Code to detect when sourcekitd has crashed and prompt the user to gather a diagnostic report + file an issue about the crash.
- **Scope**: Progress reporting
- **Risk**: Low, only affects progress reporting
- **Testing**: Manually tested that the work done progress we send when sourcekitd has crashed has the `sourcekitd.` prefix.
- **Issue**: rdar://129678779, #1476
- **Reviewer**:  @hamishknight on https://github.com/apple/sourcekit-lsp/pull/1493
