### PR TITLE
Add a request to re-index all files in SourceKit-LSP

### DIFF
--- a/Documentation/LSP Extensions.md
+++ b/Documentation/LSP Extensions.md
@@ -431,3 +431,17 @@ New request that returns symbols for all the test classes and test methods withi
 ```ts
 export interface WorkspaceTestsParams {}
 ```
+
+## `workspace/triggerReindex`
+
+New request to re-index all files open in the SourceKit-LSP server.
+
+Users should not need to rely on this request. The index should always be updated automatically in the background. Having to invoke this request means there is a bug in SourceKit-LSP's automatic re-indexing. It does, however, offer a workaround to re-index files when such a bug occurs where otherwise there would be no workaround.
+
+
+- params: `TriggerReindexParams`
+- result: `void`
+
+```ts
+export interface TriggerReindexParams {}
+```

--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(LanguageServerProtocol STATIC
   Requests/ShutdownRequest.swift
   Requests/SignatureHelpRequest.swift
   Requests/SymbolInfoRequest.swift
+  Requests/TriggerReindexRequest.swift
   Requests/TypeDefinitionRequest.swift
   Requests/TypeHierarchyPrepareRequest.swift
   Requests/TypeHierarchySubtypesRequest.swift

--- a/Sources/LanguageServerProtocol/Requests/TriggerReindexRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/TriggerReindexRequest.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Re-index all files open in the SourceKit-LSP server.
+///
+/// Users should not need to rely on this request. The index should always be updated automatically in the background.
+/// Having to invoke this request means there is a bug in SourceKit-LSP's automatic re-indexing. It does, however, offer
+/// a workaround to re-index files when such a bug occurs where otherwise there would be no workaround.
+///
+/// **LSP Extension**
+public struct TriggerReindexRequest: RequestType {
+  public static let method: String = "workspace/triggerReindex"
+  public typealias Response = VoidResponse
+
+  public init() {}
+}

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -231,15 +231,15 @@ public final actor SemanticIndexManager {
   /// Returns immediately after scheduling that task.
   ///
   /// Indexing is being performed with a low priority.
-  private func scheduleBackgroundIndex(files: some Collection<DocumentURI>) async {
-    _ = await self.scheduleIndexing(of: files, priority: .low)
+  private func scheduleBackgroundIndex(files: some Collection<DocumentURI>, indexFilesWithUpToDateUnit: Bool) async {
+    _ = await self.scheduleIndexing(of: files, indexFilesWithUpToDateUnit: indexFilesWithUpToDateUnit, priority: .low)
   }
 
   /// Regenerate the build graph (also resolving package dependencies) and then index all the source files known to the
   /// build system that don't currently have a unit with a timestamp that matches the mtime of the file.
   ///
   /// This method is intended to initially update the index of a project after it is opened.
-  public func scheduleBuildGraphGenerationAndBackgroundIndexAllFiles() async {
+  public func scheduleBuildGraphGenerationAndBackgroundIndexAllFiles(indexFilesWithUpToDateUnit: Bool = false) async {
     generateBuildGraphTask = Task(priority: .low) {
       await withLoggingSubsystemAndScope(subsystem: indexLoggingSubsystem, scope: "build-graph-generation") {
         logger.log(
@@ -263,14 +263,24 @@ public final actor SemanticIndexManager {
         // potentially not knowing about unit files, which causes the corresponding source files to be re-indexed.
         index.pollForUnitChangesAndWait()
         await testHooks.buildGraphGenerationDidFinish?()
-        let index = index.checked(for: .modifiedFiles)
-        let filesToIndex = await self.buildSystemManager.sourceFiles().lazy.map(\.uri)
-          .filter { !index.hasUpToDateUnit(for: $0) }
-        await scheduleBackgroundIndex(files: filesToIndex)
+        var filesToIndex: any Collection<DocumentURI> = await self.buildSystemManager.sourceFiles().lazy.map(\.uri)
+        if !indexFilesWithUpToDateUnit {
+          let index = index.checked(for: .modifiedFiles)
+          filesToIndex = filesToIndex.filter { !index.hasUpToDateUnit(for: $0) }
+        }
+        await scheduleBackgroundIndex(files: filesToIndex, indexFilesWithUpToDateUnit: indexFilesWithUpToDateUnit)
         generateBuildGraphTask = nil
       }
     }
     indexProgressStatusDidChange()
+  }
+
+  /// Causes all files to be re-indexed even if the unit file for the source file is up to date.
+  /// See `TriggerReindexRequest`.
+  public func scheduleReindex() async {
+    await indexStoreUpToDateTracker.markAllKnownOutOfDate()
+    await preparationUpToDateTracker.markAllKnownOutOfDate()
+    await scheduleBuildGraphGenerationAndBackgroundIndexAllFiles(indexFilesWithUpToDateUnit: true)
   }
 
   /// Wait for all in-progress index tasks to finish.
@@ -312,7 +322,7 @@ public final actor SemanticIndexManager {
     // Create a new index task for the files that aren't up-to-date. The newly scheduled index tasks will
     // - Wait for the existing index operations to finish if they have the same number of files.
     // - Reschedule the background index task in favor of an index task with fewer source files.
-    await self.scheduleIndexing(of: uris, priority: nil).value
+    await self.scheduleIndexing(of: uris, indexFilesWithUpToDateUnit: false, priority: nil).value
     index.pollForUnitChangesAndWait()
     logger.debug("Done waiting for up-to-date index")
   }
@@ -347,7 +357,7 @@ public final actor SemanticIndexManager {
       await preparationUpToDateTracker.markOutOfDate(inProgressPreparationTasks.keys)
     }
 
-    await scheduleBackgroundIndex(files: changedFiles)
+    await scheduleBackgroundIndex(files: changedFiles, indexFilesWithUpToDateUnit: false)
   }
 
   /// Returns the files that should be indexed to get up-to-date index information for the given files.
@@ -500,6 +510,7 @@ public final actor SemanticIndexManager {
   /// Update the index store for the given files, assuming that their targets have already been prepared.
   private func updateIndexStore(
     for filesAndTargets: [FileAndTarget],
+    indexFilesWithUpToDateUnit: Bool,
     preparationTaskID: UUID,
     priority: TaskPriority?
   ) async {
@@ -509,6 +520,7 @@ public final actor SemanticIndexManager {
         buildSystemManager: self.buildSystemManager,
         index: index,
         indexStoreUpToDateTracker: indexStoreUpToDateTracker,
+        indexFilesWithUpToDateUnit: indexFilesWithUpToDateUnit,
         logMessageToIndexLog: logMessageToIndexLog,
         testHooks: testHooks
       )
@@ -545,6 +557,7 @@ public final actor SemanticIndexManager {
   /// The returned task finishes when all files are indexed.
   private func scheduleIndexing(
     of files: some Collection<DocumentURI>,
+    indexFilesWithUpToDateUnit: Bool,
     priority: TaskPriority?
   ) async -> Task<Void, Never> {
     // Perform a quick initial check to whether the files is up-to-date, in which case we don't need to schedule a
@@ -619,6 +632,7 @@ public final actor SemanticIndexManager {
               taskGroup.addTask {
                 await self.updateIndexStore(
                   for: fileBatch.map { FileAndTarget(file: $0, target: target) },
+                  indexFilesWithUpToDateUnit: indexFilesWithUpToDateUnit,
                   preparationTaskID: preparationTaskID,
                   priority: priority
                 )

--- a/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
+++ b/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
@@ -199,6 +199,8 @@ enum MessageHandlingDependencyTracker: DependencyTracker {
       self = .freestanding
     case is ShutdownRequest:
       self = .globalConfigurationChange
+    case is TriggerReindexRequest:
+      self = .globalConfigurationChange
     case is TypeHierarchySubtypesRequest:
       self = .freestanding
     case is TypeHierarchySupertypesRequest:

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -747,6 +747,8 @@ extension SourceKitLSPServer: MessageHandler {
       await request.reply { try await shutdown(request.params) }
     case let request as RequestAndReply<SymbolInfoRequest>:
       await self.handleRequest(for: request, requestHandler: self.symbolInfo)
+    case let request as RequestAndReply<TriggerReindexRequest>:
+      await request.reply { try await triggerReindex(request.params) }
     case let request as RequestAndReply<TypeHierarchyPrepareRequest>:
       await self.handleRequest(for: request, requestHandler: self.prepareTypeHierarchy)
     case let request as RequestAndReply<TypeHierarchySubtypesRequest>:
@@ -2335,6 +2337,13 @@ extension SourceKitLSPServer {
     for workspace in workspaces {
       await workspace.semanticIndexManager?.waitForUpToDateIndex()
       workspace.uncheckedIndex?.pollForUnitChangesAndWait()
+    }
+    return VoidResponse()
+  }
+
+  func triggerReindex(_ req: TriggerReindexRequest) async throws -> VoidResponse {
+    for workspace in workspaces {
+      await workspace.semanticIndexManager?.scheduleReindex()
     }
     return VoidResponse()
   }


### PR DESCRIPTION
Users should not need to rely on this request. The index should always be updated automatically in the background. Having to invoke this request manes there is a bug in SourceKit-LSP's automatic re-indexing. It does, however, offer a workaround to re-index files when such a bug occurs where otherwise there would be no workaround.

rdar://127476221
Resolves #1263