### PR TITLE
Delete CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-# Code of Conduct
-
-The code of conduct for this project can be found at https://swift.org/code-of-conduct/


### PR DESCRIPTION
deleting this coc in favor of the org wide coc in the .github repo. having this file present means that this repo is opt-ing out of that.