### PR TITLE
Remove Ben Langmuir as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 # Order is important. The last matching pattern has the most precedence.
 
 # Owner of anything in SourceKit-LSP not owned by anyone else.
-* @benlangmuir @ahoppen
+* @ahoppen


### PR DESCRIPTION
No longer has write access to the repo, which makes CODEOWNERS invalid.