### PR TITLE
Add a variant of `send` to `TestSourceKitLSPClient` that allows implicit discarding of `VoidResponse`

### DIFF
--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -136,7 +136,7 @@ public struct IndexedSingleSwiftFileTestProject {
     )
 
     // Wait for the indexstore-db to finish indexing
-    _ = try await testClient.send(PollIndexRequest())
+    try await testClient.send(PollIndexRequest())
 
     // Open the document
     self.fileURI = DocumentURI(testFileURL)

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -200,7 +200,7 @@ public class SwiftPMTestProject: MultiFileTestProject {
 
     if pollIndex {
       // Wait for the indexstore-db to finish indexing
-      _ = try await testClient.send(PollIndexRequest())
+      try await testClient.send(PollIndexRequest())
     }
   }
 

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -192,6 +192,11 @@ public final class TestSourceKitLSPClient: MessageHandler, Sendable {
     }
   }
 
+  /// Variant of `send` above that allows the response to be discarded if it is a `VoidResponse`.
+  public func send<R: RequestType>(_ request: R) async throws where R.Response == VoidResponse {
+    let _: VoidResponse = try await self.send(request)
+  }
+
   /// Send the request to `server` and return the result via a completion handler.
   ///
   /// This version of the `send` function should only be used if some action needs to be performed after the request is

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -437,7 +437,7 @@ final class BackgroundIndexingTests: XCTestCase {
     )
 
     project.testClient.send(DidChangeWatchedFilesNotification(changes: [FileEvent(uri: otherFileUri, type: .changed)]))
-    _ = try await project.testClient.send(PollIndexRequest())
+    try await project.testClient.send(PollIndexRequest())
 
     let callsAfterEdit = try await project.testClient.send(
       CallHierarchyIncomingCallsRequest(item: try XCTUnwrap(prepare?.only))
@@ -503,7 +503,7 @@ final class BackgroundIndexingTests: XCTestCase {
     )
 
     project.testClient.send(DidChangeWatchedFilesNotification(changes: [FileEvent(uri: uri, type: .changed)]))
-    _ = try await project.testClient.send(PollIndexRequest())
+    try await project.testClient.send(PollIndexRequest())
 
     let callsAfterEdit = try await project.testClient.send(
       CallHierarchyIncomingCallsRequest(item: try XCTUnwrap(prepare?.only))
@@ -713,11 +713,11 @@ final class BackgroundIndexingTests: XCTestCase {
     // Ensure that LibC gets opened before LibD, so that LibD is the latest document. Two open requests don't have
     // dependencies between each other, so SourceKit-LSP is free to execute them in parallel or re-order them without
     // the barrier.
-    _ = try await project.testClient.send(BarrierRequest())
+    try await project.testClient.send(BarrierRequest())
     _ = try project.openDocument("LibD.swift")
 
     // Send a barrier request to ensure we have finished opening LibD before allowing the preparation of LibB to finish.
-    _ = try await project.testClient.send(BarrierRequest())
+    try await project.testClient.send(BarrierRequest())
 
     allDocumentsOpened.signal()
     try libDPreparedForEditing.waitOrThrow()
@@ -847,7 +847,7 @@ final class BackgroundIndexingTests: XCTestCase {
         WorkspaceFolder(uri: DocumentURI(project.scratchDirectory))
       ]
     )
-    _ = try await otherClient.send(PollIndexRequest())
+    try await otherClient.send(PollIndexRequest())
   }
 
   func testOpeningFileThatIsNotPartOfThePackageDoesntGenerateABuildFolderThere() async throws {
@@ -900,7 +900,7 @@ final class BackgroundIndexingTests: XCTestCase {
       return VoidResponse()
     }
     _ = try project.openDocument("Lib.swift")
-    _ = try await project.testClient.send(BarrierRequest())
+    try await project.testClient.send(BarrierRequest())
   }
 
   func testImportPreparedModuleWithFunctionBodiesSkipped() async throws {
@@ -1185,7 +1185,7 @@ final class BackgroundIndexingTests: XCTestCase {
         FileEvent(uri: DocumentURI(project.scratchDirectory.appendingPathComponent("Package.resolved")), type: .changed)
       ])
     )
-    _ = try await project.testClient.send(PollIndexRequest())
+    try await project.testClient.send(PollIndexRequest())
     XCTAssertEqual(try String(contentsOf: packageResolvedURL), originalPackageResolvedContents)
 
     // Simulate a package update which goes as follows:
@@ -1206,7 +1206,7 @@ final class BackgroundIndexingTests: XCTestCase {
         FileEvent(uri: DocumentURI(project.scratchDirectory.appendingPathComponent("Package.resolved")), type: .changed)
       ])
     )
-    _ = try await project.testClient.send(PollIndexRequest())
+    try await project.testClient.send(PollIndexRequest())
     project.testClient.send(
       DidChangeWatchedFilesNotification(
         changes: FileManager.default.findFiles(named: "Dependency.swift", in: project.scratchDirectory).map {

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -65,7 +65,7 @@ final class CompilationDatabaseTests: XCTestCase {
     )
 
     // Ensure that the DidChangeWatchedFilesNotification is handled before we continue.
-    _ = try await project.testClient.send(BarrierRequest())
+    try await project.testClient.send(BarrierRequest())
 
     // DocumentHighlight should now point to the definition in the `#else` block.
 

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -178,7 +178,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
     )
 
     try await SwiftPMTestProject.build(at: project.scratchDirectory)
-    _ = try await project.testClient.send(PollIndexRequest())
+    try await project.testClient.send(PollIndexRequest())
 
     // After indexing, we know that `LooksLikeTestCaseButIsNot` does not inherit from `XCTestCase` and we don't report any tests.
     let indexBasedTests = try await project.testClient.send(

--- a/Tests/SourceKitLSPTests/IndexTests.swift
+++ b/Tests/SourceKitLSPTests/IndexTests.swift
@@ -144,7 +144,7 @@ final class IndexTests: XCTestCase {
       XCTAssertEqual(versionContentsBefore.count, 1)
       XCTAssert(versionContentsBefore.first?.lastPathComponent.starts(with: "p") ?? false)
 
-      _ = try await project.testClient.send(ShutdownRequest())
+      try await project.testClient.send(ShutdownRequest())
       return versionedPath
     }
 

--- a/Tests/SourceKitLSPTests/RenameTests.swift
+++ b/Tests/SourceKitLSPTests/RenameTests.swift
@@ -1145,7 +1145,7 @@ final class RenameTests: XCTestCase {
       ])
     )
 
-    _ = try await project.testClient.send(PollIndexRequest())
+    try await project.testClient.send(PollIndexRequest())
 
     let resultAfterFileMove = try await project.testClient.send(
       RenameRequest(textDocument: TextDocumentIdentifier(callerUri), position: callerPositions["3️⃣"], newName: "bar")

--- a/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
@@ -135,7 +135,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
     )
 
     // Ensure that the DidChangeWatchedFilesNotification is handled before we continue.
-    _ = try await project.testClient.send(BarrierRequest())
+    try await project.testClient.send(BarrierRequest())
 
     let completions = try await project.testClient.send(
       CompletionRequest(textDocument: TextDocumentIdentifier(newFileUri), position: newFilePositions["2️⃣"])

--- a/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
@@ -64,7 +64,7 @@ class WorkspaceSymbolsTests: XCTestCase {
       enableBackgroundIndexing: true
     )
 
-    _ = try await project.testClient.send(PollIndexRequest())
+    try await project.testClient.send(PollIndexRequest())
     let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "funcFrom"))
 
     // Ideally, the item from the current package (PackageB) should be returned before the item from PackageA

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -77,7 +77,7 @@ final class WorkspaceTests: XCTestCase {
       },
       enableBackgroundIndexing: true
     )
-    _ = try await project.testClient.send(PollIndexRequest())
+    try await project.testClient.send(PollIndexRequest())
 
     let (bUri, bPositions) = try project.openDocument("execB.swift")
 
@@ -229,7 +229,7 @@ final class WorkspaceTests: XCTestCase {
 
     let (uri, positions) = try project.openDocument("execA.swift")
 
-    _ = try await project.testClient.send(PollIndexRequest())
+    try await project.testClient.send(PollIndexRequest())
 
     let otherCompletions = try await project.testClient.send(
       CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
@@ -320,7 +320,7 @@ final class WorkspaceTests: XCTestCase {
       enableBackgroundIndexing: true
     )
 
-    _ = try await project.testClient.send(PollIndexRequest())
+    try await project.testClient.send(PollIndexRequest())
 
     let (bUri, bPositions) = try project.openDocument("execB.swift")
 
@@ -362,7 +362,7 @@ final class WorkspaceTests: XCTestCase {
 
     let (aUri, aPositions) = try project.openDocument("execA.swift")
 
-    _ = try await project.testClient.send(PollIndexRequest())
+    try await project.testClient.send(PollIndexRequest())
 
     let otherCompletions = try await project.testClient.send(
       CompletionRequest(textDocument: TextDocumentIdentifier(aUri), position: aPositions["1️⃣"])


### PR DESCRIPTION
Cleans up tests slightly.