### PR TITLE
[6.0] Add a request to re-index all files in SourceKit-LSP

### DIFF
--- a/Documentation/LSP Extensions.md
+++ b/Documentation/LSP Extensions.md
@@ -431,3 +431,17 @@ New request that returns symbols for all the test classes and test methods withi
 ```ts
 export interface WorkspaceTestsParams {}
 ```
+
+## `workspace/triggerReindex`
+
+New request to re-index all files open in the SourceKit-LSP server.
+
+Users should not need to rely on this request. The index should always be updated automatically in the background. Having to invoke this request means there is a bug in SourceKit-LSP's automatic re-indexing. It does, however, offer a workaround to re-index files when such a bug occurs where otherwise there would be no workaround.
+
+
+- params: `TriggerReindexParams`
+- result: `void`
+
+```ts
+export interface TriggerReindexParams {}
+```

--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -77,6 +77,7 @@ add_library(LanguageServerProtocol STATIC
   Requests/ShutdownRequest.swift
   Requests/SignatureHelpRequest.swift
   Requests/SymbolInfoRequest.swift
+  Requests/TriggerReindexRequest.swift
   Requests/TypeDefinitionRequest.swift
   Requests/TypeHierarchyPrepareRequest.swift
   Requests/TypeHierarchySubtypesRequest.swift

--- a/Sources/LanguageServerProtocol/Requests/TriggerReindexRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/TriggerReindexRequest.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Re-index all files open in the SourceKit-LSP server.
+///
+/// Users should not need to rely on this request. The index should always be updated automatically in the background.
+/// Having to invoke this request means there is a bug in SourceKit-LSP's automatic re-indexing. It does, however, offer
+/// a workaround to re-index files when such a bug occurs where otherwise there would be no workaround.
+///
+/// **LSP Extension**
+public struct TriggerReindexRequest: RequestType {
+  public static let method: String = "workspace/triggerReindex"
+  public typealias Response = VoidResponse
+
+  public init() {}
+}

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -106,11 +106,17 @@ public struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
   /// The build system manager that is used to get the toolchain and build settings for the files to index.
   private let buildSystemManager: BuildSystemManager
 
-  private let indexStoreUpToDateTracker: UpToDateTracker<DocumentURI>
-
   /// A reference to the underlying index store. Used to check if the index is already up-to-date for a file, in which
   /// case we don't need to index it again.
   private let index: UncheckedIndex
+
+  private let indexStoreUpToDateTracker: UpToDateTracker<DocumentURI>
+
+  /// Whether files that have an up-to-date unit file should be indexed.
+  ///
+  /// In general, this should be `false`. The only situation when this should be set to `true` is when the user
+  /// explicitly requested a re-index of all files.
+  private let indexFilesWithUpToDateUnit: Bool
 
   /// See `SemanticIndexManager.logMessageToIndexLog`.
   private let logMessageToIndexLog: @Sendable (_ taskID: IndexTaskID, _ message: String) -> Void
@@ -145,6 +151,7 @@ public struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
     buildSystemManager: BuildSystemManager,
     index: UncheckedIndex,
     indexStoreUpToDateTracker: UpToDateTracker<DocumentURI>,
+    indexFilesWithUpToDateUnit: Bool,
     logMessageToIndexLog: @escaping @Sendable (_ taskID: IndexTaskID, _ message: String) -> Void,
     timeout: Duration,
     testHooks: IndexTestHooks
@@ -153,6 +160,7 @@ public struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
     self.buildSystemManager = buildSystemManager
     self.index = index
     self.indexStoreUpToDateTracker = indexStoreUpToDateTracker
+    self.indexFilesWithUpToDateUnit = indexFilesWithUpToDateUnit
     self.logMessageToIndexLog = logMessageToIndexLog
     self.timeout = timeout
     self.testHooks = testHooks
@@ -214,7 +222,9 @@ public struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       // If we know that the file is up-to-date without having ot hit the index, do that because it's fastest.
       return
     }
-    guard !index.checked(for: .modifiedFiles).hasUpToDateUnit(for: file.sourceFile, mainFile: file.mainFile)
+    guard
+      indexFilesWithUpToDateUnit
+        || !index.checked(for: .modifiedFiles).hasUpToDateUnit(for: file.sourceFile, mainFile: file.mainFile)
     else {
       logger.debug("Not indexing \(file.forLogging) because index has an up-to-date unit")
       // We consider a file's index up-to-date if we have any up-to-date unit. Changing build settings does not

--- a/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
+++ b/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
@@ -199,6 +199,8 @@ enum MessageHandlingDependencyTracker: DependencyTracker {
       self = .freestanding
     case is ShutdownRequest:
       self = .globalConfigurationChange
+    case is TriggerReindexRequest:
+      self = .globalConfigurationChange
     case is TypeHierarchySubtypesRequest:
       self = .freestanding
     case is TypeHierarchySupertypesRequest:

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1275,6 +1275,104 @@ final class BackgroundIndexingTests: XCTestCase {
     // also testing that we don't wait for type checking of Test.swift to finish.
     XCTAssert(Date().timeIntervalSince(dateStarted) < 30)
   }
+
+  func testManualReindex() async throws {
+    // This test relies on the issue described in https://github.com/apple/sourcekit-lsp/issues/1264 that we don't
+    // re-index dependent files if a function of a low-level module gains a new default parameter, which changes the
+    // function's USR but is API compatible with all dependencies.
+    // Check that after running the re-index request, the index gets updated.
+
+    let project = try await SwiftPMTestProject(
+      files: [
+        "LibA/LibA.swift": """
+        public func 1️⃣getInt() -> Int {
+          return 1
+        }
+        """,
+        "LibB/LibB.swift": """
+        import LibA
+
+        public func 2️⃣test() -> Int {
+          return 3️⃣getInt()
+        }
+        """,
+      ],
+      manifest: """
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+           .target(name: "LibA"),
+           .target(name: "LibB", dependencies: ["LibA"]),
+          ]
+        )
+        """,
+      enableBackgroundIndexing: true
+    )
+
+    let expectedCallHierarchyItem = CallHierarchyIncomingCall(
+      from: CallHierarchyItem(
+        name: "test()",
+        kind: .function,
+        tags: nil,
+        uri: try project.uri(for: "LibB.swift"),
+        range: try project.range(from: "2️⃣", to: "2️⃣", in: "LibB.swift"),
+        selectionRange: try project.range(from: "2️⃣", to: "2️⃣", in: "LibB.swift"),
+        data: .dictionary([
+          "usr": .string("s:4LibB4testSiyF"),
+          "uri": .string(try project.uri(for: "LibB.swift").stringValue),
+        ])
+      ),
+      fromRanges: [try project.range(from: "3️⃣", to: "3️⃣", in: "LibB.swift")]
+    )
+
+    /// Start by making a call hierarchy request to check that we get the expected results without any edits.
+    let (uri, positions) = try project.openDocument("LibA.swift")
+    let prepareBeforeUpdate = try await project.testClient.send(
+      CallHierarchyPrepareRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    let callHierarchyBeforeUpdate = try await project.testClient.send(
+      CallHierarchyIncomingCallsRequest(item: XCTUnwrap(prepareBeforeUpdate?.only))
+    )
+    XCTAssertEqual(callHierarchyBeforeUpdate, [expectedCallHierarchyItem])
+
+    // Now add a new default parameter to `getInt`.
+    project.testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(uri)))
+    let newLibAContents = """
+      public func getInt(value: Int = 1) -> Int {
+        return value
+      }
+      """
+    try newLibAContents.write(to: XCTUnwrap(uri.fileURL), atomically: true, encoding: .utf8)
+    project.testClient.send(
+      DidOpenTextDocumentNotification(
+        textDocument: TextDocumentItem(uri: uri, language: .swift, version: 0, text: newLibAContents)
+      )
+    )
+    project.testClient.send(DidChangeWatchedFilesNotification(changes: [FileEvent(uri: uri, type: .changed)]))
+    _ = try await project.testClient.send(PollIndexRequest())
+
+    // The USR of `getInt` has changed but LibB.swift has not been re-indexed due to
+    // https://github.com/apple/sourcekit-lsp/issues/1264. We expect to get an empty call hierarchy.
+    let prepareAfterUpdate = try await project.testClient.send(
+      CallHierarchyPrepareRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    let callHierarchyAfterUpdate = try await project.testClient.send(
+      CallHierarchyIncomingCallsRequest(item: XCTUnwrap(prepareAfterUpdate?.only))
+    )
+    XCTAssertEqual(callHierarchyAfterUpdate, [])
+
+    // After re-indexing, we expect to get a full call hierarchy again.
+    _ = try await project.testClient.send(TriggerReindexRequest())
+    _ = try await project.testClient.send(PollIndexRequest())
+
+    let prepareAfterReindex = try await project.testClient.send(
+      CallHierarchyPrepareRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    let callHierarchyAfterReindex = try await project.testClient.send(
+      CallHierarchyIncomingCallsRequest(item: XCTUnwrap(prepareAfterReindex?.only))
+    )
+    XCTAssertEqual(callHierarchyAfterReindex, [expectedCallHierarchyItem])
+  }
 }
 
 extension HoverResponseContents {


### PR DESCRIPTION
- **Explanation**: Users should not need to rely on this request. The index should always be updated automatically in the background. Having to invoke this request manes there is a bug in SourceKit-LSP's automatic re-indexing. It does, however, offer a workaround to re-index files when such a bug occurs where otherwise there would be no workaround.
- **Scope**: A new request, purely additive
- **Risk**: Low, purely additive
- **Testing**: Added test case
- **Issue**: rdar://127476221, #1263 
- **Reviewer**:   @bnbarham and @hamishknight on https://github.com/swiftlang/sourcekit-lsp/pull/1507
