### PR TITLE
[6.0] Handle diagnostics in secondary files correctly

### DIFF
--- a/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
+++ b/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
@@ -113,6 +113,7 @@ actor DiagnosticReportManager {
         Diagnostic(
           diag,
           in: snapshot,
+          documentManager: documentManager,
           useEducationalNoteAsCode: self.clientHasDiagnosticsCodeDescriptionSupport
         )
       }) ?? []


### PR DESCRIPTION
* **Explanation**: sourcekitd sometimes returned notes in secondary source files but SourceKit-LSP assumed that all diagnostics and notes are in the primary source file, which was incorrect
* **Scope**: Diagnostics
* **Risk**: Should be fairly low, I don’t know how this would break something
* **Testing**: Added test case
* **Issue**: rdar://130503535, #1516 
* **Reviewer**:  @hamishknight on https://github.com/swiftlang/sourcekit-lsp/pull/1528