### PR TITLE
Allow specification of SourceKitLSPOptions in the initialize request and look for SourceKit-LSP options in `$XDG_CONFIG_HOME/sourcekit-lsp`

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -4,6 +4,7 @@
 - `~/.sourcekit-lsp/config.json`
 - On macOS: `~/Library/Application Support/org.swift.sourcekit-lsp/config.json` from the various `Library` folders on the system
 - If the `XDG_CONFIG_HOME` environment variable is set: `$XDG_CONFIG_HOME/org.swift.sourcekit-lsp/config.json`
+- Initialization options passed in the initialize request
 - A `.sourcekit-lsp/config.json` file in a workspace’s root
 
 The structure of the file is currently not guaranteed to be stable. Options may be removed or renamed.

--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -3,7 +3,7 @@
 `.sourcekit-lsp/config.json` configuration files can be used to modify the behavior of SourceKit-LSP in various ways. The following locations are checked. Settings in later configuration files override settings in earlier configuration files
 - `~/.sourcekit-lsp/config.json`
 - On macOS: `~/Library/Application Support/org.swift.sourcekit-lsp/config.json` from the various `Library` folders on the system
-- If the `XDG_CONFIG_HOME` environment variable is set: `$XDG_CONFIG_HOME/org.swift.sourcekit-lsp/config.json`
+- If the `XDG_CONFIG_HOME` environment variable is set: `$XDG_CONFIG_HOME/sourcekit-lsp/config.json`
 - Initialization options passed in the initialize request
 - A `.sourcekit-lsp/config.json` file in a workspace’s root
 

--- a/Sources/SKCore/SourceKitLSPOptions.swift
+++ b/Sources/SKCore/SourceKitLSPOptions.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 import LSPLogging
-import SKCore
+import LanguageServerProtocol
 import SKSupport
 
 import struct TSCBasic.AbsolutePath
@@ -198,6 +198,21 @@ public struct SourceKitLSPOptions: Sendable, Codable {
     self.experimentalFeatures = experimentalFeatures
     self.swiftPublishDiagnosticsDebounce = swiftPublishDiagnosticsDebounce
     self.workDoneProgressDebounce = workDoneProgressDebounce
+  }
+
+  public init?(fromLSPAny lspAny: LSPAny?) throws {
+    guard let lspAny else {
+      return nil
+    }
+    let jsonEncoded = try JSONEncoder().encode(lspAny)
+    self = try JSONDecoder().decode(Self.self, from: jsonEncoded)
+  }
+
+  public var asLSPAny: LSPAny {
+    get throws {
+      let jsonEncoded = try JSONEncoder().encode(self)
+      return try JSONDecoder().decode(LSPAny.self, from: jsonEncoded)
+    }
   }
 
   public init?(path: URL?) {

--- a/Sources/SKTestSupport/MultiFileTestProject.swift
+++ b/Sources/SKTestSupport/MultiFileTestProject.swift
@@ -80,6 +80,7 @@ public class MultiFileTestProject {
   public init(
     files: [RelativeFileLocation: String],
     workspaces: (URL) async throws -> [WorkspaceFolder] = { [WorkspaceFolder(uri: DocumentURI($0))] },
+    initializationOptions: LSPAny? = nil,
     capabilities: ClientCapabilities = ClientCapabilities(),
     options: SourceKitLSPOptions = .testDefault(),
     testHooks: TestHooks = TestHooks(),
@@ -118,6 +119,7 @@ public class MultiFileTestProject {
     self.testClient = try await TestSourceKitLSPClient(
       options: options,
       testHooks: testHooks,
+      initializationOptions: initializationOptions,
       capabilities: capabilities,
       usePullDiagnostics: usePullDiagnostics,
       enableBackgroundIndexing: enableBackgroundIndexing,

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -150,6 +150,7 @@ public class SwiftPMTestProject: MultiFileTestProject {
     files: [RelativeFileLocation: String],
     manifest: String = SwiftPMTestProject.defaultPackageManifest,
     workspaces: (URL) async throws -> [WorkspaceFolder] = { [WorkspaceFolder(uri: DocumentURI($0))] },
+    initializationOptions: LSPAny? = nil,
     capabilities: ClientCapabilities = ClientCapabilities(),
     options: SourceKitLSPOptions = .testDefault(),
     testHooks: TestHooks = TestHooks(),
@@ -190,6 +191,7 @@ public class SwiftPMTestProject: MultiFileTestProject {
     try await super.init(
       files: filesByPath,
       workspaces: workspaces,
+      initializationOptions: initializationOptions,
       capabilities: capabilities,
       options: options,
       testHooks: testHooks,

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -809,7 +809,7 @@ extension SwiftLanguageService {
     var canInlineMacro = false
 
     let showMacroExpansionsIsEnabled =
-      self.sourceKitLSPServer?.options.hasExperimentalFeature(.showMacroExpansions) ?? false
+      await self.sourceKitLSPServer?.options.hasExperimentalFeature(.showMacroExpansions) ?? false
 
     var refactorActions = cursorInfoResponse.refactorActions.compactMap {
       let lspCommand = $0.asCommand()

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -263,7 +263,7 @@ struct SourceKitLSP: AsyncParsableCommand {
         override: SourceKitLSPOptions(
           path:
             URL(fileURLWithPath: xdgConfigHome)
-            .appendingPathComponent("org.swift.sourcekit-lsp")
+            .appendingPathComponent("sourcekit-lsp")
             .appendingPathComponent("config.json")
         )
       )


### PR DESCRIPTION
Specifying `SourceKitLSPOptions` in the initialize request allows editors to provide UI elements to toggle SourceKit-LSP options.

The reverse-DNS notation is macOS style and doesn’t feel at home on Linux.