### PR TITLE
Skip `testWasm` if the host toolchain can’t build for WASM

### DIFF
--- a/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegration.swift
@@ -243,6 +243,8 @@ final class SwiftPMIntegrationTests: XCTestCase {
   }
 
   func testWasm() async throws {
+    try await SkipUnless.canCompileForWasm()
+
     let project = try await SwiftPMTestProject(
       files: [
         "/.sourcekit-lsp/config.json": """


### PR DESCRIPTION
This fixes a test failure when running tests using Xcode 15.4.