### PR TITLE
[6.0] Prefix module name to test

### DIFF
--- a/Sources/SwiftExtensions/Array+Safe.swift
+++ b/Sources/SwiftExtensions/Array+Safe.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Array {
+  /// Returns the element at the specified index if it is within the Array's
+  /// bounds, otherwise `nil`.
+  public subscript(safe index: Index) -> Element? {
+    return index >= 0 && index < count ? self[index] : nil
+  }
+}

--- a/Sources/SwiftExtensions/CMakeLists.txt
+++ b/Sources/SwiftExtensions/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_library(SwiftExtensions STATIC
+  Array+Safe.swift
   AsyncQueue.swift
   AsyncUtils.swift
   Collection+Only.swift

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -53,23 +53,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
-              id: "MyTests/testMyLibrary()",
+              id: "MyLibraryTests.MyTests/testMyLibrary()",
               label: "testMyLibrary()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: try project.uri(for: "MyTests.swift"), range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: try project.uri(for: "MyTests.swift"), range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -100,21 +93,14 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/testMyLibrary()",
               label: "testMyLibrary()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -156,23 +142,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
       syntacticTests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
-              id: "MyTests/testMyLibrary()",
+              id: "MyLibraryTests.MyTests/testMyLibrary()",
               label: "testMyLibrary()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -212,21 +191,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/oneIsTwo()",
               label: "oneIsTwo()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -256,21 +230,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: project.fileURI, range: project.positions["1️⃣"]..<project.positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/oneIsTwo()",
               label: "oneIsTwo()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: project.fileURI, range: project.positions["2️⃣"]..<project.positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: project.fileURI, range: project.positions["2️⃣"]..<project.positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -303,31 +272,24 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["6️⃣"]),
           children: [
             TestItem(
               id: "MyTests/Inner",
               label: "Inner",
-              disabled: false,
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["5️⃣"]),
               children: [
                 TestItem(
                   id: "MyTests/Inner/oneIsTwo()",
                   label: "oneIsTwo()",
-                  disabled: false,
                   style: TestStyle.swiftTesting,
-                  location: Location(uri: uri, range: positions["3️⃣"]..<positions["4️⃣"]),
-                  children: [],
-                  tags: []
+                  location: Location(uri: uri, range: positions["3️⃣"]..<positions["4️⃣"])
                 )
-              ],
-              tags: []
+              ]
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -358,21 +320,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/numbersAreOne(x:)",
               label: "numbersAreOne(x:)",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -403,14 +360,12 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/numbersAreOne(_:)",
               label: "numbersAreOne(_:)",
-              disabled: false,
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
               children: [],
@@ -448,21 +403,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/numbersAreOne(x:)",
               label: "numbersAreOne(x:)",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -490,11 +440,8 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
-          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
-          children: [],
-          tags: []
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"])
         )
       ]
     )
@@ -522,11 +469,8 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "My tests",
-          disabled: false,
           style: TestStyle.swiftTesting,
-          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
-          children: [],
-          tags: []
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"])
         )
       ]
     )
@@ -555,11 +499,8 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "oneIsTwo()",
           label: "One is two",
-          disabled: false,
           style: TestStyle.swiftTesting,
-          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
-          children: [],
-          tags: []
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"])
         )
       ]
     )
@@ -597,30 +538,22 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/oneIsTwo(foo:)",
               label: "oneIsTwo(foo:)",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             ),
             TestItem(
               id: "MyTests/twoIsThree()",
               label: "twoIsThree()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["6️⃣"]..<positions["7️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["6️⃣"]..<positions["7️⃣"])
             ),
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -651,9 +584,7 @@ final class DocumentTestDiscoveryTests: XCTestCase {
           label: "One is two",
           disabled: true,
           style: TestStyle.swiftTesting,
-          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
-          children: [],
-          tags: []
+          location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"])
         )
       ]
     )
@@ -694,12 +625,9 @@ final class DocumentTestDiscoveryTests: XCTestCase {
               label: "oneIsTwo()",
               disabled: true,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -754,17 +682,14 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/oneIsTwo()",
               label: "oneIsTwo()",
-              disabled: false,
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
               tags: [TestTag(id: "red"), TestTag(id: "blue")]
             )
           ],
@@ -811,17 +736,14 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/oneIsTwo()",
               label: "oneIsTwo()",
-              disabled: false,
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
               tags: [
                 TestTag(id: "foo"),
                 TestTag(id: "Nested.foo"),
@@ -875,23 +797,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
             TestItem(
               id: "MyTests/oneIsTwo()",
               label: "oneIsTwo()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             ),
             TestItem(
               id: "MyTests/twoIsThree()",
               label: "twoIsThree()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["6️⃣"]..<positions["7️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["6️⃣"]..<positions["7️⃣"])
             ),
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -923,30 +838,22 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/oneIsTwo()",
               label: "oneIsTwo()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             ),
             TestItem(
               id: "MyTests/twoIsThree()",
               label: "twoIsThree()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["5️⃣"]..<positions["6️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["5️⃣"]..<positions["6️⃣"])
             ),
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -976,21 +883,14 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
           children: [
             TestItem(
               id: "MyTests/testOneIsTwo()",
               label: "testOneIsTwo()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: uri, range: positions["3️⃣"]..<positions["4️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["3️⃣"]..<positions["4️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -1024,40 +924,30 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "Outer",
           label: "Outer",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
           children: [
             TestItem(
               id: "Outer/Inner",
               label: "Inner",
-              disabled: false,
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["3️⃣"]..<positions["4️⃣"]),
               children: [
                 TestItem(
                   id: "Outer/Inner/oneIsTwo()",
                   label: "oneIsTwo()",
-                  disabled: false,
                   style: TestStyle.swiftTesting,
-                  location: Location(uri: uri, range: positions["5️⃣"]..<positions["6️⃣"]),
-                  children: [],
-                  tags: []
+                  location: Location(uri: uri, range: positions["5️⃣"]..<positions["6️⃣"])
                 ),
                 TestItem(
                   id: "Outer/Inner/twoIsThree()",
                   label: "twoIsThree()",
-                  disabled: false,
                   style: TestStyle.swiftTesting,
-                  location: Location(uri: uri, range: positions["7️⃣"]..<positions["8️⃣"]),
-                  children: [],
-                  tags: []
+                  location: Location(uri: uri, range: positions["7️⃣"]..<positions["8️⃣"])
                 ),
-              ],
-              tags: []
+              ]
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -1088,21 +978,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/oneIsTwo()",
               label: "oneIsTwo()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -1137,21 +1022,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests/Inner",
           label: "Inner",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/Inner/oneIsTwo()",
               label: "oneIsTwo()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -1183,14 +1063,12 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["2️⃣"]),
           children: [
             TestItem(
               id: "MyTests/oneIsTwo()",
               label: "oneIsTwo()",
-              disabled: false,
               style: TestStyle.swiftTesting,
               location: Location(uri: uri, range: positions["3️⃣"]..<positions["4️⃣"]),
               children: [],
@@ -1199,14 +1077,10 @@ final class DocumentTestDiscoveryTests: XCTestCase {
             TestItem(
               id: "MyTests/twoIsThree()",
               label: "twoIsThree()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["5️⃣"]..<positions["6️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["5️⃣"]..<positions["6️⃣"])
             ),
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -1238,21 +1112,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "My Tests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
               id: "MyTests/oneIsTwo()",
               label: "one is two",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -1364,23 +1233,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
-              id: "MyTests/testSomething",
+              id: "MyLibraryTests.MyTests/testSomething",
               label: "testSomething",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -1434,23 +1296,16 @@ final class DocumentTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
-              id: "MyTests/testSomething",
+              id: "MyLibraryTests.MyTests/testSomething",
               label: "testSomething",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -50,29 +50,22 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(
             uri: try project.uri(for: "MyTests.swift"),
             range: Range(try project.position(of: "1️⃣", in: "MyTests.swift"))
           ),
           children: [
             TestItem(
-              id: "MyTests/testMyLibrary()",
+              id: "MyLibraryTests.MyTests/testMyLibrary()",
               label: "testMyLibrary()",
-              disabled: false,
-              style: TestStyle.xcTest,
               location: Location(
                 uri: try project.uri(for: "MyTests.swift"),
                 range: Range(try project.position(of: "2️⃣", in: "MyTests.swift"))
-              ),
-              children: [],
-              tags: []
+              )
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -99,23 +92,16 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: try project.location(from: "1️⃣", to: "4️⃣", in: "MyTests.swift"),
           children: [
             TestItem(
-              id: "MyTests/testMyLibrary()",
+              id: "MyLibraryTests.MyTests/testMyLibrary()",
               label: "testMyLibrary()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift"),
-              children: [],
-              tags: []
+              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift")
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -149,29 +135,22 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(
             uri: myTestsUri,
             range: Range(try project.position(of: "1️⃣", in: "MyTests.swift"))
           ),
           children: [
             TestItem(
-              id: "MyTests/testMyLibrary()",
+              id: "MyLibraryTests.MyTests/testMyLibrary()",
               label: "testMyLibrary()",
-              disabled: false,
-              style: TestStyle.xcTest,
               location: Location(
                 uri: myTestsUri,
                 range: Range(try project.position(of: "2️⃣", in: "MyTests.swift"))
-              ),
-              children: [],
-              tags: []
+              )
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -198,29 +177,22 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       testsAfterDocumentChanged,
       [
         TestItem(
-          id: "NotQuiteTests",
+          id: "MyLibraryTests.NotQuiteTests",
           label: "NotQuiteTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(
             uri: myTestsUri,
             range: newFilePositions["3️⃣"]..<newFilePositions["6️⃣"]
           ),
           children: [
             TestItem(
-              id: "NotQuiteTests/testSomething()",
+              id: "MyLibraryTests.NotQuiteTests/testSomething()",
               label: "testSomething()",
-              disabled: false,
-              style: TestStyle.xcTest,
               location: Location(
                 uri: myTestsUri,
                 range: newFilePositions["4️⃣"]..<newFilePositions["5️⃣"]
-              ),
-              children: [],
-              tags: []
+              )
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -256,23 +228,18 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: try project.location(from: "1️⃣", to: "4️⃣", in: "MyTests.swift"),
           children: [
             TestItem(
-              id: "MyTests/oneIsTwo()",
+              id: "MyLibraryTests.MyTests/oneIsTwo()",
               label: "oneIsTwo()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift"),
-              children: [],
-              tags: []
+              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift")
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -308,42 +275,91 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: try project.location(from: "1️⃣", to: "4️⃣", in: "MyTests.swift"),
           children: [
             TestItem(
-              id: "MyTests/oneIsTwo()",
+              id: "MyLibraryTests.MyTests/oneIsTwo()",
               label: "oneIsTwo()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift"),
-              children: [],
-              tags: []
+              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift")
             )
           ],
           tags: []
         ),
         TestItem(
-          id: "MyOldTests",
+          id: "MyLibraryTests.MyOldTests",
           label: "MyOldTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: try project.location(from: "5️⃣", to: "5️⃣", in: "MyTests.swift"),
           children: [
             TestItem(
-              id: "MyOldTests/testOld()",
+              id: "MyLibraryTests.MyOldTests/testOld()",
               label: "testOld()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: try project.location(from: "6️⃣", to: "6️⃣", in: "MyTests.swift"),
-              children: [],
-              tags: []
+              location: try project.location(from: "6️⃣", to: "6️⃣", in: "MyTests.swift")
             )
-          ],
-          tags: []
+          ]
+        ),
+      ]
+    )
+  }
+
+  func testMultipleTargetsWithSameXCTestClassName() async throws {
+    let packageManifestWithTwoTestTargets = """
+      let package = Package(
+        name: "MyLibrary",
+        targets: [.testTarget(name: "MyLibraryTests"), .testTarget(name: "MyLibraryTests2")]
+      )
+      """
+
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Tests/MyLibraryTests/MyTests.swift": """
+        import XCTest
+
+        1️⃣class MyTests: XCTestCase {
+          2️⃣func testMyLibrary() {}3️⃣
+        }4️⃣
+        """,
+        "Tests/MyLibraryTests2/MyTests2.swift": """
+        import XCTest
+
+        5️⃣class MyTests: XCTestCase {
+          6️⃣func testMyLibrary() {}7️⃣
+        }8️⃣
+        """,
+      ],
+      manifest: packageManifestWithTwoTestTargets
+    )
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+
+    XCTAssertEqual(
+      tests,
+      [
+        TestItem(
+          id: "MyLibraryTests.MyTests",
+          label: "MyTests",
+          location: try project.location(from: "1️⃣", to: "4️⃣", in: "MyTests.swift"),
+          children: [
+            TestItem(
+              id: "MyLibraryTests.MyTests/testMyLibrary()",
+              label: "testMyLibrary()",
+              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift")
+            )
+          ]
+        ),
+        TestItem(
+          id: "MyLibraryTests2.MyTests",
+          label: "MyTests",
+          location: try project.location(from: "5️⃣", to: "8️⃣", in: "MyTests2.swift"),
+          children: [
+            TestItem(
+              id: "MyLibraryTests2.MyTests/testMyLibrary()",
+              label: "testMyLibrary()",
+              location: try project.location(from: "6️⃣", to: "7️⃣", in: "MyTests2.swift")
+            )
+          ]
         ),
       ]
     )
@@ -378,23 +394,16 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       testsAfterDocumentOpen,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["2️⃣"]..<positions["2️⃣"]),
           children: [
             TestItem(
-              id: "MyTests/testMyLibrary()",
+              id: "MyLibraryTests.MyTests/testMyLibrary()",
               label: "testMyLibrary()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: uri, range: positions["4️⃣"]..<positions["4️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["4️⃣"]..<positions["4️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -415,23 +424,16 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["6️⃣"]),
           children: [
             TestItem(
-              id: "MyTests/testMyLibraryUpdated()",
+              id: "MyLibraryTests.MyTests/testMyLibraryUpdated()",
               label: "testMyLibraryUpdated()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: uri, range: positions["3️⃣"]..<positions["5️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["3️⃣"]..<positions["5️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -475,42 +477,28 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyFirstTests",
+          id: "MyLibraryTests.MyFirstTests",
           label: "MyFirstTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
-              id: "MyFirstTests/testOneUpdated()",
+              id: "MyLibraryTests.MyFirstTests/testOneUpdated()",
               label: "testOneUpdated()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         ),
         TestItem(
-          id: "MySecondTests",
+          id: "MyLibraryTests.MySecondTests",
           label: "MySecondTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: try project.location(from: "5️⃣", to: "5️⃣", in: "MySecondTests.swift"),
           children: [
             TestItem(
-              id: "MySecondTests/testTwo()",
+              id: "MyLibraryTests.MySecondTests/testTwo()",
               label: "testTwo()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: try project.location(from: "6️⃣", to: "6️⃣", in: "MySecondTests.swift"),
-              children: [],
-              tags: []
+              location: try project.location(from: "6️⃣", to: "6️⃣", in: "MySecondTests.swift")
             )
-          ],
-          tags: []
+          ]
         ),
       ]
     )
@@ -597,23 +585,16 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["6️⃣"]),
           children: [
             TestItem(
-              id: "MyTests/testSomething()",
+              id: "MyLibraryTests.MyTests/testSomething()",
               label: "testSomething()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: uri, range: positions["3️⃣"]..<positions["5️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["3️⃣"]..<positions["5️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -641,21 +622,14 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["6️⃣"]),
           children: [
             TestItem(
               id: "MyTests/testSomething()",
               label: "testSomething()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: uri, range: positions["3️⃣"]..<positions["5️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["3️⃣"]..<positions["5️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -681,21 +655,14 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: project.fileURI, range: Range(project.positions["1️⃣"])),
           children: [
             TestItem(
               id: "MyTests/testSomething()",
               label: "testSomething()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: project.fileURI, range: Range(project.positions["2️⃣"])),
-              children: [],
-              tags: []
+              location: Location(uri: project.fileURI, range: Range(project.positions["2️⃣"]))
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -745,21 +712,14 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         TestItem(
           id: "MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: try project.location(from: "1️⃣", to: "4️⃣", in: "MyTests.swift"),
           children: [
             TestItem(
               id: "MyTests/testSomething()",
               label: "testSomething()",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift"),
-              children: [],
-              tags: []
+              location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift")
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -785,23 +745,16 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
 
     let expectedTests = [
       TestItem(
-        id: "MyTests",
+        id: "MyLibraryTests.MyTests",
         label: "MyTests",
-        disabled: false,
-        style: TestStyle.xcTest,
         location: try project.location(from: "1️⃣", to: "4️⃣", in: "MyTests.swift"),
         children: [
           TestItem(
-            id: "MyTests/testMyLibrary()",
+            id: "MyLibraryTests.MyTests/testMyLibrary()",
             label: "testMyLibrary()",
-            disabled: false,
-            style: TestStyle.xcTest,
-            location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift"),
-            children: [],
-            tags: []
+            location: try project.location(from: "2️⃣", to: "3️⃣", in: "MyTests.swift")
           )
-        ],
-        tags: []
+        ]
       )
     ]
 
@@ -868,7 +821,6 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       class NotQuiteTest: SomeClass {
         func testMyLibrary() {}
       }
-
       """
 
     let project = try await IndexedSingleSwiftFileTestProject(originalContents, allowBuildFailure: true)
@@ -931,23 +883,16 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: try project.location(from: "1️⃣", to: "1️⃣", in: "Test.m"),
           children: [
             TestItem(
-              id: "MyTests/testSomething",
+              id: "MyLibraryTests.MyTests/testSomething",
               label: "testSomething",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: try project.location(from: "2️⃣", to: "2️⃣", in: "Test.m"),
-              children: [],
-              tags: []
+              location: try project.location(from: "2️⃣", to: "2️⃣", in: "Test.m")
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -1001,23 +946,16 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
-          style: TestStyle.xcTest,
           location: Location(uri: uri, range: positions["1️⃣"]..<positions["4️⃣"]),
           children: [
             TestItem(
-              id: "MyTests/testSomething",
+              id: "MyLibraryTests.MyTests/testSomething",
               label: "testSomething",
-              disabled: false,
-              style: TestStyle.xcTest,
-              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: uri, range: positions["2️⃣"]..<positions["3️⃣"])
             )
-          ],
-          tags: []
+          ]
         )
       ]
     )
@@ -1052,34 +990,50 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       tests,
       [
         TestItem(
-          id: "MyTests",
+          id: "MyLibraryTests.MyTests",
           label: "MyTests",
-          disabled: false,
           style: TestStyle.swiftTesting,
           location: Location(uri: fileBURI, range: fileBPositions["1️⃣"]..<fileBPositions["2️⃣"]),
           children: [
             TestItem(
-              id: "MyTests/inStruct()",
+              id: "MyLibraryTests.MyTests/inStruct()",
               label: "inStruct()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: fileBURI, range: fileBPositions["3️⃣"]..<fileBPositions["4️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: fileBURI, range: fileBPositions["3️⃣"]..<fileBPositions["4️⃣"])
             ),
             TestItem(
-              id: "MyTests/inExtension()",
+              id: "MyLibraryTests.MyTests/inExtension()",
               label: "inExtension()",
-              disabled: false,
               style: TestStyle.swiftTesting,
-              location: Location(uri: fileAURI, range: fileAPositions["5️⃣"]..<fileAPositions["6️⃣"]),
-              children: [],
-              tags: []
+              location: Location(uri: fileAURI, range: fileAPositions["5️⃣"]..<fileAPositions["6️⃣"])
             ),
-          ],
-          tags: []
+          ]
         )
       ]
+    )
+  }
+}
+
+extension TestItem {
+  init(
+    id: String,
+    label: String,
+    disabled: Bool = false,
+    style: String = TestStyle.xcTest,
+    location: Location,
+    children: [TestItem] = [],
+    tags: [TestTag] = []
+  ) {
+    self.init(
+      id: id,
+      label: label,
+      description: nil,
+      sortText: nil,
+      disabled: disabled,
+      style: style,
+      location: location,
+      children: children,
+      tags: tags
     )
   }
 }


### PR DESCRIPTION
  - **Explanation**: It is possible to have two identically named suites in two different test targets. These were being erroniously rolled up in to the same parent TestItem.
  - **Scope**: `workspace/tests` and `textDocument/tests` requests
  - **Original PRs**: https://github.com/swiftlang/sourcekit-lsp/pull/1530
  - **Risk**: If 6.0 users are already using this request they'll need to remove any prepended module name. Only known current use is VS Code Swift, and this fix is merged here: https://github.com/swiftlang/vscode-swift/pull/941
  - **Testing**: Added test case
  - **Reviewers**: @ahoppen on https://github.com/swiftlang/sourcekit-lsp/pull/1530