### PR TITLE
Skip `testAttachedMacroExpansion` if host toolchain does not support background indexing

### DIFF
--- a/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
+++ b/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
@@ -310,6 +310,7 @@ final class ExecuteCommandTests: XCTestCase {
 
   func testAttachedMacroExpansion() async throws {
     try await SkipUnless.canBuildMacroUsingSwiftSyntaxFromSourceKitLSPBuild()
+    try await SkipUnless.swiftPMSupportsExperimentalPrepareForIndexing()
 
     let files: [RelativeFileLocation: String] = [
       "MyMacros/MyMacros.swift": #"""


### PR DESCRIPTION
Similar to https://github.com/swiftlang/sourcekit-lsp/pull/1548