### PR TITLE
[6.0] Respect module name argument order precedence

### DIFF
--- a/Sources/SKCore/BuildSystemManager.swift
+++ b/Sources/SKCore/BuildSystemManager.swift
@@ -166,14 +166,14 @@ extension BuildSystemManager {
     switch language {
     case .swift:
       // Module name is specified in the form -module-name MyLibrary
-      guard let moduleNameFlagIndex = buildSettings.compilerArguments.firstIndex(of: "-module-name") else {
+      guard let moduleNameFlagIndex = buildSettings.compilerArguments.lastIndex(of: "-module-name") else {
         return nil
       }
       return buildSettings.compilerArguments[safe: moduleNameFlagIndex + 1]
     case .objective_c:
       // Specified in the form -fmodule-name=MyLibrary
       guard
-        let moduleNameArgument = buildSettings.compilerArguments.first(where: {
+        let moduleNameArgument = buildSettings.compilerArguments.last(where: {
           $0.starts(with: "-fmodule-name=")
         }),
         let moduleName = moduleNameArgument.split(separator: "=").last


### PR DESCRIPTION
  - **Explanation**: When the same compiler flag is specified multiple times the last one found should be used.
  - **Scope**: `workspace/tests` and `textDocument/tests` requests
  - **Original PRs**: https://github.com/swiftlang/sourcekit-lsp/pull/1530
  - **Risk**: Low, this just brings in line the moduleName function with how SwiftPM parses arguments.
  - **Testing**: Added test case
  - **Reviewers**: @ahoppen in https://github.com/swiftlang/sourcekit-lsp/pull/1549

