### PR TITLE
[6.0] Import new Bionic module and Android overlay

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/DisableSigpipe.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/DisableSigpipe.swift
@@ -14,9 +14,11 @@
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
-#if canImport(Glibc) || canImport(Musl)
+#if canImport(Glibc) || canImport(Musl) || canImport(Android)
 // This is a lazily initialised global variable that when read for the first time, will ignore SIGPIPE.
 private let globallyIgnoredSIGPIPE: Bool = {
   /* no F_SETNOSIGPIPE on Linux :( */

--- a/Sources/SKSupport/dlopen.swift
+++ b/Sources/SKSupport/dlopen.swift
@@ -19,6 +19,8 @@ import Darwin
 import Glibc
 #elseif canImport(Musl)
 import Musl
+#elseif canImport(Android)
+import Android
 #endif
 
 public final class DLHandle {

--- a/Sources/SourceKitD/SKDRequestArray.swift
+++ b/Sources/SourceKitD/SKDRequestArray.swift
@@ -18,6 +18,8 @@ import Glibc
 import Musl
 #elseif canImport(CRT)
 import CRT
+#elseif canImport(Android)
+import Android
 #endif
 
 extension SourceKitD {

--- a/Sources/SourceKitD/SKDRequestArray.swift
+++ b/Sources/SourceKitD/SKDRequestArray.swift
@@ -18,8 +18,8 @@ import Glibc
 import Musl
 #elseif canImport(CRT)
 import CRT
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 extension SourceKitD {

--- a/Sources/SourceKitD/SKDRequestDictionary.swift
+++ b/Sources/SourceKitD/SKDRequestDictionary.swift
@@ -19,6 +19,8 @@ import Glibc
 import Musl
 #elseif canImport(CRT)
 import CRT
+#elseif canImport(Android)
+import Android
 #endif
 
 /// Values that can be stored in a `SKDRequestDictionary`.

--- a/Sources/SourceKitD/SKDRequestDictionary.swift
+++ b/Sources/SourceKitD/SKDRequestDictionary.swift
@@ -19,8 +19,8 @@ import Glibc
 import Musl
 #elseif canImport(CRT)
 import CRT
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 /// Values that can be stored in a `SKDRequestDictionary`.

--- a/Sources/SourceKitD/SKDResponse.swift
+++ b/Sources/SourceKitD/SKDResponse.swift
@@ -19,8 +19,8 @@ import Glibc
 import Musl
 #elseif canImport(CRT)
 import CRT
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 public final class SKDResponse: Sendable {

--- a/Sources/SourceKitD/SKDResponse.swift
+++ b/Sources/SourceKitD/SKDResponse.swift
@@ -19,6 +19,8 @@ import Glibc
 import Musl
 #elseif canImport(CRT)
 import CRT
+#elseif canImport(Android)
+import Android
 #endif
 
 public final class SKDResponse: Sendable {

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -18,8 +18,8 @@ import Glibc
 import Musl
 #elseif canImport(CRT)
 import CRT
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 public final class SKDResponseArray: Sendable {

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -18,6 +18,8 @@ import Glibc
 import Musl
 #elseif canImport(CRT)
 import CRT
+#elseif canImport(Android)
+import Android
 #endif
 
 public final class SKDResponseArray: Sendable {

--- a/Sources/SourceKitD/SKDResponseDictionary.swift
+++ b/Sources/SourceKitD/SKDResponseDictionary.swift
@@ -18,8 +18,8 @@ import Glibc
 import Musl
 #elseif canImport(CRT)
 import CRT
-#elseif canImport(Android)
-import Android
+#elseif canImport(Bionic)
+import Bionic
 #endif
 
 public final class SKDResponseDictionary: Sendable {

--- a/Sources/SourceKitD/SKDResponseDictionary.swift
+++ b/Sources/SourceKitD/SKDResponseDictionary.swift
@@ -18,6 +18,8 @@ import Glibc
 import Musl
 #elseif canImport(CRT)
 import CRT
+#elseif canImport(Android)
+import Android
 #endif
 
 public final class SKDResponseDictionary: Sendable {


### PR DESCRIPTION
__Explanation:__ Now that this new overlay was merged into the 6.0 compiler too in swiftlang/swift#74758, this adds the overlay to the seven files that currently `import Glibc`.

__Scope:__ Add imports on Android only

__Issue:__ None

__Original PR:__ #1550 and #1559

__Risk:__ None

__Testing:__ Passed all CI on trunk, plus on my daily Android CI, finagolfin/swift-android-sdk#151

__Reviewer:__ @ahoppen

@bnbarham, easy review.