### PR TITLE
Fixup some import related warnings

### DIFF
--- a/Sources/SKSupport/LineTable.swift
+++ b/Sources/SKSupport/LineTable.swift
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import LSPLogging
+#if canImport(os)
 import os
+#endif
 
 public struct LineTable: Hashable, Sendable {
   @usableFromInline

--- a/Sources/SKSupport/LineTable.swift
+++ b/Sources/SKSupport/LineTable.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import LSPLogging
+import os
 
 public struct LineTable: Hashable, Sendable {
   @usableFromInline

--- a/Sources/SwiftExtensions/PipeAsStringHandler.swift
+++ b/Sources/SwiftExtensions/PipeAsStringHandler.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import SwiftExtensions
 
 /// Gathers data from a stdout or stderr pipe. When it has accumulated a full line, calls the handler to handle the
 /// string.

--- a/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
+++ b/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
@@ -58,7 +58,7 @@ final class ExecuteCommandTests: XCTestCase {
       return ApplyEditResponse(applied: true, failureReason: nil)
     }
 
-    try await testClient.send(request)
+    let _ = try await testClient.send(request)
 
     try await fulfillmentOfOrThrow([expectation])
 
@@ -123,7 +123,7 @@ final class ExecuteCommandTests: XCTestCase {
       return ApplyEditResponse(applied: true, failureReason: nil)
     }
 
-    try await testClient.send(request)
+    let _ = try await testClient.send(request)
 
     try await fulfillmentOfOrThrow([expectation])
 


### PR DESCRIPTION
This patch fixes up:
- 1 File 'Foo.swift' is part of module 'module'; ignoring import warning
- 70 "Instance method 'foo' cannot be used in an '@inlinable' function because 'module' was not imported by this file" warnings
- 2 "Result of call 'foo' is unused" warnings