### PR TITLE
Add TriggerReindexRequest to builtinRequests

### DIFF
--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -70,6 +70,7 @@ public let builtinRequests: [_RequestType.Type] = [
   ShutdownRequest.self,
   SignatureHelpRequest.self,
   SymbolInfoRequest.self,
+  TriggerReindexRequest.self,
   TypeDefinitionRequest.self,
   TypeHierarchyPrepareRequest.self,
   TypeHierarchySubtypesRequest.self,


### PR DESCRIPTION
`TriggerReindexRequest` was missing from the list of builtinRequests, which caused the LSP to respond with a `methodNotFound` error when it recieved a `workspace/triggerReindex` request.