### PR TITLE
Report workspace/triggerReindex server capability

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1120,6 +1120,7 @@ extension SourceKitLSPServer {
       experimental: .dictionary([
         "workspace/tests": .dictionary(["version": .int(2)]),
         "textDocument/tests": .dictionary(["version": .int(2)]),
+        "workspace/triggerReindex": .dictionary(["version": .int(1)]),
       ])
     )
   }


### PR DESCRIPTION
If the server is configured to support background indexing then report to clients that it supports the `workspace/triggerReindex` request. This lets clients expose this functionality only if SourceKit-LSP is configured to support it.