### PR TITLE
[6.0] Add TriggerReindexRequest to builtinRequests

### DIFF
--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -69,6 +69,7 @@ public let builtinRequests: [_RequestType.Type] = [
   ShutdownRequest.self,
   SignatureHelpRequest.self,
   SymbolInfoRequest.self,
+  TriggerReindexRequest.self,
   TypeDefinitionRequest.self,
   TypeHierarchyPrepareRequest.self,
   TypeHierarchySubtypesRequest.self,


### PR DESCRIPTION
  - **Explanation**: `TriggerReindexRequest` was missing from the list of builtinRequests, which caused the LSP to respond with a methodNotFound error when it recieved a `workspace/triggerReindex` request.
  - **Scope**: `workspace/triggerReindex` requests
  - **Original PRs**: https://github.com/swiftlang/sourcekit-lsp/pull/1561
  - **Risk**: Very low, this simply exposes an existing endpoint
  - **Testing**: N/A
  - **Reviewers**: @ahoppen in https://github.com/swiftlang/sourcekit-lsp/pull/1561

