### PR TITLE
[6.0] Report workspace/triggerReindex server capability

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1104,6 +1104,7 @@ extension SourceKitLSPServer {
       experimental: .dictionary([
         "workspace/tests": .dictionary(["version": .int(2)]),
         "textDocument/tests": .dictionary(["version": .int(2)]),
+        "workspace/triggerReindex": .dictionary(["version": .int(1)]),
       ])
     )
   }


### PR DESCRIPTION
  - **Explanation**: Report to clients that the server supports the
`workspace/triggerReindex` request. This lets clients expose this functionality only if SourceKit-LSP is configured to support it.
  - **Scope**: `workspace/triggerReindex` requests
  - **Original PRs**: https://github.com/swiftlang/sourcekit-lsp/pull/1563
  - **Risk**: Very low, this simply exposes a capability
  - **Testing**: N/A
  - **Reviewers**: @ahoppen in https://github.com/swiftlang/sourcekit-lsp/pull/1563
