### PR TITLE
[6.0] Fix incorrect ConfiguredTargets for Package.swift w/ multiple workspaces

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -400,7 +400,7 @@ extension SwiftPMBuildSystem {
     )
 
     self.fileToTargets = [DocumentURI: [SwiftBuildTarget]](
-      modulesGraph.allTargets.flatMap { target in
+      modulesGraph.allModules.flatMap { target in
         return target.sources.paths.compactMap { (filePath) -> (key: DocumentURI, value: [SwiftBuildTarget])? in
           guard let buildTarget = buildDescription.getBuildTarget(for: target, in: modulesGraph) else {
             return nil
@@ -412,7 +412,7 @@ extension SwiftPMBuildSystem {
     )
 
     self.sourceDirToTargets = [DocumentURI: [SwiftBuildTarget]](
-      modulesGraph.allTargets.compactMap { (target) -> (DocumentURI, [SwiftBuildTarget])? in
+      modulesGraph.allModules.compactMap { (target) -> (DocumentURI, [SwiftBuildTarget])? in
         guard let buildTarget = buildDescription.getBuildTarget(for: target, in: modulesGraph) else {
           return nil
         }
@@ -545,7 +545,9 @@ extension SwiftPMBuildSystem: SKCore.BuildSystem {
       return targets.map(ConfiguredTarget.init)
     }
 
-    if path.basename == "Package.swift" {
+    if path.basename == "Package.swift"
+      && projectRoot == (try? TSCBasic.resolveSymlinks(TSCBasic.AbsolutePath(path.parentDirectory)))
+    {
       // We use an empty target name to represent the package manifest since an empty target name is not valid for any
       // user-defined target.
       return [ConfiguredTarget.forPackageManifest]


### PR DESCRIPTION
  - **Explanation**: In a project with multiple folders each containing a Package.swift, the `bestWorkspace` found in `workspaceForDocument(uri:)` was always the first one encountered. This picks the correct workspace for the Package.swift.
  - **Scope**: Package.swift files in projects with multiple workspaces
  - **Original PRs**: https://github.com/swiftlang/sourcekit-lsp/pull/1545
  - **Risk**: Low, this just associates the right workspace with a Package.swift
  - **Testing**: Added unit test
  - **Reviewers**: @ahoppen in https://github.com/swiftlang/sourcekit-lsp/pull/1545