### PR TITLE
Allow macro expansions to be viewed through `GetReferenceDocumentRequest` instead of storing in temporary files

### DIFF
--- a/Contributor Documentation/LSP Extensions.md
+++ b/Contributor Documentation/LSP Extensions.md
@@ -473,3 +473,30 @@ export interface PeekDocumentsResult {
   success: boolean;
 }
 ```
+
+## `workspace/getReferenceDocument`
+
+Request from the client to the server asking for contents of a URI having a custom scheme.
+For example: "sourcekit-lsp:"
+
+Enable the experimental client capability `"workspace/getReferenceDocument"` so that the server responds with reference document URLs for certain requests or commands whenever possible.
+
+- params: `GetReferenceDocumentParams`
+
+- result: `GetReferenceDocumentResponse`
+
+```ts
+export interface GetReferenceDocumentParams {
+  /**
+   * The `DocumentUri` of the custom scheme url for which content is required
+   */
+  uri: DocumentUri;
+}
+
+/**
+ * Response containing `content` of `GetReferenceDocumentRequest`
+ */
+export interface GetReferenceDocumentResult {
+  content: string;
+}
+```

--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(LanguageServerProtocol STATIC
   Requests/ExecuteCommandRequest.swift
   Requests/FoldingRangeRequest.swift
   Requests/FormattingRequests.swift
+  Requests/GetReferenceDocumentRequest.swift
   Requests/HoverRequest.swift
   Requests/ImplementationRequest.swift
   Requests/IndexedRenameRequest.swift

--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -48,6 +48,7 @@ public let builtinRequests: [_RequestType.Type] = [
   DocumentTestsRequest.self,
   ExecuteCommandRequest.self,
   FoldingRangeRequest.self,
+  GetReferenceDocumentRequest.self,
   HoverRequest.self,
   ImplementationRequest.self,
   InitializeRequest.self,

--- a/Sources/LanguageServerProtocol/Requests/GetReferenceDocumentRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/GetReferenceDocumentRequest.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Request from the client to the server asking for contents of a URI having a custom scheme **(LSP Extension)**
+/// For example: "sourcekit-lsp:"
+///
+/// - Parameters:
+///   - uri: The `DocumentUri` of the custom scheme url for which content is required
+///
+/// - Returns: `GetReferenceDocumentResponse` which contains the `content` to be displayed.
+///
+/// ### LSP Extension
+///
+/// This request is an extension to LSP supported by SourceKit-LSP.
+/// Enable the experimental client capability `"workspace/getReferenceDocument"` so that the server responds with
+/// reference document URLs for certain requests or commands whenever possible.
+public struct GetReferenceDocumentRequest: RequestType {
+  public static let method: String = "workspace/getReferenceDocument"
+  public typealias Response = GetReferenceDocumentResponse
+
+  public var uri: DocumentURI
+
+  public init(uri: DocumentURI) {
+    self.uri = uri
+  }
+}
+
+/// Response containing `content` of `GetReferenceDocumentRequest`
+public struct GetReferenceDocumentResponse: ResponseType {
+  public var content: String
+
+  public init(content: String) {
+    self.content = content
+  }
+}

--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -36,6 +36,10 @@ public struct DocumentURI: Codable, Hashable, Sendable {
     }
   }
 
+  /// The URL representation of the URI. Note that this URL can have an arbitrary scheme and might
+  /// not represent a file URL.
+  public var arbitrarySchemeURL: URL { storage }
+
   /// The document's URL scheme, if present.
   public var scheme: String? {
     return storage.scheme

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -47,10 +47,12 @@ target_sources(SourceKitLSP PRIVATE
   Swift/ExpandMacroCommand.swift
   Swift/FoldingRange.swift
   Swift/MacroExpansion.swift
+  Swift/MacroExpansionReferenceDocumentURLData.swift
   Swift/OpenInterface.swift
   Swift/RefactoringResponse.swift
   Swift/RefactoringEdit.swift
   Swift/RefactorCommand.swift
+  Swift/ReferenceDocumentURL.swift
   Swift/RelatedIdentifiers.swift
   Swift/RewriteSourceKitPlaceholders.swift
   Swift/SemanticRefactorCommand.swift

--- a/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
@@ -663,6 +663,10 @@ extension ClangLanguageService {
   func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny? {
     return try await forwardRequestToClangd(req)
   }
+
+  func getReferenceDocument(_ req: GetReferenceDocumentRequest) async throws -> GetReferenceDocumentResponse {
+    throw ResponseError.unknown("unsupported method")
+  }
 }
 
 /// Clang build settings derived from a `FileBuildSettingsChange`.

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -252,6 +252,8 @@ package protocol LanguageService: AnyObject, Sendable {
 
   func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny?
 
+  func getReferenceDocument(_ req: GetReferenceDocumentRequest) async throws -> GetReferenceDocumentResponse
+
   /// Perform a syntactic scan of the file at the given URI for test cases and test classes.
   ///
   /// This is used as a fallback to show the test cases in a file if the index for a given file is not up-to-date.

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -687,7 +687,7 @@ extension SourceKitLSPServer {
     guard let workspace = await workspaceForDocument(uri: uri) else {
       throw ResponseError.workspaceNotOpen(uri)
     }
-    guard let primaryFileLanguageService = workspace.documentService.value[uri] else {
+    guard let primaryFileLanguageService = workspace.documentService(for: uri) else {
       return nil
     }
 

--- a/Sources/SourceKitLSP/Swift/MacroExpansionReferenceDocumentURLData.swift
+++ b/Sources/SourceKitLSP/Swift/MacroExpansionReferenceDocumentURLData.swift
@@ -1,0 +1,141 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import LanguageServerProtocol
+import RegexBuilder
+
+/// Represents url of macro expansion reference document as follows:
+/// `sourcekit-lsp://swift-macro-expansion/LaCb-LcCd.swift?primaryFilePath=&fromLine=&fromColumn=&toLine=&toColumn=&bufferName=`
+///
+/// Here,
+///  - `LaCb-LcCd.swift`, the `displayName`, represents where the macro will expand to or
+///    replace in the source file (i.e. `macroExpansionEditRange`)
+///  - `primaryFilePath` denoting the URL of the source file
+///  - `fromLine`, `fromColumn`, `toLine`, `toColumn` represents the cursor's `selectionRange`
+///  - `bufferName` denotes the buffer name of the specific macro expansion edit
+package struct MacroExpansionReferenceDocumentURLData {
+  package static let documentType = "swift-macro-expansion"
+
+  package var primaryFileURL: URL
+  package var selectionRange: Range<Position>
+  package var bufferName: String
+  package var macroExpansionEditRange: Range<Position>
+
+  package init(
+    macroExpansionEditRange: Range<Position>,
+    primaryFileURL: URL,
+    selectionRange: Range<Position>,
+    bufferName: String
+  ) {
+    self.primaryFileURL = primaryFileURL
+    self.selectionRange = selectionRange
+    self.bufferName = bufferName
+    self.macroExpansionEditRange = macroExpansionEditRange
+  }
+
+  package var displayName: String {
+    "L\(macroExpansionEditRange.lowerBound.line + 1)C\(macroExpansionEditRange.lowerBound.utf16index + 1)-L\(macroExpansionEditRange.upperBound.line + 1)C\(macroExpansionEditRange.upperBound.utf16index + 1).swift"
+  }
+
+  package var queryItems: [URLQueryItem] {
+    [
+      URLQueryItem(name: Parameters.primaryFilePath, value: primaryFileURL.path(percentEncoded: false)),
+      URLQueryItem(name: Parameters.fromLine, value: String(selectionRange.lowerBound.line)),
+      URLQueryItem(name: Parameters.fromColumn, value: String(selectionRange.lowerBound.utf16index)),
+      URLQueryItem(name: Parameters.toLine, value: String(selectionRange.upperBound.line)),
+      URLQueryItem(name: Parameters.toColumn, value: String(selectionRange.upperBound.utf16index)),
+      URLQueryItem(name: Parameters.bufferName, value: bufferName),
+    ]
+  }
+
+  package init(displayName: String, queryItems: [URLQueryItem]) throws {
+    guard let primaryFilePath = queryItems.last { $0.name == Parameters.primaryFilePath }?.value,
+      let fromLine = Int(queryItems.last { $0.name == Parameters.fromLine }?.value ?? ""),
+      let fromColumn = Int(queryItems.last { $0.name == Parameters.fromColumn }?.value ?? ""),
+      let toLine = Int(queryItems.last { $0.name == Parameters.toLine }?.value ?? ""),
+      let toColumn = Int(queryItems.last { $0.name == Parameters.toColumn }?.value ?? ""),
+      let bufferName = queryItems.last { $0.name == Parameters.bufferName }?.value
+    else {
+      throw ReferenceDocumentURLError(description: "Invalid queryItems for macro expansion reference document url")
+    }
+
+    guard let primaryFileURL = URL(string: "file://\(primaryFilePath)") else {
+      throw ReferenceDocumentURLError(
+        description: "Unable to parse source file url"
+      )
+    }
+
+    self.primaryFileURL = primaryFileURL
+    self.selectionRange =
+      Position(line: fromLine, utf16index: fromColumn)..<Position(line: toLine, utf16index: toColumn)
+    self.bufferName = bufferName
+    self.macroExpansionEditRange = try Self.parse(displayName: displayName)
+  }
+
+  package var primaryFile: DocumentURI {
+    DocumentURI(primaryFileURL)
+  }
+
+  private struct Parameters {
+    static let primaryFilePath = "primaryFilePath"
+    static let fromLine = "fromLine"
+    static let fromColumn = "fromColumn"
+    static let toLine = "toLine"
+    static let toColumn = "toColumn"
+    static let bufferName = "bufferName"
+  }
+
+  private static func parse(displayName: String) throws -> Range<Position> {
+    let regex = Regex {
+      "L"
+      TryCapture {
+        OneOrMore(.digit)
+      } transform: {
+        Int($0)
+      }
+      "C"
+      TryCapture {
+        OneOrMore(.digit)
+      } transform: {
+        Int($0)
+      }
+      "-L"
+      TryCapture {
+        OneOrMore(.digit)
+      } transform: {
+        Int($0)
+      }
+      "C"
+      TryCapture {
+        OneOrMore(.digit)
+      } transform: {
+        Int($0)
+      }
+      ".swift"
+    }
+
+    guard let match = try? regex.wholeMatch(in: displayName) else {
+      throw ReferenceDocumentURLError(
+        description: "Wrong format of display name of macro expansion reference document: '\(displayName)'"
+      )
+    }
+
+    return Position(
+      line: match.1 - 1,
+      utf16index: match.2 - 1
+    )..<Position(
+      line: match.3 - 1,
+      utf16index: match.4 - 1
+    )
+  }
+}

--- a/Sources/SourceKitLSP/Swift/ReferenceDocumentURL.swift
+++ b/Sources/SourceKitLSP/Swift/ReferenceDocumentURL.swift
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import LanguageServerProtocol
+
+/// A Reference Document is a document whose url scheme is `sourcekit-lsp:` and whose content can only be retrieved
+/// using `GetReferenceDocumentRequest`. The enum represents a specific type of reference document and its
+/// associated value represents the data necessary to generate the document's contents and its url
+///
+/// The `url` will be of the form: `sourcekit-lsp://<document-type>/<display-name>?<parameters>`
+/// Here,
+///  - The `<document-type>` denotes the kind of the content present in the reference document
+///  - The `<parameters>` denotes the parameter-value pairs such as "p1=v1&p2=v2&..." needed to generate
+/// the content of the reference document.
+///  - The `<display-name>` is the displayed file name of the reference document. It doesn't involve in generating
+/// the content of the reference document.
+package enum ReferenceDocumentURL {
+  package static let scheme = "sourcekit-lsp"
+
+  case macroExpansion(MacroExpansionReferenceDocumentURLData)
+
+  var url: URL {
+    get throws {
+      switch self {
+      case let .macroExpansion(data):
+        var components = URLComponents()
+        components.scheme = Self.scheme
+        components.host = MacroExpansionReferenceDocumentURLData.documentType
+        components.path = "/\(data.displayName)"
+        components.queryItems = data.queryItems
+
+        guard let url = components.url else {
+          throw ReferenceDocumentURLError(
+            description: "Unable to create URL for macro expansion reference document"
+          )
+        }
+
+        return url
+      }
+    }
+  }
+
+  init(from uri: DocumentURI) throws {
+    try self.init(from: uri.arbitrarySchemeURL)
+  }
+
+  init(from url: URL) throws {
+    guard url.scheme == Self.scheme else {
+      throw ReferenceDocumentURLError(description: "Invalid Scheme for reference document")
+    }
+
+    let documentType = url.host(percentEncoded: false)
+
+    switch documentType {
+    case MacroExpansionReferenceDocumentURLData.documentType:
+      guard let queryItems = URLComponents(string: url.absoluteString)?.queryItems else {
+        throw ReferenceDocumentURLError(
+          description: "No queryItems passed for macro expansion reference document: \(url)"
+        )
+      }
+
+      let macroExpansionURLData = try MacroExpansionReferenceDocumentURLData(
+        displayName: url.lastPathComponent,
+        queryItems: queryItems
+      )
+      self = .macroExpansion(macroExpansionURLData)
+    case nil:
+      throw ReferenceDocumentURLError(
+        description: "Bad URL for reference document: \(url)"
+      )
+    default:
+      throw ReferenceDocumentURLError(
+        description: "Invalid document type in URL for reference document: \(documentType)"
+      )
+    }
+  }
+
+  /// The URI of the document from which this reference document was derived. This is used to determine the
+  /// workspace and language service that is used to generate the reference document.
+  var primaryFile: DocumentURI {
+    switch self {
+    case let .macroExpansion(data):
+      return data.primaryFile
+    }
+  }
+}
+
+package struct ReferenceDocumentURLError: Error, CustomStringConvertible {
+  package var description: String
+
+  init(description: String) {
+    self.description = description
+  }
+}

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -980,6 +980,17 @@ extension SwiftLanguageService {
 
     return nil
   }
+
+  package func getReferenceDocument(_ req: GetReferenceDocumentRequest) async throws -> GetReferenceDocumentResponse {
+    let referenceDocumentURL = try ReferenceDocumentURL(from: req.uri)
+
+    switch referenceDocumentURL {
+    case let .macroExpansion(data):
+      return GetReferenceDocumentResponse(
+        content: try await expandMacro(macroExpansionURLData: data)
+      )
+    }
+  }
 }
 
 extension SwiftLanguageService: SKDNotificationHandler {

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -203,7 +203,7 @@ extension SourceKitLSPServer {
     }
 
     let testsFromFilesWithInMemoryState = await filesWithInMemoryState.concurrentMap { (uri) -> [AnnotatedTestItem] in
-      guard let languageService = workspace.documentService.value[uri] else {
+      guard let languageService = workspace.documentService(for: uri) else {
         return []
       }
       return await orLog("Getting document tests for \(uri)") {

--- a/Sources/SwiftExtensions/CMakeLists.txt
+++ b/Sources/SwiftExtensions/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(SwiftExtensions STATIC
   Array+Safe.swift
   AsyncQueue.swift
   AsyncUtils.swift
+  CartesianProduct.swift
   Collection+Only.swift
   Collection+PartitionIntoBatches.swift
   NSLock+WithLock.swift

--- a/Sources/SwiftExtensions/CartesianProduct.swift
+++ b/Sources/SwiftExtensions/CartesianProduct.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Calculates the cartesian product of `lhs` and `rhs`
+///
+/// Creates an array of tuple pairs, known as "Cartesian Product", which contains all the possible ways of
+/// pairing each element from `lhs` with each element in `rhs`.
+///
+/// Example Usage:
+/// ```swift
+/// let alphaNumberPairs = cartesianProduct([1, 2, 3],  ["a", "b", "c"])
+/// print(alphaNumberPairs)
+/// // Prints: "[(1, "a"), (2, "a"), (3, "a"), (1, "b"), (2, "b"), (3, "b"), (1, "c"), (2, "c"), (3, "c")]"
+/// ```
+package func cartesianProduct<T, U>(_ lhs: [T], _ rhs: [U]) -> [(T, U)] {
+  var result: [(T, U)] = []
+
+  for lhsElement in lhs {
+    for rhsElement in rhs {
+      result.append((lhsElement, rhsElement))
+    }
+  }
+  return result
+}


### PR DESCRIPTION
This PR eliminates the storage of temporary macro expansion files for `PeekDocumentsRequest` by introducing a new LSP Extension `GetReferenceDocumentRequest`.

The implementation is made in such a way that the URI passed for macro expansions through `PeekDocumentsRequest` is customised with a new scheme, and expects the client to resolve the contents of this new URI by making a `GetReferenceDocumentRequest`.

```
Custom Scheme for Macro Expansions:
`sourcekit-lsp://swift-macro-expansion/LaCb-LcCd.swift?primaryFilePath=&fromLine=&fromColumn=&toLine=&toColumn=&bufferName=`
```

#### References:
Previous PR which implemented `PeekDocumentsRequest`: https://github.com/swiftlang/sourcekit-lsp/pull/1479
Accompanying PR in vscode-swift repository: https://github.com/swiftlang/vscode-swift/pull/971

------
[Expansion of Swift Macros in Visual Studio Code - Google Summer Of Code 2024](https://summerofcode.withgoogle.com/programs/2024/projects/zQNf7ztP)
@lokesh-tr @ahoppen @adam-fowler 