### PR TITLE
Remove `indexPrefixMappings` from `BuildSystem`

### DIFF
--- a/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
@@ -72,9 +72,6 @@ package actor BuildServerBuildSystem: MessageHandler {
   package private(set) var indexDatabasePath: AbsolutePath?
   package private(set) var indexStorePath: AbsolutePath?
 
-  // FIXME: Add support for prefix mappings to the Build Server protocol.
-  package var indexPrefixMappings: [PathPrefixMapping] { return [] }
-
   /// Delegate to handle any build system events.
   package weak var delegate: BuildSystemDelegate?
 

--- a/Sources/BuildSystemIntegration/BuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuildSystem.swift
@@ -107,9 +107,6 @@ package protocol BuildSystem: AnyObject, Sendable {
   /// The path to put the index database, if any.
   var indexDatabasePath: AbsolutePath? { get async }
 
-  /// Path remappings for remapping index data for local use.
-  var indexPrefixMappings: [PathPrefixMapping] { get async }
-
   /// Delegate to handle any build system events such as file build settings initial reports as well as changes.
   ///
   /// The build system must not retain the delegate because the delegate can be the `BuildSystemManager`, which could

--- a/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
@@ -100,8 +100,6 @@ extension CompilationDatabaseBuildSystem: BuildSystem {
     indexStorePath?.parentDirectory.appending(component: "IndexDatabase")
   }
 
-  package var indexPrefixMappings: [PathPrefixMapping] { return [] }
-
   package func buildSettings(
     for document: DocumentURI,
     in buildTarget: ConfiguredTarget,

--- a/Sources/BuildSystemIntegration/FallbackBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/FallbackBuildSystem.swift
@@ -49,8 +49,6 @@ package actor FallbackBuildSystem {
 
   package var indexDatabasePath: AbsolutePath? { return nil }
 
-  package var indexPrefixMappings: [PathPrefixMapping] { return [] }
-
   package func buildSettings(for uri: DocumentURI, language: Language) -> FileBuildSettings? {
     var fileBuildSettings: FileBuildSettings?
     switch language {

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -455,8 +455,6 @@ extension SwiftPMBuildSystem: BuildSystemIntegration.BuildSystem {
     return buildPath.appending(components: "index", "db")
   }
 
-  package var indexPrefixMappings: [PathPrefixMapping] { return [] }
-
   /// Return the compiler arguments for the given source file within a target, making any necessary adjustments to
   /// account for differences in the SwiftPM versions being linked into SwiftPM and being installed in the toolchain.
   private func compilerArguments(for file: DocumentURI, in buildTarget: any SwiftBuildTarget) async throws -> [String] {

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -178,10 +178,7 @@ package final class Workspace: Sendable {
         let lib = try IndexStoreLibrary(dylibPath: libPath.pathString)
         indexDelegate = SourceKitIndexDelegate()
         let prefixMappings =
-          await firstNonNil(
-            indexOptions.indexPrefixMap?.map { PathPrefixMapping(original: $0.key, replacement: $0.value) },
-            await buildSystem?.indexPrefixMappings
-          ) ?? []
+          indexOptions.indexPrefixMap?.map { PathPrefixMapping(original: $0.key, replacement: $0.value) } ?? []
         index = try IndexStoreDB(
           storePath: storePath.pathString,
           databasePath: dbPath.pathString,

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -500,7 +500,6 @@ class ManualBuildSystem: BuildSystem {
 
   var indexStorePath: AbsolutePath? { nil }
   var indexDatabasePath: AbsolutePath? { nil }
-  var indexPrefixMappings: [PathPrefixMapping] { return [] }
 
   func filesDidChange(_ events: [FileEvent]) {}
 

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -27,7 +27,6 @@ actor TestBuildSystem: BuildSystem {
   let projectRoot: AbsolutePath = try! AbsolutePath(validating: "/")
   let indexStorePath: AbsolutePath? = nil
   let indexDatabasePath: AbsolutePath? = nil
-  let indexPrefixMappings: [PathPrefixMapping] = []
 
   weak var delegate: BuildSystemDelegate?
 


### PR DESCRIPTION
They weren’t used.