### PR TITLE
[6.0] Import `Darwin` in files that use `free`

### DIFF
--- a/Sources/SourceKitD/SKDRequestArray.swift
+++ b/Sources/SourceKitD/SKDRequestArray.swift
@@ -12,7 +12,9 @@
 
 import Csourcekitd
 
-#if canImport(Glibc)
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
 import Musl

--- a/Sources/SourceKitD/SKDRequestDictionary.swift
+++ b/Sources/SourceKitD/SKDRequestDictionary.swift
@@ -13,7 +13,9 @@
 import Csourcekitd
 import LSPLogging
 
-#if canImport(Glibc)
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
 import Musl

--- a/Sources/SourceKitD/SKDResponse.swift
+++ b/Sources/SourceKitD/SKDResponse.swift
@@ -13,7 +13,9 @@
 import Csourcekitd
 import LSPLogging
 
-#if canImport(Glibc)
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
 import Musl

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -12,7 +12,9 @@
 
 import Csourcekitd
 
-#if canImport(Glibc)
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
 import Musl

--- a/Sources/SourceKitD/SKDResponseDictionary.swift
+++ b/Sources/SourceKitD/SKDResponseDictionary.swift
@@ -12,7 +12,9 @@
 
 import Csourcekitd
 
-#if canImport(Glibc)
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
 import Glibc
 #elseif canImport(Musl)
 import Musl


### PR DESCRIPTION
* **Explanation**: Import `Darwin` in files that use `free` to fix compilation errors in some setups.
* **Scope**: Build-time only
* **Risk**: Very low, no functionality change
* **Testing**: n/a
* **Issue**: rdar://131965190
* **Reviewer**:  @bnbarham 