### PR TITLE
[6.0] Remove `availableLibraries` argument from `loadPackageGraph`

### DIFF
--- a/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
+++ b/Sources/SKSwiftPMWorkspace/SwiftPMBuildSystem.swift
@@ -370,7 +370,6 @@ extension SwiftPMBuildSystem {
     let modulesGraph = try self.workspace.loadPackageGraph(
       rootInput: PackageGraphRootInput(packages: [AbsolutePath(projectRoot)]),
       forceResolvedVersions: forceResolvedVersions,
-      availableLibraries: [],
       observabilityScope: observabilitySystem.topScope
     )
 


### PR DESCRIPTION
- Explanation:

  Prebuilt/provided libraries feature is reverted by https://github.com/swiftlang/swift-package-manager/pull/7800

- Main Branch PR: N/A (not required on main)

- Risk: Very Low

- Reviewers: @ahoppen, @bnbarham 

- Testing: No testing is required since it's an API adjustment