### PR TITLE
Add a configuration profile to enable extended logging in SourceKit-LSP

### DIFF
--- a/Documentation/Diagnose Bundle.md
+++ b/Documentation/Diagnose Bundle.md
@@ -7,7 +7,7 @@ The diagnose bundle contains the following information:
   - From Xcode toolchains, just a stack trace.
   - For assert compilers (ie. nightly toolchains) also sometimes some source code that was currently compiled to cause the crash.
 - Log messages emitted by SourceKit
-  - We mark all information that may contain private information (source code, file names, …) as private in os_log so by default all of that will be redacted. Private logging can be enabled for SourceKit-LSP on macOS by running `sudo log config --subsystem org.swift.sourcekit-lsp --mode private_data:on`. These log messages are also included in a sysdiagnose.
+  - We mark all information that may contain private information (source code, file names, …) as private in os_log so by default all of that will be redacted. Private logging can be enabled for SourceKit-LSP as described in [Enable Extended Logging](#enable-extended-logging). These extended log messages are also included in a sysdiagnose.
   - On Linux and Windows, we currently don’t redact the private information, so users should always explicitly be asked before sharing these logs.
 - Versions of Swift installed on your system
   - We don’t consider this private information
@@ -15,3 +15,11 @@ The diagnose bundle contains the following information:
 - If possible, a minimized project that caused the Swift compiler to crash
   - Both minimized projects contain user code and are thus considered private. Hence we need to explicitly prompt the user before sharing this information.
   - As a future direction, it could be possible to remove any private information from the reduced examples by removing all comments and replacing all identifiers by obfuscated names.
+
+## Enable Extended logging
+
+Extended logging of SourceKit-LSP is not enabled by default because it contains information about your source code, directory structure and similar potentially sensitive information. Instead, the logging system redacts that information. If you are comfortable with sharing such information, you can enable extended SourceKit-LSP’s extended logging, which improves the ability of SourceKit-LSP developers to understand and fix issues.
+
+To enable extended logging on macOS, install the configuration profile from https://github.com/swiftlang/sourcekit-lsp/blob/main/Documentation/Enable%20Extended%20Logging.mobileconfig as described in https://support.apple.com/guide/mac-help/configuration-profiles-standardize-settings-mh35561/mac#mchlp41bd550. SourceKit-LSP will immediately stop redacting information and include them in the system log.
+
+To disable extended logging again, remove the configuration profile as described in https://support.apple.com/guide/mac-help/configuration-profiles-standardize-settings-mh35561/mac#mchlpa04df41.

--- a/Documentation/Enable Extended Logging.mobileconfig
+++ b/Documentation/Enable Extended Logging.mobileconfig
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>Enable Extended Logging</string>
+			<key>PayloadEnabled</key>
+			<true/>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.system.logging.C6E6C174-6B72-42FE-AF4D-2EBEB7080F6A</string>
+			<key>PayloadType</key>
+			<string>com.apple.system.logging</string>
+			<key>PayloadUUID</key>
+			<string>C6E6C174-6B72-42FE-AF4D-2EBEB7080F6A</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>Subsystems</key>
+			<dict>
+				<key>org.swift.sourcekit-lsp</key>
+				<dict>
+					<key>DEFAULT-OPTIONS</key>
+					<dict>
+						<key>Enable-Private-Data</key>
+						<true/>
+					</dict>
+				</dict>
+				<key>org.swift.sourcekit-lsp.indexing</key>
+				<dict>
+					<key>DEFAULT-OPTIONS</key>
+					<dict>
+						<key>Enable-Private-Data</key>
+						<true/>
+					</dict>
+				</dict>
+				<key>org.swift.sourcekit-lsp.task-scheduler</key>
+				<dict>
+					<key>DEFAULT-OPTIONS</key>
+					<dict>
+						<key>Enable-Private-Data</key>
+						<true/>
+					</dict>
+				</dict>
+			</dict>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Enables extended logging from SourceKit-LSP, which is not enabled by default because it contains information about your source code, directory structure and similar potentially sensitive information.</string>
+	<key>PayloadDisplayName</key>
+	<string>Extended SourceKit-LSP Logging</string>
+	<key>PayloadIdentifier</key>
+	<string>org.swift.sourcekit-lsp.enable-extended-logging</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>AB0B405D-E807-4BFA-8D83-765A8AAC6EC7</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
A configuration profile is needed to enable extended logging, ie to disable redacting possibly private information. Add documentation about when and how to install it.