### PR TITLE
Build in Swift 6 mode using CMake

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-package-name SourceKitLSP>")
+add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-DRESILIENT_LIBRARIES>")
+add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-swift-version 6>")
 add_subdirectory(BuildServerProtocol)
 add_subdirectory(BuildSystemIntegration)
 add_subdirectory(CAtomics)

--- a/Sources/SourceKitLSP/Swift/CodeActions/ConvertIntegerLiteral.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/ConvertIntegerLiteral.swift
@@ -51,6 +51,10 @@ struct ConvertIntegerLiteral: SyntaxCodeActionProvider {
         prefix = "0x"
       case .decimal:
         prefix = ""
+      #if RESILIENT_LIBRARIES
+      @unknown default:
+        fatalError("Unknown case")
+      #endif
       }
 
       let convertedValue: ExprSyntax =

--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -423,6 +423,10 @@ fileprivate extension SwiftDiagnostics.DiagnosticSeverity {
     case .warning: return .warning
     case .note: return .information
     case .remark: return .hint
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError("Unknown case")
+    #endif
     }
   }
 }

--- a/Sources/SourceKitLSP/Swift/RewriteSourceKitPlaceholders.swift
+++ b/Sources/SourceKitLSP/Swift/RewriteSourceKitPlaceholders.swift
@@ -38,6 +38,10 @@ fileprivate extension EditorPlaceholderData {
     switch self {
     case .basic(text: let text): return text
     case .typed(text: let text, type: _): return text
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError("Unknown case")
+    #endif
     }
   }
 }

--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -151,6 +151,10 @@ extension SyntaxClassification {
       return (.comment, .documentation)
     case .argumentLabel:
       return (.function, [])
+    #if RESILIENT_LIBRARIES
+    @unknown default:
+      fatalError("Unknown case")
+    #endif
     }
   }
 }


### PR DESCRIPTION
The CMake build should only be run when building an entire toolchain, which means that we are guaranteed to have a Swift 6 compiler at hand and can unconditionally enable Swift 6 mode.