### PR TITLE
Ensure that all `TODO` and `FIXME` comments have associated issues

### DIFF
--- a/Contributor Documentation/LSP Extensions.md
+++ b/Contributor Documentation/LSP Extensions.md
@@ -113,37 +113,37 @@ interface WorkspaceBuildSetup {
   /**
    * The configuration that the workspace should be built in.
    */
-  buildConfiguration?: BuildConfiguration
+  buildConfiguration?: BuildConfiguration;
 
   /**
    * The default workspace type to use for this workspace.
    */
-  defaultWorkspaceType?: WorkspaceType
+  defaultWorkspaceType?: WorkspaceType;
 
   /**
    * The build directory for the workspace.
    */
-  scratchPath?: DocumentURI
+  scratchPath?: DocumentURI;
 
   /**
    * Arguments to be passed to any C compiler invocations.
    */
-  cFlags?: string[]
+  cFlags?: string[];
 
   /**
    * Arguments to be passed to any C++ compiler invocations.
    */
-  cxxFlags?: string[]
+  cxxFlags?: string[];
 
   /**
    * Arguments to be passed to any linker invocations.
    */
-  linkerFlags?: string[]
+  linkerFlags?: string[];
 
   /**
    * Arguments to be passed to any Swift compiler invocations.
    */
-  swiftFlags?: string[]
+  swiftFlags?: string[];
 }
 ```
 
@@ -155,7 +155,7 @@ Added field:
 /**
  * Options to control code completion behavior in Swift
  */
-sourcekitlspOptions?: SKCompletionOptions
+sourcekitlspOptions?: SKCompletionOptions;
 ```
 
 with
@@ -165,7 +165,7 @@ interface SKCompletionOptions {
   /**
    * The maximum number of completion results to return, or `null` for unlimited.
    */
-  maxResults?: int
+  maxResults?: int;
 }
 ```
 
@@ -190,31 +190,31 @@ export interface SymbolInfoParams {
   /**
    * The document in which to lookup the symbol location.
    */
-  textDocument: TextDocumentIdentifier
+  textDocument: TextDocumentIdentifier;
 
   /**
    * The document location at which to lookup symbol information.
    */
-  position: Position
+  position: Position;
 }
 
 interface ModuleInfo {
   /**
    * The name of the module in which the symbol is defined.
    */
-  moduleName: string
+  moduleName: string;
 
   /**
    * If the symbol is defined within a subgroup of a module, the name of the group. Otherwise `nil`.
    */
-  groupName?: string
+  groupName?: string;
 }
 
 interface SymbolDetails {
   /**
    * The name of the symbol, if any.
    */
-  name?: string
+  name?: string;
 
   /**
    * The name of the containing type for the symbol, if any.
@@ -226,12 +226,12 @@ interface SymbolDetails {
    *   void foo() {}
    * }
    */
-  containerName?: string
+  containerName?: string;
 
   /**
    * The USR of the symbol, if any.
    */
-  usr?: string
+  usr?: string;
 
   /**
    * Best known declaration or definition location without global knowledge.
@@ -242,12 +242,12 @@ interface SymbolDetails {
    * the declaration location from a header as opposed to the definition in some other
    * translation unit.
    */
-  bestLocalDeclaration?: Location
+  bestLocalDeclaration?: Location;
 
   /**
    * The kind of the symbol
    */
-  kind?: SymbolKind
+  kind?: SymbolKind;
 
   /**
    * Whether the symbol is a dynamic call for which it isn't known which method will be invoked at runtime. This is
@@ -255,14 +255,14 @@ interface SymbolDetails {
    *
    * Optional because `clangd` does not return whether a symbol is dynamic.
    */
-  isDynamic?: bool
+  isDynamic?: bool;
 
   /**
    * Whether this symbol is defined in the SDK or standard library.
    *
    * This property only applies to Swift symbols
    */
-  isSystem?: bool
+  isSystem?: bool;
 
   /**
    * If the symbol is dynamic, the USRs of the types that might be called.
@@ -289,7 +289,7 @@ interface SymbolDetails {
    * receiver USR would be `B`, indicating that only overrides of subtypes in
    * `B` may be called dynamically.
    */
-  receiverUsrs?: string[]
+  receiverUsrs?: string[];
 
   /**
    * If the symbol is defined in a module that doesn't have source information associated with it, the name and group
@@ -297,7 +297,7 @@ interface SymbolDetails {
    *
    * This property only applies to Swift symbols.
    */
-  systemModule?: ModuleInfo
+  systemModule?: ModuleInfo;
 }
 ```
 
@@ -313,7 +313,7 @@ interface TestTag {
   /**
    * ID of the test tag. `TestTag` instances with the same ID are considered to be identical.
    */
-  id: string
+  id: string;
 }
 
 /**
@@ -329,51 +329,51 @@ interface TestItem {
    *
    * This identifier uniquely identifies the test case or test suite. It can be used to run an individual test (suite).
    */
-  id: string
+  id: string;
 
   /**
    * Display name describing the test.
    */
-  label: string
+  label: string;
 
   /**
    * Optional description that appears next to the label.
    */
-  description?: string
+  description?: string;
 
   /**
    * A string that should be used when comparing this item with other items.
    *
    * When `nil` the `label` is used.
    */
-  sortText?: string
+  sortText?: string;
 
   /**
    * Whether the test is disabled.
    */
-  disabled: bool
+  disabled: bool;
 
   /**
    * The type of test, eg. the testing framework that was used to declare the test.
    */
-  style: string
+  style: string;
 
   /**
    * The location of the test item in the source code.
    */
-  location: Location
+  location: Location;
 
   /**
    * The children of this test item.
    *
    * For a test suite, this may contain the individual test cases or nested suites.
    */
-  children: TestItem[]]
+  children: TestItem[];
 
   /**
    * Tags associated with this test item.
    */
-  tags: TestTag[]
+  tags: TestTag[];
 }
 
 export interface DocumentTestsParams {
@@ -386,7 +386,129 @@ export interface DocumentTestsParams {
 
 ## `textDocument/symbolInfo`
 
-TODO
+Request for semantic information about the symbol at a given location.
+This request looks up the symbol (if any) at a given text document location and returns `SymbolDetails` for that location, including information such as the symbol's USR. The symbolInfo request is not primarily designed for editors, but instead as an implementation detail of how one LSP implementation (e.g. SourceKit) gets information from another (e.g. clangd) to use in performing index queries or otherwise implementing the higher level requests such as definition.
+
+- params: `SymbolInfoParams`
+- result: `SymbolDetails[]`
+
+```ts
+export interface SymbolInfoParams {
+  /**
+   * The document in which to lookup the symbol location.
+   */
+  textDocument: TextDocumentIdentifier;
+
+  /**
+   * The document location at which to lookup symbol information.
+   */
+  position: Position;
+}
+
+export interface ModuleInfo {
+  /**
+   * The name of the module in which the symbol is defined.
+   */
+  moduleName: string;
+
+  /**
+   * If the symbol is defined within a subgroup of a module, the name of the group. Otherwise `nil`.
+   */
+  groupName?: string;
+}
+
+
+
+export interface SymbolDetails {
+  /**
+   * The name of the symbol, if any.
+   */
+  name?: string;
+
+  /**
+   * The name of the containing type for the symbol, if any.
+   *
+   * For example, in the following snippet, the `containerName` of `foo()` is `C`.
+   *
+   * ```c++
+   * class C {
+   *   void foo() {}
+   * }
+   * ```
+   */
+  containerName?: string;
+
+  /**
+   * The USR of the symbol, if any.
+   */
+  usr?: string;
+
+  /**
+   * Best known declaration or definition location without global knowledge.
+   *
+   * For a local or private variable, this is generally the canonical definition location -
+   * appropriate as a response to a `textDocument/definition` request. For global symbols this is
+   * the best known location within a single compilation unit. For example, in C++ this might be
+   * the declaration location from a header as opposed to the definition in some other
+   * translation unit.
+   */
+  bestLocalDeclaration?: Location;
+
+  /**
+   * The kind of the symbol
+   */
+  kind?: SymbolKind;
+
+  /**
+   * Whether the symbol is a dynamic call for which it isn't known which method will be invoked at runtime. This is
+   * the case for protocol methods and class functions.
+   *
+   * Optional because `clangd` does not return whether a symbol is dynamic.
+   */
+  isDynamic?: bool;
+
+  /**
+   * Whether this symbol is defined in the SDK or standard library.
+   *
+   * This property only applies to Swift symbols.
+   */
+  isSystem?: bool;
+
+  /**
+   * If the symbol is dynamic, the USRs of the types that might be called.
+   *
+   * This is relevant in the following cases
+   * ```swift
+   * class A {
+   *   func doThing() {}
+   * }
+   * class B: A {}
+   * class C: B {
+   *   override func doThing() {}
+   * }
+   * class D: A {
+   *   override func doThing() {}
+   * }
+   * func test(value: B) {
+   *   value.doThing()
+   * }
+   * ```
+   *
+   * The USR of the called function in `value.doThing` is `A.doThing` (or its
+   * mangled form) but it can never call `D.doThing`. In this case, the
+   * receiver USR would be `B`, indicating that only overrides of subtypes in
+   * `B` may be called dynamically.
+   */
+  receiverUsrs?: string[];
+
+  /**
+   * If the symbol is defined in a module that doesn't have source information associated with it, the name and group
+   * and group name that defines this symbol.
+   *
+   * This property only applies to Swift symbols.
+   */
+  systemModule?: ModuleInfo;
+```
 
 ## `window/logMessage`
 
@@ -398,7 +520,7 @@ Added field:
  *
  * Clients may ignore this parameter and add the message to the global log
  */
-logName?: string
+logName?: string;
 ```
 
 ## `workspace/_pollIndex`

--- a/Contributor Documentation/Modules.md
+++ b/Contributor Documentation/Modules.md
@@ -4,9 +4,7 @@ The SourceKit-LSP package contains the following non-testing modules.
 
 ### BuildServerProtocol
 
-Swift types to represent the [Build Server Protocol (BSP) specification, version TODO](TODO). These types should also be usable when implementing a BSP client and thus this module should not have any dependencies other than the LanguageServerProtocol module, with which it shares some types.
-
-FIXME: Add link for BSP and version
+Swift types to represent the [Build Server Protocol (BSP) specification](https://build-server-protocol.github.io/docs/specification). These types should also be usable when implementing a BSP client and thus this module should not have any dependencies other than the LanguageServerProtocol module, with which it shares some types.
 
 ### BuildSystemIntegration
 
@@ -18,11 +16,12 @@ Implementation of atomics for Swift using C. Once we can raise our deployment ta
 
 ### CSKTestSupport
 
-FIXME: Can we remove this?
+For testing, overrides `__cxa_atexit` to prevent registration of static destructors due to work around https://github.com/swiftlang/swift/issues/55112.
+
 
 ### Csourcekitd
 
-Header file defining the interface to sourcekitd. This should stay in sync with [sourcekitd.h](TODO) in the Swift repository.
+Header file defining the interface to sourcekitd. This should stay in sync with [sourcekitd.h](https://github.com/swiftlang/swift/blob/main/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h) in the Swift repository.
 
 ### Diagnose
 

--- a/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
@@ -334,8 +334,9 @@ extension BuildServerBuildSystem: BuildSystem {
       return .unhandled
     }
 
-    // FIXME: We should not make any assumptions about which files the build server can handle.
-    // Instead we should query the build server which files it can handle (#492).
+    // TODO: We should not make any assumptions about which files the build server can handle.
+    // Instead we should query the build server which files it can handle
+    // (https://github.com/swiftlang/sourcekit-lsp/issues/492).
 
     if projectRoot.isAncestorOfOrEqual(to: path) {
       return .handled
@@ -399,8 +400,7 @@ private func makeJSONRPCBuildServer(
   )
 
   connection.start(receiveHandler: client) {
-    // FIXME: keep the pipes alive until we close the connection. This
-    // should be fixed systemically.
+    // Keep the pipes alive until we close the connection.
     withExtendedLifetime((clientToServer, serverToClient)) {}
   }
   let process = Foundation.Process()

--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -198,11 +198,11 @@ extension BuildSystemManager {
     guard let buildSystem, let target else {
       return nil
     }
-    // FIXME: (async) We should only wait `fallbackSettingsTimeout` for build
-    // settings and return fallback afterwards. I am not sure yet, how best to
-    // implement that with Swift concurrency.
+    // TODO: We should only wait `fallbackSettingsTimeout` for build settings
+    // and return fallback afterwards.
     // For now, this should be fine because all build systems return
     // very quickly from `settings(for:language:)`.
+    // https://github.com/apple/sourcekit-lsp/issues/1181
     return try await buildSystem.buildSettings(for: document, in: target, language: language)
   }
 
@@ -382,7 +382,6 @@ extension BuildSystemManager: BuildSystemDelegate {
 }
 
 extension BuildSystemManager {
-  // FIXME: Consider debouncing/limiting this, seems to trigger often during a build.
   /// Checks if there are any files in `mainFileAssociations` where the main file
   /// that we have stored has changed.
   ///

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -530,8 +530,7 @@ extension SwiftPMBuildSystem: BuildSystemIntegration.BuildSystem {
   }
 
   package func defaultLanguage(for document: DocumentURI) -> Language? {
-    // TODO (indexing): Query The SwiftPM build system for the document's language.
-    // https://github.com/swiftlang/sourcekit-lsp/issues/1267
+    // TODO: Query The SwiftPM build system for the document's language. (https://github.com/swiftlang/sourcekit-lsp/issues/1267)
     return nil
   }
 
@@ -602,8 +601,7 @@ extension SwiftPMBuildSystem: BuildSystemIntegration.BuildSystem {
     targets: [ConfiguredTarget],
     logMessageToIndexLog: @escaping @Sendable (_ taskID: IndexTaskID, _ message: String) -> Void
   ) async throws {
-    // TODO (indexing): Support preparation of multiple targets at once.
-    // https://github.com/swiftlang/sourcekit-lsp/issues/1262
+    // TODO: Support preparation of multiple targets at once. (https://github.com/swiftlang/sourcekit-lsp/issues/1262)
     for target in targets {
       await orLog("Preparing") { try await prepare(singleTarget: target, logMessageToIndexLog: logMessageToIndexLog) }
     }
@@ -620,8 +618,7 @@ extension SwiftPMBuildSystem: BuildSystemIntegration.BuildSystem {
       return
     }
 
-    // TODO (indexing): Add a proper 'prepare' job in SwiftPM instead of building the target.
-    // https://github.com/swiftlang/sourcekit-lsp/issues/1254
+    // TODO: Add a proper 'prepare' job in SwiftPM instead of building the target. (https://github.com/swiftlang/sourcekit-lsp/issues/1254)
     guard let swift = toolchain.swift else {
       logger.error(
         "Not preparing because toolchain at \(self.toolchain.identifier) does not contain a Swift compiler"
@@ -757,7 +754,6 @@ extension SwiftPMBuildSystem: BuildSystemIntegration.BuildSystem {
     if events.contains(where: { self.fileEventShouldTriggerPackageReload(event: $0) }) {
       logger.log("Reloading package because of file change")
       await orLog("Reloading package") {
-        // TODO: It should not be necessary to reload the entire package just to get build settings for one file.
         try await self.reloadPackage(forceResolvedVersions: !isForIndexBuild)
       }
     }

--- a/Sources/CSKTestSupport/CSKTestSupport.c
+++ b/Sources/CSKTestSupport/CSKTestSupport.c
@@ -12,7 +12,7 @@
 
 #ifdef __linux__
 // For testing, override __cxa_atexit to prevent registration of static
-// destructors due to SR-12668.
+// destructors due to https://github.com/swiftlang/swift/issues/55112.
 int __cxa_atexit(void (*f) (void *), void *arg, void *dso_handle) {
   return 0;
 }

--- a/Sources/Diagnose/StderrStreamConcurrencySafe.swift
+++ b/Sources/Diagnose/StderrStreamConcurrencySafe.swift
@@ -16,7 +16,7 @@ import class TSCBasic.ThreadSafeOutputByteStream
 #if canImport(Darwin)
 import TSCLibc
 #else
-// FIXME: (async-workaround) @preconcurrency needed because stderr is not sendable on Linux rdar://125578486
+// TODO: @preconcurrency needed because stderr is not sendable on Linux https://github.com/swiftlang/swift/issues/75601
 @preconcurrency import TSCLibc
 #endif
 

--- a/Sources/LanguageServerProtocol/Error.swift
+++ b/Sources/LanguageServerProtocol/Error.swift
@@ -89,11 +89,12 @@ public struct ErrorCode: RawRepresentable, Codable, Hashable, Sendable {
 public struct ResponseError: Error, Codable, Hashable {
   public var code: ErrorCode
   public var message: String
-  // FIXME: data
+  public var data: LSPAny?
 
-  public init(code: ErrorCode, message: String) {
+  public init(code: ErrorCode, message: String, data: LSPAny? = nil) {
     self.code = code
     self.message = message
+    self.data = data
   }
 }
 

--- a/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ClientCapabilities.swift
@@ -70,7 +70,6 @@ public struct RefreshRegistrationCapability: Hashable, Codable, Sendable {
 }
 
 /// Capabilities of the client editor/IDE related to managing the workspace.
-// FIXME: Instead of making all of these optional, provide default values and make the deserialization handle missing values.
 public struct WorkspaceClientCapabilities: Hashable, Codable, Sendable {
 
   /// Capabilities specific to `WorkspaceEdit`.
@@ -223,7 +222,6 @@ public struct WorkspaceClientCapabilities: Hashable, Codable, Sendable {
 }
 
 /// Capabilities of the client editor/IDE related to the document.
-// FIXME: Instead of making all of these optional, provide default values and make the deserialization handle missing values.
 public struct TextDocumentClientCapabilities: Hashable, Codable, Sendable {
 
   /// Capabilities specific to the `textDocument/...` change notifications.

--- a/Sources/LanguageServerProtocol/SupportTypes/CodeActionKind.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/CodeActionKind.swift
@@ -37,11 +37,9 @@ public struct CodeActionKind: RawRepresentable, Codable, Hashable, Sendable {
   public static let refactorInline: CodeActionKind = CodeActionKind(rawValue: "refactor.inline")
 
   /// Refactoring rewrite action.
-  // FIXME: what is this?
   public static let refactorRewrite: CodeActionKind = CodeActionKind(rawValue: "refactor.rewrite")
 
   /// Source action that applies to the entire file.
-  // FIXME: what is this?
   public static let source: CodeActionKind = CodeActionKind(rawValue: "source")
 
   /// Organize imports action.

--- a/Sources/LanguageServerProtocolJSONRPC/MessageSplitting.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageSplitting.swift
@@ -104,7 +104,6 @@ extension RandomAccessCollection where Element: Equatable {
       return nil
     }
 
-    // FIXME: use a better algorithm (e.g. Boyer-Moore-Horspool).
     var i = startIndex
     for _ in 0..<(count - pattern.count + 1) {
       if self[i...].starts(with: pattern) {

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -227,11 +227,7 @@ package class SwiftPMTestProject: MultiFileTestProject {
         "-Xswiftc", "-module-cache-path", "-Xswiftc", globalModuleCache.path,
       ]
     }
-    var environment = ProcessEnv.block
-    // FIXME: SwiftPM does not index-while-building on non-Darwin platforms for C-family files (rdar://117744039).
-    // Force-enable index-while-building with the environment variable.
-    environment["SWIFTPM_ENABLE_CLANG_INDEX_STORE"] = "1"
-    try await Process.checkNonZeroExit(arguments: arguments, environmentBlock: environment)
+    try await Process.checkNonZeroExit(arguments: arguments)
   }
 
   /// Resolve package dependencies for the package at `path`.

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -59,13 +59,11 @@ package final class TestJSONRPCConnection: Sendable {
     server = TestServer(client: serverToClientConnection)
 
     clientToServerConnection.start(receiveHandler: client) {
-      // FIXME: keep the pipes alive until we close the connection. This
-      // should be fixed systemically.
+      // Keep the pipes alive until we close the connection.
       withExtendedLifetime(self) {}
     }
     serverToClientConnection.start(receiveHandler: server) {
-      // FIXME: keep the pipes alive until we close the connection. This
-      // should be fixed systemically.
+      // Keep the pipes alive until we close the connection.
       withExtendedLifetime(self) {}
     }
   }

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -273,8 +273,8 @@ package final actor SemanticIndexManager {
         // potentially not knowing about unit files, which causes the corresponding source files to be re-indexed.
         index.pollForUnitChangesAndWait()
         await testHooks.buildGraphGenerationDidFinish?()
-        // FIXME: (async-workaround) Ideally this would be a type like any Collection<DocumentURI> & Sendable but that
-        // doesn't work due to rdar://132374933
+        // TODO: Ideally this would be a type like any Collection<DocumentURI> & Sendable but that doesn't work due to
+        // https://github.com/swiftlang/swift/issues/75602
         var filesToIndex: [DocumentURI] = await self.buildSystemManager.sourceFiles().lazy.map(\.uri)
         if !indexFilesWithUpToDateUnit {
           let index = index.checked(for: .modifiedFiles)
@@ -626,9 +626,9 @@ package final actor SemanticIndexManager {
 
     var indexTasks: [Task<Void, Never>] = []
 
-    // TODO (indexing): When we can index multiple targets concurrently in SwiftPM, increase the batch size to half the
+    // TODO: When we can index multiple targets concurrently in SwiftPM, increase the batch size to half the
     // processor count, so we can get parallelism during preparation.
-    // https://github.com/swiftlang/sourcekit-lsp/issues/1262
+    // (https://github.com/swiftlang/sourcekit-lsp/issues/1262)
     for targetsBatch in sortedTargets.partition(intoBatchesOfSize: 1) {
       let preparationTaskID = UUID()
       let indexTask = Task(priority: priority) {
@@ -638,9 +638,9 @@ package final actor SemanticIndexManager {
         // And after preparation is done, index the files in the targets.
         await withTaskGroup(of: Void.self) { taskGroup in
           for target in targetsBatch {
-            // TODO (indexing): Once swiftc supports indexing of multiple files in a single invocation, increase the
-            // batch size to allow it to share AST builds between multiple files within a target.
-            // https://github.com/swiftlang/sourcekit-lsp/issues/1268
+            // TODO: Once swiftc supports indexing of multiple files in a single invocation, increase the batch size to
+            // allow it to share AST builds between multiple files within a target.
+            // (https://github.com/swiftlang/sourcekit-lsp/issues/1268)
             for fileBatch in filesByTarget[target]!.partition(intoBatchesOfSize: 1) {
               taskGroup.addTask {
                 await self.updateIndexStore(

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -184,9 +184,8 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
         "Starting updating index store with priority \(Task.currentPriority.rawValue, privacy: .public): \(filesToIndexDescription)"
       )
       let filesToIndex = filesToIndex.sorted(by: { $0.file.sourceFile.stringValue < $1.file.sourceFile.stringValue })
-      // TODO (indexing): Once swiftc supports it, we should group files by target and index files within the same
-      // target together in one swiftc invocation.
-      // https://github.com/swiftlang/sourcekit-lsp/issues/1268
+      // TODO: Once swiftc supports it, we should group files by target and index files within the same target together
+      // in one swiftc invocation. (https://github.com/swiftlang/sourcekit-lsp/issues/1268)
       for file in filesToIndex {
         await updateIndexStore(forSingleFile: file.file, in: file.target)
       }

--- a/Sources/SourceKitD/DynamicallyLoadedSourceKitD.swift
+++ b/Sources/SourceKitD/DynamicallyLoadedSourceKitD.swift
@@ -83,9 +83,8 @@ package actor DynamicallyLoadedSourceKitD: SourceKitD {
   deinit {
     self.api.set_notification_handler(nil)
     self.api.shutdown()
-    // FIXME: is it safe to dlclose() sourcekitd? If so, do that here. For now, let the handle leak.
-    Task.detached(priority: .background) { [dylib] in
-      dylib.leak()
+    Task.detached(priority: .background) { [dylib, path] in
+      orLog("Closing dylib \(path)") { try dylib.close() }
     }
   }
 

--- a/Sources/SourceKitD/SKDRequestDictionary.swift
+++ b/Sources/SourceKitD/SKDRequestDictionary.swift
@@ -102,8 +102,9 @@ extension SKDRequestDictionary: CustomStringConvertible {
 
 extension SKDRequestDictionary: CustomLogStringConvertible {
   package var redactedDescription: String {
-    // FIXME: (logging) Implement a better redacted log that contains keys,
-    // number of elements in an array but not the data itself.
+    // TODO: Implement a better redacted log that contains keys, number of
+    // elements in an array but not the data itself.
+    // (https://github.com/swiftlang/sourcekit-lsp/issues/1598)
     return "<\(description.filter(\.isNewline).count) lines>"
   }
 }

--- a/Sources/SourceKitD/SKDResponse.swift
+++ b/Sources/SourceKitD/SKDResponse.swift
@@ -73,8 +73,9 @@ extension SKDResponse: CustomStringConvertible {
 
 extension SKDResponse: CustomLogStringConvertible {
   package var redactedDescription: String {
-    // FIXME: (logging) Implement a better redacted log that contains keys,
-    // number of elements in an array but not the data itself.
+    // TODO: Implement a better redacted log that contains keys, number of
+    // elements in an array but not the data itself.
+    // (https://github.com/swiftlang/sourcekit-lsp/issues/1598)
     return "<\(description.filter(\.isNewline).count) lines>"
   }
 }

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -74,7 +74,6 @@ target_sources(SourceKitLSP PRIVATE
 )
 set_target_properties(SourceKitLSP PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
-# TODO(compnerd) reduce the exposure here, why is everything PUBLIC-ly linked?
 target_link_libraries(SourceKitLSP PUBLIC
   BuildServerProtocol
   BuildSystemIntegration

--- a/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
@@ -486,17 +486,15 @@ extension ClangLanguageService {
     let clangBuildSettings = await self.buildSettings(for: uri)
 
     // The compile command changed, send over the new one.
-    // FIXME: what should we do if we no longer have valid build settings?
     if let compileCommand = clangBuildSettings?.compileCommand,
       let pathString = (try? AbsolutePath(validating: url.path))?.pathString
     {
       let notification = DidChangeConfigurationNotification(
-        settings: .clangd(
-          ClangWorkspaceSettings(
-            compilationDatabaseChanges: [pathString: compileCommand])
-        )
+        settings: .clangd(ClangWorkspaceSettings(compilationDatabaseChanges: [pathString: compileCommand]))
       )
       clangd.send(notification)
+    } else {
+      logger.error("No longer have build settings for \(url.path) but can't send null build settings to clangd")
     }
   }
 

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -191,6 +191,15 @@ package final class DocumentManager: InMemoryDocumentManager, Sendable {
     }
   }
 
+  /// Returns the latest open snapshot of `uri` or, if no document with that URI is open, reads the file contents of
+  /// that file from disk.
+  package func latestSnapshotOrDisk(_ uri: DocumentURI, language: Language) -> DocumentSnapshot? {
+    if let snapshot = try? self.latestSnapshot(uri) {
+      return snapshot
+    }
+    return try? DocumentSnapshot(withContentsFromDisk: uri, language: language)
+  }
+
   package func fileHasInMemoryModifications(_ uri: DocumentURI) -> Bool {
     guard let document = try? latestSnapshot(uri), let fileURL = uri.fileURL else {
       return false

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -91,7 +91,7 @@ package final class DocumentManager: InMemoryDocumentManager, Sendable {
     case missingDocument(DocumentURI)
   }
 
-  // FIXME: (async) Migrate this to be an AsyncQueue
+  // TODO: Migrate this to be an AsyncQueue (https://github.com/swiftlang/sourcekit-lsp/issues/1597)
   private let queue: DispatchQueue = DispatchQueue(label: "document-manager-queue")
 
   // `nonisolated(unsafe)` is fine because `documents` is guarded by queue.

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -482,7 +482,6 @@ package actor SourceKitLSPServer {
         registry: workspace.capabilityRegistry
       )
 
-      // FIXME: store the server capabilities.
       var syncKind: TextDocumentSyncKind
       switch resp.capabilities.textDocumentSync {
       case .options(let options):
@@ -777,6 +776,7 @@ extension SourceKitLSPServer: MessageHandler {
 extension SourceKitLSPServer: BuildSystemDelegate {
   package func buildTargetsChanged(_ changes: [BuildTargetEvent]) {
     // TODO: do something with these changes once build target support is in place
+    // (https://github.com/swiftlang/sourcekit-lsp/issues/1226)
   }
 
   private func affectedOpenDocumentsForChangeSet(
@@ -1570,7 +1570,8 @@ extension SourceKitLSPServer {
     return symbolsAndIndex.sorted(by: { $0.symbol < $1.symbol }).map { symbolOccurrence, index in
       let symbolPosition = Position(
         line: symbolOccurrence.location.line - 1,  // 1-based -> 0-based
-        // FIXME: we need to convert the utf8/utf16 column, which may require reading the file!
+        // Technically we would need to convert the UTF-8 column to a UTF-16 column. This would require reading the
+        // file. In practice they almost always coincide, so we accept the incorrectness here to avoid the file read.
         utf16index: symbolOccurrence.location.utf8Column - 1
       )
 
@@ -1752,7 +1753,8 @@ extension SourceKitLSPServer {
           // 1-based -> 0-based
           // Note that we still use max(0, ...) as a fallback if the location is zero.
           line: max(0, location.line - 1),
-          // FIXME: we need to convert the utf8/utf16 column, which may require reading the file!
+          // Technically we would need to convert the UTF-8 column to a UTF-16 column. This would require reading the
+          // file. In practice they almost always coincide, so we accept the incorrectness here to avoid the file read.
           utf16index: max(0, location.utf8Column - 1)
         )
       )
@@ -2165,12 +2167,12 @@ extension SourceKitLSPServer {
       }
     }
 
-    // FIXME: (async-workaround) Needed to work around rdar://130112205
+    // TODO: Remove this workaround once https://github.com/swiftlang/swift/issues/75600 is fixed
     func indexToLSPLocation2(_ location: SymbolLocation) -> Location? {
       return self.indexToLSPLocation(location)
     }
 
-    // FIXME: (async-workaround) Needed to work around rdar://130112205
+    // TODO: Remove this workaround once https://github.com/swiftlang/swift/issues/75600 is fixed
     func indexToLSPCallHierarchyItem2(
       symbol: Symbol,
       containerName: String?,
@@ -2215,12 +2217,12 @@ extension SourceKitLSPServer {
       return []
     }
 
-    // FIXME: (async-workaround) Needed to work around rdar://130112205
+    // TODO: Remove this workaround once https://github.com/swiftlang/swift/issues/75600 is fixed
     func indexToLSPLocation2(_ location: SymbolLocation) -> Location? {
       return self.indexToLSPLocation(location)
     }
 
-    // FIXME: (async-workaround) Needed to work around rdar://130112205
+    // TODO: Remove this workaround once https://github.com/swiftlang/swift/issues/75600 is fixed
     func indexToLSPCallHierarchyItem2(
       symbol: Symbol,
       containerName: String?,
@@ -2407,12 +2409,12 @@ extension SourceKitLSPServer {
       return index.occurrences(relatedToUSR: related.symbol.usr, roles: .baseOf)
     }
 
-    // FIXME: (async-workaround) Needed to work around rdar://130112205
+    // TODO: Remove this workaround once https://github.com/swiftlang/swift/issues/75600 is fixed
     func indexToLSPLocation2(_ location: SymbolLocation) -> Location? {
       return self.indexToLSPLocation(location)
     }
 
-    // FIXME: (async-workaround) Needed to work around rdar://130112205
+    // TODO: Remove this workaround once https://github.com/swiftlang/swift/issues/75600 is fixed
     func indexToLSPTypeHierarchyItem2(
       symbol: Symbol,
       moduleName: String?,
@@ -2454,12 +2456,12 @@ extension SourceKitLSPServer {
     // Resolve child types and extensions
     let occurs = index.occurrences(ofUSR: data.usr, roles: [.baseOf, .extendedBy])
 
-    // FIXME: (async-workaround) Needed to work around rdar://130112205
+    // TODO: Remove this workaround once https://github.com/swiftlang/swift/issues/75600 is fixed
     func indexToLSPLocation2(_ location: SymbolLocation) -> Location? {
       return self.indexToLSPLocation(location)
     }
 
-    // FIXME: (async-workaround) Needed to work around rdar://130112205
+    // TODO: Remove this workaround once https://github.com/swiftlang/swift/issues/75600 is fixed
     func indexToLSPTypeHierarchyItem2(
       symbol: Symbol,
       moduleName: String?,

--- a/Sources/SourceKitLSP/Swift/CodeActions/ConvertIntegerLiteral.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/ConvertIntegerLiteral.swift
@@ -40,25 +40,8 @@ struct ConvertIntegerLiteral: SyntaxCodeActionProvider {
         continue
       }
 
-      //TODO: Add this to swift-syntax?
-      let prefix: String
-      switch radix {
-      case .binary:
-        prefix = "0b"
-      case .octal:
-        prefix = "0o"
-      case .hex:
-        prefix = "0x"
-      case .decimal:
-        prefix = ""
-      #if RESILIENT_LIBRARIES
-      @unknown default:
-        fatalError("Unknown case")
-      #endif
-      }
-
       let convertedValue: ExprSyntax =
-        "\(raw: prefix)\(raw: String(integerValue, radix: radix.size))"
+        "\(raw: radix.literalPrefix)\(raw: String(integerValue, radix: radix.size))"
       let edit = TextEdit(
         range: scope.snapshot.range(of: integerExpr),
         newText: convertedValue.description

--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -226,8 +226,6 @@ class CodeCompletionSession {
     position: Position,
     in snapshot: DocumentSnapshot
   ) async throws -> CompletionList {
-    // FIXME: Assertion for prefix of snapshot matching what we started with.
-
     logger.info("Updating code completion session: \(self.description) filter=\(filterText)")
     let req = sourcekitd.dictionary([
       keys.request: sourcekitd.requests.codeCompleteUpdate,

--- a/Sources/SourceKitLSP/Swift/CommentXML.swift
+++ b/Sources/SourceKitLSP/Swift/CommentXML.swift
@@ -120,7 +120,6 @@ private struct XMLToMarkdown {
         toMarkdown(discussion.children)
         inParam = false
       }
-    // FIXME: closure parameters would go here.
 
     case "CodeListing":
       lineNumber = 0

--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -340,10 +340,8 @@ extension DiagnosticRelatedInformation {
     let snapshot: DocumentSnapshot
     if filePath == primaryDocumentSnapshot.uri.pseudoPath {
       snapshot = primaryDocumentSnapshot
-    } else if let inMemorySnapshot = try? documentManager.latestSnapshot(uri) {
-      snapshot = inMemorySnapshot
-    } else if let snapshotFromDisk = try? DocumentSnapshot(withContentsFromDisk: uri, language: .swift) {
-      snapshot = snapshotFromDisk
+    } else if let loadedSnapshot = documentManager.latestSnapshotOrDisk(uri, language: .swift) {
+      snapshot = loadedSnapshot
     } else {
       return nil
     }

--- a/Sources/SourceKitLSP/Swift/SemanticRefactorCommand.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactorCommand.swift
@@ -92,7 +92,6 @@ extension Array where Element == SemanticRefactorCommand {
       {
         let actionName = String(cString: ptr)
         guard !actionName.hasPrefix("source.refactoring.kind.rename.") else {
-          // TODO: Rename.
           return true
         }
         commands.append(

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -1319,15 +1319,15 @@ extension sourcekitd_api_uid_t {
     case vals.declAssociatedType:
       return .typeParameter
     case vals.declTypeAlias:
-      return .typeParameter  // FIXME: is there a better choice?
+      return .typeParameter
     case vals.declGenericTypeParam:
       return .typeParameter
     case vals.declConstructor:
       return .constructor
     case vals.declDestructor:
-      return .value  // FIXME: is there a better choice?
+      return .value
     case vals.declSubscript:
-      return .method  // FIXME: is there a better choice?
+      return .method
     case vals.declMethodStatic:
       return .method
     case vals.declMethodInstance:

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -187,7 +187,7 @@ extension SourceKitLSPServer {
     //  - All files that have in-memory modifications are syntactically scanned for tests here.
     let index = workspace.index(checkedFor: .inMemoryModifiedFiles(documentManager))
 
-    // FIXME: (async-workaround) Needed to work around rdar://130112205
+    // TODO: Remove this workaround once https://github.com/swiftlang/swift/issues/75600 is fixed
     func documentManagerHasInMemoryModifications(_ uri: DocumentURI) -> Bool {
       return documentManager.fileHasInMemoryModifications(uri)
     }

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -324,7 +324,7 @@ struct SourceKitLSP: AsyncParsableCommand {
         // FIXME: keep the FileHandle alive until we close the connection to
         // workaround SR-13822.
         withExtendedLifetime(realStdoutHandle) {}
-        // Use _Exit to avoid running static destructors due to SR-12668.
+        // Use _Exit to avoid running static destructors due to https://github.com/swiftlang/swift/issues/55112.
         _Exit(0)
       }
     )

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -321,9 +321,6 @@ struct SourceKitLSP: AsyncParsableCommand {
       receiveHandler: server,
       closeHandler: {
         await server.prepareForExit()
-        // FIXME: keep the FileHandle alive until we close the connection to
-        // workaround SR-13822.
-        withExtendedLifetime(realStdoutHandle) {}
         // Use _Exit to avoid running static destructors due to https://github.com/swiftlang/swift/issues/55112.
         _Exit(0)
       }

--- a/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
@@ -22,8 +22,6 @@ import XCTest
 /// The path to the INPUTS directory of shared test projects.
 private let skTestSupportInputsDirectory: URL = {
   #if os(macOS)
-  // FIXME: Use Bundle.module.resourceURL once the fix for SR-12912 is released.
-
   var resources =
     productsDirectory
     .appendingPathComponent("SourceKitLSP_SKTestSupport.bundle")

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -262,8 +262,7 @@ class ConnectionTests: XCTestCase {
           // We get an error from XCTest if this is fulfilled more than once.
           expectation.fulfill()
 
-          // FIXME: keep the pipes alive until we close the connection. This
-          // should be fixed systemically.
+          // Keep the pipes alive until we close the connection.
           withExtendedLifetime((to, from)) {}
         }
       )

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -253,8 +253,8 @@ final class ImplementationTests: XCTestCase {
   }
 
   func testOverrideProtocolFunc() async throws {
-    // FIXME: We should not be reporting locations 4, 5 and 7 because they don't actually contain myFunc.
-    // We should, however, be reporting location 6
+    // TODO: We should not be reporting locations 4, 5 and 7 because they don't actually contain myFunc.
+    // We should, however, be reporting location 6. (https://github.com/swiftlang/sourcekit-lsp/issues/1600)
 
     try await testImplementation(
       """

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -209,7 +209,6 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertEqual(test.kind, .method)
       XCTAssertEqual(test.detail, "Void")
       XCTAssertEqual(test.filterText, "test(:)")
-      // FIXME:
       XCTAssertEqual(
         test.textEdit,
         .textEdit(
@@ -315,7 +314,7 @@ final class SwiftCompletionTests: XCTestCase {
       XCTFail("No completion item with label 'foo()'")
       return
     }
-    // FIXME: should be "foo()"
+    // TODO: The filter text should be "foo()" (https://github.com/swiftlang/sourcekit-lsp/issues/1599)
     XCTAssertEqual(item.filterText, "func foo()")
     XCTAssertEqual(
       item.textEdit,


### PR DESCRIPTION
I have found that standalone `FIXME` and `TODO` comments rarely get addressed and are thus not very valuable. 

Do one of the following for every `FIXME` or `TODO` comment
- Address them
- Add an issue that tracks the task
- Remove the comment if we are not planning to address it