### PR TITLE
Fix build warnings

### DIFF
--- a/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import BuildServerProtocol
+import Foundation
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
 import SKLogging
@@ -25,13 +26,6 @@ import func TSCBasic.getEnvSearchPaths
 import var TSCBasic.localFileSystem
 import func TSCBasic.lookupExecutablePath
 import func TSCBasic.resolveSymlinks
-
-#if canImport(Darwin)
-import Foundation
-#else
-// FIMXE: (async-workaround) @preconcurrency needed because Pipe is not marked as Sendable on Linux rdar://132378792
-@preconcurrency import Foundation
-#endif
 
 enum BuildServerTestError: Error {
   case executableNotFound(String)

--- a/Sources/Diagnose/DiagnoseCommand.swift
+++ b/Sources/Diagnose/DiagnoseCommand.swift
@@ -213,7 +213,9 @@ package struct DiagnoseCommand: AsyncParsableCommand {
     #if os(macOS)
     reportProgress(.collectingLogMessages(progress: 0), message: "Collecting log messages")
     let outputFileUrl = bundlePath.appendingPathComponent("log.txt")
-    FileManager.default.createFile(atPath: outputFileUrl.path, contents: nil)
+    guard FileManager.default.createFile(atPath: outputFileUrl.path, contents: nil) else {
+      throw ReductionError("Failed to create log.txt")
+    }
     let fileHandle = try FileHandle(forWritingTo: outputFileUrl)
     var bytesCollected = 0
     // 50 MB is an average log size collected by sourcekit-lsp diagnose.
@@ -304,7 +306,9 @@ package struct DiagnoseCommand: AsyncParsableCommand {
   @MainActor
   private func addSwiftVersion(toBundle bundlePath: URL) async throws {
     let outputFileUrl = bundlePath.appendingPathComponent("swift-versions.txt")
-    FileManager.default.createFile(atPath: outputFileUrl.path, contents: nil)
+    guard FileManager.default.createFile(atPath: outputFileUrl.path, contents: nil) else {
+      throw ReductionError("Failed to create file at \(outputFileUrl)")
+    }
     let fileHandle = try FileHandle(forWritingTo: outputFileUrl)
 
     let toolchains = try await toolchainRegistry.toolchains

--- a/Sources/Diagnose/IndexCommand.swift
+++ b/Sources/Diagnose/IndexCommand.swift
@@ -121,4 +121,4 @@ fileprivate extension SourceKitLSPServer {
   }
 }
 
-extension ExperimentalFeature: ExpressibleByArgument {}
+extension ExperimentalFeature: ArgumentParser.ExpressibleByArgument {}

--- a/Sources/Diagnose/MergeSwiftFiles.swift
+++ b/Sources/Diagnose/MergeSwiftFiles.swift
@@ -23,7 +23,8 @@ extension RequestInfo {
     progressUpdate: (_ progress: Double, _ message: String) -> Void
   ) async throws -> RequestInfo? {
     let swiftFilePaths = compilerArgs.filter { $0.hasSuffix(".swift") }
-    let mergedFile = try swiftFilePaths.map { try String(contentsOfFile: $0) }.joined(separator: "\n\n\n\n")
+    let mergedFile = try swiftFilePaths.map { try String(contentsOfFile: $0, encoding: .utf8) }
+      .joined(separator: "\n\n\n\n")
 
     progressUpdate(0, "Merging all .swift files into a single file")
 

--- a/Sources/Diagnose/ReduceCommand.swift
+++ b/Sources/Diagnose/ReduceCommand.swift
@@ -78,7 +78,7 @@ package struct ReduceCommand: AsyncParsableCommand {
 
     let progressBar = PercentProgressAnimation(stream: stderrStreamConcurrencySafe, header: "Reducing sourcekitd issue")
 
-    let request = try String(contentsOfFile: sourcekitdRequestPath)
+    let request = try String(contentsOfFile: sourcekitdRequestPath, encoding: .utf8)
     let requestInfo = try RequestInfo(request: request)
 
     let executor = OutOfProcessSourceKitRequestExecutor(

--- a/Sources/Diagnose/RequestInfo.swift
+++ b/Sources/Diagnose/RequestInfo.swift
@@ -104,7 +104,7 @@ package struct RequestInfo: Sendable {
 
     self.requestTemplate = requestTemplate
 
-    fileContents = try String(contentsOf: URL(fileURLWithPath: sourceFilePath))
+    fileContents = try String(contentsOf: URL(fileURLWithPath: sourceFilePath), encoding: .utf8)
   }
 
   /// Create a `RequestInfo` that is used to reduce a `swift-frontend issue`
@@ -126,7 +126,7 @@ package struct RequestInfo: Sendable {
         guard let fileList = iterator.next() else {
           throw ReductionError("Expected file path after -filelist command line argument")
         }
-        frontendArgsWithFilelistInlined += try String(contentsOfFile: fileList)
+        frontendArgsWithFilelistInlined += try String(contentsOfFile: fileList, encoding: .utf8)
           .split(separator: "\n")
           .map { String($0) }
       default:

--- a/Sources/Diagnose/RunSourcekitdRequestCommand.swift
+++ b/Sources/Diagnose/RunSourcekitdRequestCommand.swift
@@ -42,7 +42,7 @@ package struct RunSourceKitdRequestCommand: AsyncParsableCommand {
   package init() {}
 
   package func run() async throws {
-    var requestString = try String(contentsOf: URL(fileURLWithPath: sourcekitdRequestPath))
+    var requestString = try String(contentsOf: URL(fileURLWithPath: sourcekitdRequestPath), encoding: .utf8)
 
     let installPath = try AbsolutePath(validating: Bundle.main.bundlePath)
     let sourcekitdPath =

--- a/Sources/SKLogging/NonDarwinLogging.swift
+++ b/Sources/SKLogging/NonDarwinLogging.swift
@@ -15,8 +15,7 @@ import SwiftExtensions
 #if canImport(Darwin)
 import Foundation
 #else
-// FIMXE: (async-workaround) @preconcurrency needed because DateFormatter and stderr are not marked as Sendable on Linux
-// rdar://125578486, rdar://132378589
+// TODO: @preconcurrency needed because stderr is not sendable on Linux https://github.com/swiftlang/swift/issues/75601
 @preconcurrency import Foundation
 #endif
 

--- a/Sources/SKLogging/SetGlobalLogFileHandler.swift
+++ b/Sources/SKLogging/SetGlobalLogFileHandler.swift
@@ -15,8 +15,7 @@ import RegexBuilder
 #if canImport(Darwin)
 import Foundation
 #else
-// FIMXE: (async-workaround) @preconcurrency needed because DateFormatter and stderr are not marked as Sendable on Linux
-// rdar://125578486, rdar://132378589
+// TODO: @preconcurrency needed because stderr is not sendable on Linux https://github.com/swiftlang/swift/issues/75601
 @preconcurrency import Foundation
 #endif
 

--- a/Sources/SKSupport/DocumentURI+CustomLogStringConvertible.swift
+++ b/Sources/SKSupport/DocumentURI+CustomLogStringConvertible.swift
@@ -21,4 +21,4 @@ extension DocumentURI {
     return "<DocumentURI length=\(description.count) hash=\(description.hashForLogging)>"
   }
 }
-extension DocumentURI: CustomLogStringConvertible {}
+extension DocumentURI: SKLogging.CustomLogStringConvertible {}

--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -471,7 +471,10 @@ package actor SkipUnless {
         .appending(component: "swift-frontend")
       return try await withTestScratchDir { scratchDirectory in
         let input = scratchDirectory.appending(component: "Input.swift")
-        FileManager.default.createFile(atPath: input.pathString, contents: nil)
+        guard FileManager.default.createFile(atPath: input.pathString, contents: nil) else {
+          struct FailedToCrateInputFileError: Error {}
+          throw FailedToCrateInputFileError()
+        }
         // If we can't compile for wasm, this fails complaining that it can't find the stdlib for wasm.
         let process = Process(
           args: swiftFrontend.pathString,

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -17,12 +17,7 @@ import SKSupport
 import SwiftExtensions
 import XCTest
 
-#if canImport(Darwin)
 import class Foundation.Pipe
-#else
-// FIMXE: (async-workaround) @preconcurrency needed because Pipe is not marked as Sendable on Linux rdar://132378792
-@preconcurrency import class Foundation.Pipe
-#endif
 
 package final class TestJSONRPCConnection: Sendable {
   package let clientToServer: Pipe = Pipe()

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -202,7 +202,7 @@ private let testMessageRegistry = MessageRegistry(
   notifications: [EchoNotification.self, ShowMessageNotification.self]
 )
 
-extension String: ResponseType {}
+extension String: LanguageServerProtocol.ResponseType {}
 
 package struct EchoRequest: RequestType {
   package static let method: String = "test_server/echo"

--- a/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import BuildSystemIntegration
+import Foundation
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
 import SKLogging
@@ -22,19 +23,8 @@ import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
 
-#if canImport(Darwin)
-import Foundation
-#else
-// FIMXE: (async-workaround) @preconcurrency needed because Pipe is not marked as Sendable on Linux
-@preconcurrency import Foundation
-#endif
-
 #if os(Windows)
 import WinSDK
-#endif
-
-#if !canImport(Darwin)
-extension Process: @unchecked Sendable {}
 #endif
 
 /// A thin wrapper over a connection to a clangd server providing build setting handling.

--- a/Sources/SourceKitLSP/DocumentSnapshot+FromFileContents.swift
+++ b/Sources/SourceKitLSP/DocumentSnapshot+FromFileContents.swift
@@ -29,7 +29,7 @@ package extension DocumentSnapshot {
   ///
   /// Throws an error if the file could not be read.
   init(withContentsFromDisk url: URL, language: Language) throws {
-    let contents = try String(contentsOf: url)
+    let contents = try String(contentsOf: url, encoding: .utf8)
     self.init(uri: DocumentURI(url), language: language, version: 0, lineTable: LineTable(contents))
   }
 }

--- a/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
+++ b/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
@@ -34,4 +34,4 @@ extension UncheckedIndex {
   }
 }
 
-extension UncheckedIndex: MainFilesProvider {}
+extension UncheckedIndex: BuildSystemIntegration.MainFilesProvider {}

--- a/Sources/SourceKitLSP/Swift/MacroExpansion.swift
+++ b/Sources/SourceKitLSP/Swift/MacroExpansion.swift
@@ -180,12 +180,6 @@ extension SwiftLanguageService {
   }
 
   func expandMacro(macroExpansionURLData: MacroExpansionReferenceDocumentURLData) async throws -> String {
-    guard let sourceKitLSPServer = self.sourceKitLSPServer else {
-      // `SourceKitLSPServer` has been destructed. We are tearing down the
-      // language server. Nothing left to do.
-      throw ResponseError.unknown("Connection to the editor closed")
-    }
-
     let expandMacroCommand = ExpandMacroCommand(
       positionRange: macroExpansionURLData.selectionRange,
       textDocument: TextDocumentIdentifier(macroExpansionURLData.primaryFile)

--- a/Sources/SourceKitLSP/Swift/MacroExpansionReferenceDocumentURLData.swift
+++ b/Sources/SourceKitLSP/Swift/MacroExpansionReferenceDocumentURLData.swift
@@ -59,12 +59,12 @@ package struct MacroExpansionReferenceDocumentURLData {
   }
 
   package init(displayName: String, queryItems: [URLQueryItem]) throws {
-    guard let primaryFilePath = queryItems.last { $0.name == Parameters.primaryFilePath }?.value,
-      let fromLine = Int(queryItems.last { $0.name == Parameters.fromLine }?.value ?? ""),
-      let fromColumn = Int(queryItems.last { $0.name == Parameters.fromColumn }?.value ?? ""),
-      let toLine = Int(queryItems.last { $0.name == Parameters.toLine }?.value ?? ""),
-      let toColumn = Int(queryItems.last { $0.name == Parameters.toColumn }?.value ?? ""),
-      let bufferName = queryItems.last { $0.name == Parameters.bufferName }?.value
+    guard let primaryFilePath = queryItems.last(where: { $0.name == Parameters.primaryFilePath })?.value,
+      let fromLine = Int(queryItems.last(where: { $0.name == Parameters.fromLine })?.value ?? ""),
+      let fromColumn = Int(queryItems.last(where: { $0.name == Parameters.fromColumn })?.value ?? ""),
+      let toLine = Int(queryItems.last(where: { $0.name == Parameters.toLine })?.value ?? ""),
+      let toColumn = Int(queryItems.last(where: { $0.name == Parameters.toColumn })?.value ?? ""),
+      let bufferName = queryItems.last(where: { $0.name == Parameters.bufferName })?.value
     else {
       throw ReferenceDocumentURLError(description: "Invalid queryItems for macro expansion reference document url")
     }

--- a/Sources/SourceKitLSP/Swift/ReferenceDocumentURL.swift
+++ b/Sources/SourceKitLSP/Swift/ReferenceDocumentURL.swift
@@ -78,7 +78,7 @@ package enum ReferenceDocumentURL {
       throw ReferenceDocumentURLError(
         description: "Bad URL for reference document: \(url)"
       )
-    default:
+    case let documentType?:
       throw ReferenceDocumentURLError(
         description: "Invalid document type in URL for reference document: \(documentType)"
       )

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -84,11 +84,11 @@ extension PathPrefixMapping {
     )
   }
 }
-extension PathPrefixMapping: ExpressibleByArgument {}
+extension PathPrefixMapping: ArgumentParser.ExpressibleByArgument {}
 
-extension SKOptions.BuildConfiguration: ExpressibleByArgument {}
+extension SKOptions.BuildConfiguration: ArgumentParser.ExpressibleByArgument {}
 
-extension SKOptions.WorkspaceType: ExpressibleByArgument {}
+extension SKOptions.WorkspaceType: ArgumentParser.ExpressibleByArgument {}
 
 @main
 struct SourceKitLSP: AsyncParsableCommand {

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -15,6 +15,7 @@ import BuildSystemIntegration
 import Csourcekitd  // Not needed here, but fixes debugging...
 import Diagnose
 import Dispatch
+import Foundation
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
 import SKLogging
@@ -27,13 +28,6 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
 import var TSCBasic.localFileSystem
-
-#if canImport(Darwin)
-import Foundation
-#else
-// FIMXE: (async-workaround) @preconcurrency needed because FileHandle is not marked as Sendable on Linux rdar://132378985
-@preconcurrency import Foundation
-#endif
 
 extension AbsolutePath {
   public init?(argument: String) {

--- a/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
@@ -12,18 +12,12 @@
 
 import BuildServerProtocol
 import BuildSystemIntegration
+import Foundation
 import ISDBTestSupport
 import LanguageServerProtocol
 import SKTestSupport
 import TSCBasic
 import XCTest
-
-#if canImport(Darwin)
-import Foundation
-#else
-// FIMXE: (async-workaround) @preconcurrency needed because Pipe is not marked as Sendable on Linux rdar://132378792
-@preconcurrency import Foundation
-#endif
 
 /// The path to the INPUTS directory of shared test projects.
 private let skTestSupportInputsDirectory: URL = {

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -15,12 +15,7 @@ import LanguageServerProtocol
 import SKTestSupport
 import XCTest
 
-#if canImport(Darwin)
 import class Foundation.Pipe
-#else
-// FIMXE: (async-workaround) @preconcurrency needed because Pipe is not marked as Sendable on Linux rdar://132378792
-@preconcurrency import class Foundation.Pipe
-#endif
 
 #if os(Windows)
 import WinSDK

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1199,7 +1199,7 @@ final class BackgroundIndexingTests: XCTestCase {
     )
     let packageResolvedURL = project.scratchDirectory.appendingPathComponent("Package.resolved")
 
-    let originalPackageResolvedContents = try String(contentsOf: packageResolvedURL)
+    let originalPackageResolvedContents = try String(contentsOf: packageResolvedURL, encoding: .utf8)
 
     // First check our setup to see that we get the expected hover response before changing the dependency project.
     let (uri, positions) = try project.openDocument("Test.swift")
@@ -1234,7 +1234,7 @@ final class BackgroundIndexingTests: XCTestCase {
       ])
     )
     try await project.testClient.send(PollIndexRequest())
-    XCTAssertEqual(try String(contentsOf: packageResolvedURL), originalPackageResolvedContents)
+    XCTAssertEqual(try String(contentsOf: packageResolvedURL, encoding: .utf8), originalPackageResolvedContents)
 
     // Simulate a package update which goes as follows:
     //  - The user runs `swift package update`
@@ -1248,7 +1248,7 @@ final class BackgroundIndexingTests: XCTestCase {
       ],
       workingDirectory: nil
     )
-    XCTAssertNotEqual(try String(contentsOf: packageResolvedURL), originalPackageResolvedContents)
+    XCTAssertNotEqual(try String(contentsOf: packageResolvedURL, encoding: .utf8), originalPackageResolvedContents)
     project.testClient.send(
       DidChangeWatchedFilesNotification(changes: [
         FileEvent(uri: DocumentURI(project.scratchDirectory.appendingPathComponent("Package.resolved")), type: .changed)


### PR DESCRIPTION
Fix build warnings both when building with Swift 6.0 and with Swift from `main` on Linux and macOS.