### PR TITLE
Add configuration option to disable the sandbox for SwiftPM operations

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -23,6 +23,7 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `cxxCompilerFlags: string[]`: Extra arguments passed to the compiler for C++ files. Equivalent to SwiftPM's `-Xcxx` option.
   - `swiftCompilerFlags: string[]`: Extra arguments passed to the compiler for Swift files. Equivalent to SwiftPM's `-Xswiftc` option.
   - `linkerFlags: string[]`: Extra arguments passed to the linker. Equivalent to SwiftPM's `-Xlinker` option.
+  - `disableSandbox: bool`: Disables running subprocesses from SwiftPM in a sandbox. Useful when running `sourcekit-lsp` in a sandbox because nested sandboxes are not supported.
 - `compilationDatabase`: Dictionary with the following keys, defining options for workspaces with a compilation database
   - `searchPaths: string[]`: Additional paths to search for a compilation database, relative to a workspace root.
 - `fallbackBuildSystem`: Dictionary with the following keys, defining options for files that aren't managed by any build system

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -261,7 +261,13 @@ package actor SwiftPMBuildSystem {
       fileSystem: fileSystem,
       location: location,
       configuration: configuration,
-      customHostToolchain: hostSwiftPMToolchain
+      customHostToolchain: hostSwiftPMToolchain,
+      customManifestLoader: ManifestLoader(
+        toolchain: hostSwiftPMToolchain,
+        isManifestSandboxEnabled: !(options.swiftPM.disableSandbox ?? false),
+        cacheDir: location.sharedManifestsCacheDirectory,
+        importRestrictions: configuration.manifestImportRestrictions
+      )
     )
 
     let buildConfiguration: PackageModel.BuildConfiguration
@@ -378,6 +384,7 @@ extension SwiftPMBuildSystem {
       destinationBuildParameters: destinationBuildParameters,
       toolsBuildParameters: toolsBuildParameters,
       graph: modulesGraph,
+      disableSandbox: options.swiftPM.disableSandbox ?? false,
       fileSystem: fileSystem,
       observabilityScope: observabilitySystem.topScope
     )
@@ -631,6 +638,9 @@ extension SwiftPMBuildSystem: BuildSystemIntegration.BuildSystem {
       "--disable-index-store",
       "--target", target.targetID,
     ]
+    if options.swiftPM.disableSandbox ?? false {
+      arguments += ["--disable-sandbox"]
+    }
     if let configuration = options.swiftPM.configuration {
       arguments += ["-c", configuration.rawValue]
     }

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -53,6 +53,9 @@ public struct SourceKitLSPOptions: Sendable, Codable, CustomLogStringConvertible
     /// Equivalent to SwiftPM's `-Xlinker` option
     public var linkerFlags: [String]?
 
+    /// Equivalent to SwiftPM's `--disable-sandbox` option
+    public var disableSandbox: Bool?
+
     public init(
       configuration: BuildConfiguration? = nil,
       scratchPath: String? = nil,
@@ -62,7 +65,8 @@ public struct SourceKitLSPOptions: Sendable, Codable, CustomLogStringConvertible
       cCompilerFlags: [String]? = nil,
       cxxCompilerFlags: [String]? = nil,
       swiftCompilerFlags: [String]? = nil,
-      linkerFlags: [String]? = nil
+      linkerFlags: [String]? = nil,
+      disableSandbox: Bool? = nil
     ) {
       self.configuration = configuration
       self.scratchPath = scratchPath
@@ -73,6 +77,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, CustomLogStringConvertible
       self.cxxCompilerFlags = cxxCompilerFlags
       self.swiftCompilerFlags = swiftCompilerFlags
       self.linkerFlags = linkerFlags
+      self.disableSandbox = disableSandbox
     }
 
     static func merging(base: SwiftPMOptions, override: SwiftPMOptions?) -> SwiftPMOptions {
@@ -85,7 +90,8 @@ public struct SourceKitLSPOptions: Sendable, Codable, CustomLogStringConvertible
         cCompilerFlags: override?.cCompilerFlags ?? base.cCompilerFlags,
         cxxCompilerFlags: override?.cxxCompilerFlags ?? base.cxxCompilerFlags,
         swiftCompilerFlags: override?.swiftCompilerFlags ?? base.swiftCompilerFlags,
-        linkerFlags: override?.linkerFlags ?? base.linkerFlags
+        linkerFlags: override?.linkerFlags ?? base.linkerFlags,
+        disableSandbox: override?.disableSandbox ?? base.disableSandbox
       )
     }
 


### PR DESCRIPTION
Disabling the sandbox is needed to run tests for the Swift VS Code extension in a sandbox.