### PR TITLE
Add Semantic Functionality to Macro Expansion Reference Documents (including Nested Macro Expansion) 🚦

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1674,10 +1674,18 @@ extension SourceKitLSPServer {
   }
 
   func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny? {
-    guard let uri = req.textDocument?.uri else {
+    guard let reqURI = req.textDocument?.uri,
+      let uri =
+        if let primaryFileURI = (try? ReferenceDocumentURL(from: reqURI))?.primaryFile {
+          primaryFileURI
+        } else {
+          reqURI
+        }
+    else {
       logger.error("Attempted to perform executeCommand request without an URL")
       return nil
     }
+
     guard let workspace = await workspaceForDocument(uri: uri) else {
       throw ResponseError.workspaceNotOpen(uri)
     }

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -158,10 +158,10 @@ extension SwiftLanguageService {
       keys.cancelOnSubsequentRequest: 0,
       keys.offset: offsetRange.lowerBound,
       keys.length: offsetRange.upperBound != offsetRange.lowerBound ? offsetRange.count : nil,
-      keys.sourceFile: snapshot.uri.pseudoPath,
+      keys.sourceFile: snapshot.uri.actualFilePath,
+      keys.primaryFile: (try? ReferenceDocumentURL(from: snapshot.uri))?.primaryFile.pseudoPath,
       keys.compilerArgs: await self.buildSettings(for: uri)?.compilerArgs as [SKDRequestValue]?,
     ])
-
     appendAdditionalParameters?(skreq)
 
     let dict = try await sendSourcekitdRequest(skreq, fileContents: snapshot.text)

--- a/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
+++ b/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
@@ -104,7 +104,8 @@ actor DiagnosticReportManager {
 
     let skreq = sourcekitd.dictionary([
       keys.request: requests.diagnostics,
-      keys.sourceFile: snapshot.uri.pseudoPath,
+      keys.sourceFile: snapshot.uri.actualFilePath,
+      keys.primaryFile: (try? ReferenceDocumentURL(from: snapshot.uri))?.primaryFile.pseudoPath,
       keys.compilerArgs: compilerArgs as [SKDRequestValue],
     ])
 

--- a/Sources/SourceKitLSP/Swift/MacroExpansionReferenceDocumentURLData.swift
+++ b/Sources/SourceKitLSP/Swift/MacroExpansionReferenceDocumentURLData.swift
@@ -71,7 +71,7 @@ package struct MacroExpansionReferenceDocumentURLData {
 
     guard let primaryFileURL = URL(string: "file://\(primaryFilePath)") else {
       throw ReferenceDocumentURLError(
-        description: "Unable to parse source file url"
+        description: "Unable to parse primary file url"
       )
     }
 
@@ -82,6 +82,61 @@ package struct MacroExpansionReferenceDocumentURLData {
     self.macroExpansionEditRange = try Self.parse(displayName: displayName)
   }
 
+  /// The file path of the document that originally contains the contents of this reference document.
+  /// This is used since `sourcekitd` cannot understand reference document urls.
+  ///
+  /// For any `ReferenceDocumentURL.macroExpansion`, its `actualFilePath` will be its sourcekitd `bufferName`
+  ///
+  /// *Example:*
+  ///
+  /// User's source File:
+  /// URL: `file:///path/to/swift_file.swift`
+  /// ```swift
+  /// let a = 10
+  /// let b = 5
+  /// print(#stringify(a + b))
+  /// ```
+  ///
+  /// Generated content of reference document url:
+  /// URL:
+  /// `sourcekit-lsp://swift-macro-expansion/L3C7-L3C23.swift?primaryFilePath=/path/to/swift_file.swift&fromLine=3&fromColumn=8&toLine=3&toColumn=8&bufferName=@__swift_macro_..._Stringify_.swift`
+  /// ```swift
+  /// (a + b, "a + b")
+  /// ```
+  ///
+  /// Here the `actualFilePath` of the reference document url is `@__swift_macro_..._Stringify_.swift`
+  ///
+  /// *NOTE*: In case of nested macro expansion reference documents, the `actualFilePath` will be their corresponding
+  /// `bufferName`s
+  package var actualFilePath: String {
+    bufferName
+  }
+
+  /// The URI of the document from which this reference document was derived.
+  /// This is used to determine the workspace and language service that is used to generate the reference document.
+  ///
+  /// *Example:*
+  ///
+  /// User's source File:
+  /// URL: `file://path/to/swift_file.swift`
+  /// ```swift
+  /// let a = 10
+  /// let b = 5
+  /// print(#stringify(a + b))
+  /// ```
+  ///
+  /// Generated content of reference document url:
+  /// URL:
+  /// `sourcekit-lsp://swift-macro-expansion/L3C7-L3C23.swift?primaryFilePath=/path/to/swift_file.swift&fromLine=3&fromColumn=8&toLine=3&toColumn=8&bufferName=@__swift_macro_..._Stringify_.swift`
+  /// ```swift
+  /// (a + b, "a + b")
+  /// ```
+  ///
+  /// Here the `primaryFile` of the reference document url is a `DocumentURI`
+  /// with the following url: `file:///path/to/swift_file.swift`
+  ///
+  /// *NOTE*: In case of nested macro expansion reference documents, they all will have the same `primaryFile`
+  /// as that of the first macro expansion reference document i.e. `primaryFile` doesn't change.
   package var primaryFile: DocumentURI {
     DocumentURI(primaryFileURL)
   }

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -44,12 +44,20 @@ extension SwiftLanguageService {
         symbol: symbol
       )
     } else {
+      let primaryDocument =
+        if let referenceDocument = try? ReferenceDocumentURL(from: document) {
+          referenceDocument.primaryFile
+        } else {
+          document
+        }
+
       let interfaceInfo = try await self.generatedInterfaceInfo(
-        document: document,
+        document: primaryDocument,
         moduleName: moduleName,
         groupName: groupName,
         interfaceURI: interfaceDocURI
       )
+
       try interfaceInfo.contents.write(to: interfaceFilePath, atomically: true, encoding: String.Encoding.utf8)
       let snapshot = DocumentSnapshot(
         uri: interfaceDocURI,

--- a/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
+++ b/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
@@ -69,7 +69,8 @@ extension SwiftLanguageService {
       keys.request: requests.relatedIdents,
       keys.cancelOnSubsequentRequest: 0,
       keys.offset: snapshot.utf8Offset(of: position),
-      keys.sourceFile: snapshot.uri.pseudoPath,
+      keys.sourceFile: snapshot.uri.actualFilePath,
+      keys.primaryFile: (try? ReferenceDocumentURL(from: snapshot.uri))?.primaryFile.pseudoPath,
       keys.includeNonEditableBaseNames: includeNonEditableBaseNames ? 1 : 0,
       keys.compilerArgs: await self.buildSettings(for: snapshot.uri)?.compilerArgs as [SKDRequestValue]?,
     ])

--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -26,7 +26,8 @@ extension SwiftLanguageService {
 
     let skreq = sourcekitd.dictionary([
       keys.request: requests.semanticTokens,
-      keys.sourceFile: snapshot.uri.pseudoPath,
+      keys.sourceFile: snapshot.uri.actualFilePath,
+      keys.primaryFile: (try? ReferenceDocumentURL(from: snapshot.uri))?.primaryFile.pseudoPath,
       keys.compilerArgs: buildSettings.compilerArgs as [SKDRequestValue],
     ])
 

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -87,7 +87,8 @@ extension SwiftLanguageService {
 
     let skreq = sourcekitd.dictionary([
       keys.request: requests.collectVariableType,
-      keys.sourceFile: snapshot.uri.pseudoPath,
+      keys.sourceFile: snapshot.uri.actualFilePath,
+      keys.primaryFile: (try? ReferenceDocumentURL(from: snapshot.uri))?.primaryFile.pseudoPath,
       keys.compilerArgs: await self.buildSettings(for: uri)?.compilerArgs as [SKDRequestValue]?,
     ])
 


### PR DESCRIPTION
**Note: WORK IN PROGRESS**

This PR migrates several requests made to sourcekitd to support Semantic Functionality in Macro Expansion Reference Documents.

What has been migrated and works?
1. `cursorInfo`
2. `documentDiagnosticReport`
3. `openInterface`
4. `semanticTokens`
5. `relatedIdentifiers` (used by `documentSymbolHighlight`)
6. `RefactoringResponse.refactoring`, `getMacroExpansion`, etc. (Nested macro expansions)

What has been migrated but doesn’t work? (probably needs a fix in sourcekitd)
- `inlayHints` (variableTypeInfo)

What won't be migrated since they don't apply for reference documents?
- Rename (Symbol)
- Code Completion Session

Accompanying PR in vscode-swift extension repository: https://github.com/swiftlang/vscode-swift/pull/990

------
[Expansion of Swift Macros in Visual Studio Code - Google Summer Of Code 2024](https://summerofcode.withgoogle.com/programs/2024/projects/zQNf7ztP)
@lokesh-tr @ahoppen @adam-fowler 