### PR TITLE
Use `firstRange` instead of implementing `firstIndex`

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/MessageSplitting.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageSplitting.swift
@@ -25,7 +25,7 @@ public struct JSONRPCMessageHeader: Hashable {
   }
 }
 
-extension RandomAccessCollection<UInt8> {
+extension RandomAccessCollection<UInt8> where Index == Int {
   /// Tries to parse a single message from this collection of bytes.
   ///
   /// If an entire message could be found, returns
@@ -85,33 +85,11 @@ extension RandomAccessCollection<UInt8> {
       throw MessageDecodingError.parseError("expected ':' in message header")
     }
     let valueStart = index(after: keyEnd)
-    guard let valueEnd = self[valueStart...].firstIndex(of: JSONRPCMessageHeader.separator) else {
+    guard let valueEnd = self[valueStart...].firstRange(of: JSONRPCMessageHeader.separator)?.startIndex else {
       return nil
     }
 
     return ((key: self[..<keyEnd], value: self[valueStart..<valueEnd]), self[index(valueEnd, offsetBy: 2)...])
-  }
-}
-
-extension RandomAccessCollection where Element: Equatable {
-  /// Returns the first index where the specified subsequence appears or nil.
-  @inlinable
-  public func firstIndex(of pattern: some RandomAccessCollection<Element>) -> Index? {
-    if pattern.isEmpty {
-      return startIndex
-    }
-    if count < pattern.count {
-      return nil
-    }
-
-    var i = startIndex
-    for _ in 0..<(count - pattern.count + 1) {
-      if self[i...].starts(with: pattern) {
-        return i
-      }
-      i = self.index(after: i)
-    }
-    return nil
   }
 }
 

--- a/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
@@ -850,7 +850,7 @@ private func assertArgumentsDoNotContain(
   file: StaticString = #filePath,
   line: UInt = #line
 ) {
-  if let index = arguments.firstIndex(of: pattern) {
+  if let index = arguments.firstRange(of: pattern)?.startIndex {
     XCTFail(
       "not-pattern \(pattern) unexpectedly found at \(index) in arguments \(arguments)",
       file: file,
@@ -867,12 +867,12 @@ private func assertArgumentsContain(
   file: StaticString = #filePath,
   line: UInt = #line
 ) {
-  guard let index = arguments.firstIndex(of: pattern) else {
+  guard let index = arguments.firstRange(of: pattern)?.startIndex else {
     XCTFail("pattern \(pattern) not found in arguments \(arguments)", file: file, line: line)
     return
   }
 
-  if !allowMultiple, let index2 = arguments[(index + 1)...].firstIndex(of: pattern) {
+  if !allowMultiple, let index2 = arguments[(index + 1)...].firstRange(of: pattern)?.startIndex {
     XCTFail(
       "pattern \(pattern) found twice (\(index), \(index2)) in \(arguments)",
       file: file,

--- a/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/MessageParsingTests.swift
@@ -188,28 +188,6 @@ final class MessageParsingTests: XCTestCase {
     checkError("C\r\n", MessageDecodingError.parseError("expected ':' in message header"))
   }
 
-  func testFindSubsequence() {
-    XCTAssertNil([0, 1, 2].firstIndex(of: [3]))
-    XCTAssertNil([].firstIndex(of: [3]))
-    XCTAssertNil([0, 1, 2].firstIndex(of: [1, 3]))
-    XCTAssertNil([0, 1, 2].firstIndex(of: [0, 2]))
-    XCTAssertNil([0, 1, 2].firstIndex(of: [2, 3]))
-    XCTAssertNil([0, 1].firstIndex(of: [1, 0]))
-    XCTAssertNil([0].firstIndex(of: [0, 1]))
-
-    XCTAssertEqual([Int]().firstIndex(of: []), 0)
-    XCTAssertEqual([0].firstIndex(of: []), 0)
-    XCTAssertEqual([0].firstIndex(of: [0]), 0)
-    XCTAssertEqual([0, 1].firstIndex(of: [0]), 0)
-    XCTAssertEqual([0, 1].firstIndex(of: [1]), 1)
-
-    XCTAssertEqual([0, 1].firstIndex(of: [0, 1]), 0)
-    XCTAssertEqual([0, 1, 2, 3].firstIndex(of: [0, 1]), 0)
-    XCTAssertEqual([0, 1, 2, 3].firstIndex(of: [0, 1, 2]), 0)
-    XCTAssertEqual([0, 1, 2, 3].firstIndex(of: [1, 2]), 1)
-    XCTAssertEqual([0, 1, 2, 3].firstIndex(of: [3]), 3)
-  }
-
   func testIntFromAscii() {
     XCTAssertNil(Int(ascii: ""))
     XCTAssertNil(Int(ascii: "a"))


### PR DESCRIPTION
We have `firstRange` in the stdlib now, so we don’t need to implement `firstIndex` ourselves.