### PR TITLE
Add support for semantic functionality in macro expansion reference documents

### DIFF
--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -147,7 +147,7 @@ extension SwiftLanguageService {
     additionalParameters appendAdditionalParameters: ((SKDRequestDictionary) -> Void)? = nil
   ) async throws -> (cursorInfo: [CursorInfo], refactorActions: [SemanticRefactorCommand]) {
     let documentManager = try self.documentManager
-    let snapshot = try documentManager.latestSnapshot(uri)
+    let snapshot = try await self.latestSnapshot(for: uri)
 
     let offsetRange = snapshot.utf8OffsetRange(of: range)
 
@@ -158,7 +158,8 @@ extension SwiftLanguageService {
       keys.cancelOnSubsequentRequest: 0,
       keys.offset: offsetRange.lowerBound,
       keys.length: offsetRange.upperBound != offsetRange.lowerBound ? offsetRange.count : nil,
-      keys.sourceFile: snapshot.uri.pseudoPath,
+      keys.sourceFile: snapshot.uri.sourcekitdSourceFile,
+      keys.primaryFile: snapshot.uri.primaryFile?.pseudoPath,
       keys.compilerArgs: await self.buildSettings(for: uri)?.compilerArgs as [SKDRequestValue]?,
     ])
 

--- a/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
+++ b/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
@@ -104,7 +104,8 @@ actor DiagnosticReportManager {
 
     let skreq = sourcekitd.dictionary([
       keys.request: requests.diagnostics,
-      keys.sourceFile: snapshot.uri.pseudoPath,
+      keys.sourceFile: snapshot.uri.sourcekitdSourceFile,
+      keys.primaryFile: snapshot.uri.primaryFile?.pseudoPath,
       keys.compilerArgs: compilerArgs as [SKDRequestValue],
     ])
 

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -37,7 +37,7 @@ extension SwiftLanguageService {
     let interfaceFilePath = self.generatedInterfacesPath.appendingPathComponent("\(name).swiftinterface")
     let interfaceDocURI = DocumentURI(interfaceFilePath)
     // has interface already been generated
-    if let snapshot = try? self.documentManager.latestSnapshot(interfaceDocURI) {
+    if let snapshot = try? await self.latestSnapshot(for: interfaceDocURI) {
       return await self.generatedInterfaceDetails(
         uri: interfaceDocURI,
         snapshot: snapshot,
@@ -111,7 +111,8 @@ extension SwiftLanguageService {
       let keys = self.keys
       let skreq = sourcekitd.dictionary([
         keys.request: requests.editorFindUSR,
-        keys.sourceFile: uri.pseudoPath,
+        keys.sourceFile: uri.sourcekitdSourceFile,
+        keys.primaryFile: uri.primaryFile?.pseudoPath,
         keys.usr: symbol,
       ])
 

--- a/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
+++ b/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
@@ -69,7 +69,8 @@ extension SwiftLanguageService {
       keys.request: requests.relatedIdents,
       keys.cancelOnSubsequentRequest: 0,
       keys.offset: snapshot.utf8Offset(of: position),
-      keys.sourceFile: snapshot.uri.pseudoPath,
+      keys.sourceFile: snapshot.uri.sourcekitdSourceFile,
+      keys.primaryFile: snapshot.uri.primaryFile?.pseudoPath,
       keys.includeNonEditableBaseNames: includeNonEditableBaseNames ? 1 : 0,
       keys.compilerArgs: await self.buildSettings(for: snapshot.uri)?.compilerArgs as [SKDRequestValue]?,
     ])

--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -26,7 +26,8 @@ extension SwiftLanguageService {
 
     let skreq = sourcekitd.dictionary([
       keys.request: requests.semanticTokens,
-      keys.sourceFile: snapshot.uri.pseudoPath,
+      keys.sourceFile: snapshot.uri.sourcekitdSourceFile,
+      keys.primaryFile: snapshot.uri.primaryFile?.pseudoPath,
       keys.compilerArgs: buildSettings.compilerArgs as [SKDRequestValue],
     ])
 
@@ -84,7 +85,7 @@ extension SwiftLanguageService {
   package func documentSemanticTokens(
     _ req: DocumentSemanticTokensRequest
   ) async throws -> DocumentSemanticTokensResponse? {
-    let snapshot = try self.documentManager.latestSnapshot(req.textDocument.uri)
+    let snapshot = try await self.latestSnapshot(for: req.textDocument.uri)
 
     let tokens = try await mergedAndSortedTokens(for: snapshot)
     let encodedTokens = tokens.lspEncoded

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -529,13 +529,13 @@ extension SwiftLanguageService {
         return
       }
       do {
-        let snapshot = try await documentManager.latestSnapshot(document)
+        let snapshot = try await self.latestSnapshot(for: document)
         let buildSettings = await self.buildSettings(for: document)
         let diagnosticReport = try await self.diagnosticReportManager.diagnosticReport(
           for: snapshot,
           buildSettings: buildSettings
         )
-        let latestSnapshotID = try? await documentManager.latestSnapshot(snapshot.uri).id
+        let latestSnapshotID = try? await self.latestSnapshot(for: snapshot.uri).id
         if latestSnapshotID != snapshot.id {
           // Check that the document wasn't modified while we were getting diagnostics. This could happen because we are
           // calling `publishDiagnosticsIfNeeded` outside of `messageHandlingQueue` and thus a concurrent edit is
@@ -766,7 +766,7 @@ extension SwiftLanguageService {
   }
 
   package func documentSymbolHighlight(_ req: DocumentHighlightRequest) async throws -> [DocumentHighlight]? {
-    let snapshot = try self.documentManager.latestSnapshot(req.textDocument.uri)
+    let snapshot = try await self.latestSnapshot(for: req.textDocument.uri)
 
     let relatedIdentifiers = try await self.relatedIdentifiers(
       at: req.position,
@@ -867,7 +867,7 @@ extension SwiftLanguageService {
   }
 
   func retrieveQuickFixCodeActions(_ params: CodeActionRequest) async throws -> [CodeAction] {
-    let snapshot = try documentManager.latestSnapshot(params.textDocument.uri)
+    let snapshot = try await self.latestSnapshot(for: params.textDocument.uri)
     let buildSettings = await self.buildSettings(for: params.textDocument.uri)
     let diagnosticReport = try await self.diagnosticReportManager.diagnosticReport(
       for: snapshot,
@@ -960,7 +960,7 @@ extension SwiftLanguageService {
       await semanticIndexManager?.prepareFileForEditorFunctionality(
         req.textDocument.uri.primaryFile ?? req.textDocument.uri
       )
-      let snapshot = try documentManager.latestSnapshot(req.textDocument.uri)
+      let snapshot = try await self.latestSnapshot(for: req.textDocument.uri)
       let buildSettings = await self.buildSettings(for: req.textDocument.uri)
       let diagnosticReport = try await self.diagnosticReportManager.diagnosticReport(
         for: snapshot,

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -83,11 +83,12 @@ extension SwiftLanguageService {
     _ uri: DocumentURI,
     _ range: Range<Position>? = nil
   ) async throws -> [VariableTypeInfo] {
-    let snapshot = try documentManager.latestSnapshot(uri)
+    let snapshot = try await self.latestSnapshot(for: uri)
 
     let skreq = sourcekitd.dictionary([
       keys.request: requests.collectVariableType,
-      keys.sourceFile: snapshot.uri.pseudoPath,
+      keys.sourceFile: snapshot.uri.sourcekitdSourceFile,
+      keys.primaryFile: snapshot.uri.primaryFile?.pseudoPath,
       keys.compilerArgs: await self.buildSettings(for: uri)?.compilerArgs as [SKDRequestValue]?,
     ])
 


### PR DESCRIPTION
Reimplementation of https://github.com/swiftlang/sourcekit-lsp/pull/1610 after https://github.com/swiftlang/sourcekit-lsp/pull/1631

This PR migrates several requests made to sourcekitd to support Semantic Functionality in Macro Expansion Reference Documents.

What has been migrated and works?
1. `cursorInfo`
2. `documentDiagnosticReport`
3. `openInterface`
4. `semanticTokens`
5. `relatedIdentifiers` (used by `documentSymbolHighlight`)
6. Nested Macro Expansions

What has been migrated but doesn’t work?
- `inlayHints` (variableTypeInfo) probably needs a fix in sourcekitd

What won't be migrated since they don't apply for reference documents?
- Rename (Symbol)
- Code Completion Session
- RefactoringResponse.refactoring (i.e. Semantic Refactor)

*Note:*
- A fix for the percent encoding issue will be done in the sourcekit-lsp [PR](https://github.com/swiftlang/sourcekit-lsp/pull/1636) and this PR will only work in conjunction with that.
- Test cases for semantic functionality will be available in a follow-up PR

Moreover, this PR also does the following:
1. Updates outdated doc comments from https://github.com/swiftlang/sourcekit-lsp/pull/1631
2. Fixes an issue where wrong file and position passed in PeekDocumentsRequest from  https://github.com/swiftlang/sourcekit-lsp/pull/1631

------
[Expansion of Swift Macros in Visual Studio Code - Google Summer Of Code 2024](https://summerofcode.withgoogle.com/programs/2024/projects/zQNf7ztP)
@lokesh-tr @ahoppen @adam-fowler 