### PR TITLE
Remove `ExperimentalFeature.showMacroExpansions` flag for macro expansions

### DIFF
--- a/Sources/Diagnose/ActiveRequestsCommand.swift
+++ b/Sources/Diagnose/ActiveRequestsCommand.swift
@@ -13,6 +13,7 @@
 import ArgumentParser
 import Foundation
 import RegexBuilder
+
 import class TSCBasic.Process
 
 package struct ActiveRequestsCommand: AsyncParsableCommand {

--- a/Sources/SKSupport/ExperimentalFeatures.swift
+++ b/Sources/SKSupport/ExperimentalFeatures.swift
@@ -13,6 +13,6 @@
 /// An experimental feature that can be enabled by passing `--experimental-feature` to `sourcekit-lsp` on the command
 /// line. The raw value of this feature is how it is named on the command line.
 public enum ExperimentalFeature: String, Codable, Sendable, CaseIterable {
-  /// Enable showing macro expansions via `ShowDocumentRequest`
-  case showMacroExpansions = "show-macro-expansions"
+  /* This is here to silence the errors when the enum doesn't have any cases */
+  case exampleCase = "example-case"
 }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -856,12 +856,9 @@ extension SwiftLanguageService {
 
     var canInlineMacro = false
 
-    let showMacroExpansionsIsEnabled =
-      await self.sourceKitLSPServer?.options.hasExperimentalFeature(.showMacroExpansions) ?? false
-
     var refactorActions = cursorInfoResponse.refactorActions.compactMap {
       let lspCommand = $0.asCommand()
-      if !canInlineMacro, showMacroExpansionsIsEnabled {
+      if !canInlineMacro {
         canInlineMacro = $0.actionString == "source.refactoring.kind.inline.macro"
       }
 
@@ -1005,10 +1002,7 @@ extension SwiftLanguageService {
   package func executeCommand(_ req: ExecuteCommandRequest) async throws -> LSPAny? {
     if let command = req.swiftCommand(ofType: SemanticRefactorCommand.self) {
       try await semanticRefactoring(command)
-    } else if let command = req.swiftCommand(ofType: ExpandMacroCommand.self),
-      let experimentalFeatures = await self.sourceKitLSPServer?.options.experimentalFeatures,
-      experimentalFeatures.contains(.showMacroExpansions)
-    {
+    } else if let command = req.swiftCommand(ofType: ExpandMacroCommand.self) {
       try await expandMacro(command)
     } else {
       throw ResponseError.unknown("unknown command \(req.command)")

--- a/Tests/SourceKitLSPTests/ExpandMacroTests.swift
+++ b/Tests/SourceKitLSPTests/ExpandMacroTests.swift
@@ -59,8 +59,6 @@ final class ExpandMacroTests: XCTestCase {
       """,
     ]
 
-    let options = SourceKitLSPOptions.testDefault(experimentalFeatures: [.showMacroExpansions])
-
     for (getReferenceDocument, peekDocuments) in cartesianProduct([true], [true]) {
       let project = try await SwiftPMTestProject(
         files: files,
@@ -69,7 +67,7 @@ final class ExpandMacroTests: XCTestCase {
           "workspace/peekDocuments": .bool(peekDocuments),
           "workspace/getReferenceDocument": .bool(getReferenceDocument),
         ]),
-        options: options,
+        options: SourceKitLSPOptions.testDefault(),
         enableBackgroundIndexing: true
       )
 
@@ -236,8 +234,6 @@ final class ExpandMacroTests: XCTestCase {
       """#,
     ]
 
-    let options = SourceKitLSPOptions.testDefault(experimentalFeatures: [.showMacroExpansions])
-
     for (getReferenceDocument, peekDocuments) in cartesianProduct([true, false], [true, false]) {
       let project = try await SwiftPMTestProject(
         files: files,
@@ -246,7 +242,7 @@ final class ExpandMacroTests: XCTestCase {
           "workspace/peekDocuments": .bool(peekDocuments),
           "workspace/getReferenceDocument": .bool(getReferenceDocument),
         ]),
-        options: options,
+        options: SourceKitLSPOptions.testDefault(),
         enableBackgroundIndexing: true
       )
 
@@ -443,7 +439,7 @@ final class ExpandMacroTests: XCTestCase {
         "workspace/peekDocuments": .bool(true),
         "workspace/getReferenceDocument": .bool(true),
       ]),
-      options: SourceKitLSPOptions.testDefault(experimentalFeatures: [.showMacroExpansions]),
+      options: SourceKitLSPOptions.testDefault(),
       enableBackgroundIndexing: true
     )
 


### PR DESCRIPTION
This brings the "Expand Macro" Code Action out of the experimental feature flag.

You can now remove the following from your swift settings:
```
"swift.sourcekit-lsp.serverArguments": [
    "--experimental-feature", "show-macro-expansions"
],
```

------
[Expansion of Swift Macros in Visual Studio Code - Google Summer Of Code 2024](https://summerofcode.withgoogle.com/programs/2024/projects/zQNf7ztP)
@lokesh-tr @ahoppen @adam-fowler 