### PR TITLE
Fix the build using a Swift 5.10 compiler

### DIFF
--- a/Sources/Diagnose/ActiveRequestsCommand.swift
+++ b/Sources/Diagnose/ActiveRequestsCommand.swift
@@ -66,7 +66,7 @@ package struct ActiveRequestsCommand: AsyncParsableCommand {
       log = try await readOSLog()
     }
     let logParseRegex = Regex {
-      /.*/
+      #/.*/#
       "[spid 0x"
       Capture {  // Signpost ID
         OneOrMore(.hexDigit)
@@ -74,7 +74,7 @@ package struct ActiveRequestsCommand: AsyncParsableCommand {
       ", process, "
       ZeroOrMore(.whitespace)
       Capture {  // Event ("begin", "event", "end")
-        /[a-z]+/
+        #/[a-z]+/#
       }
       "]"
       ZeroOrMore(.any)

--- a/Sources/SourceKitLSP/Swift/ReferenceDocumentURL.swift
+++ b/Sources/SourceKitLSP/Swift/ReferenceDocumentURL.swift
@@ -59,7 +59,7 @@ package enum ReferenceDocumentURL {
       throw ReferenceDocumentURLError(description: "Invalid Scheme for reference document")
     }
 
-    let documentType = url.host(percentEncoded: false)
+    let documentType = url.host
 
     switch documentType {
     case MacroExpansionReferenceDocumentURLData.documentType:


### PR DESCRIPTION
`host(percentEncoded:)` is not available using Swift 5.10 on Linux.

Bare slash regex literals are not enabled in Swift 5 mode.