### PR TITLE
Use SwiftPM's SDK computation logic

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -226,25 +226,25 @@ package actor SwiftPMBuildSystem {
     let hostSDK = try SwiftSDK.hostSwiftSDK(AbsolutePath(destinationToolchainBinDir))
     let hostSwiftPMToolchain = try UserToolchain(swiftSDK: hostSDK)
 
-    var destinationSDK: SwiftSDK
-    if let swiftSDK = options.swiftPM.swiftSDK {
-      let bundleStore = try SwiftSDKBundleStore(
-        swiftSDKsDirectory: fileSystem.getSharedSwiftSDKsDirectory(
-          explicitDirectory: options.swiftPM.swiftSDKsDirectory.map { try AbsolutePath(validating: $0) }
-        ),
-        fileSystem: fileSystem,
-        observabilityScope: observabilitySystem.topScope,
-        outputHandler: { _ in }
-      )
-      destinationSDK = try bundleStore.selectBundle(matching: swiftSDK, hostTriple: hostSwiftPMToolchain.targetTriple)
-    } else {
-      destinationSDK = hostSDK
-    }
+    let bundleStore = try SwiftSDKBundleStore(
+      swiftSDKsDirectory: fileSystem.getSharedSwiftSDKsDirectory(
+        explicitDirectory: options.swiftPM.swiftSDKsDirectory.map { try AbsolutePath(validating: $0) }
+      ),
+      fileSystem: fileSystem,
+      observabilityScope: observabilitySystem.topScope,
+      outputHandler: { _ in }
+    )
 
-    if let triple = options.swiftPM.triple {
-      destinationSDK = hostSDK
-      destinationSDK.targetTriple = try Triple(triple)
-    }
+    let destinationSDK = try SwiftSDK.deriveTargetSwiftSDK(
+      hostSwiftSDK: hostSDK,
+      hostTriple: hostSwiftPMToolchain.targetTriple,
+      customCompileTriple: options.swiftPM.triple.map { try Triple($0) },
+      swiftSDKSelector: options.swiftPM.swiftSDK,
+      store: bundleStore,
+      observabilityScope: observabilitySystem.topScope,
+      fileSystem: fileSystem
+    )
+
     let destinationSwiftPMToolchain = try UserToolchain(swiftSDK: destinationSDK)
 
     var location = try Workspace.Location(

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -226,21 +226,19 @@ package actor SwiftPMBuildSystem {
     let hostSDK = try SwiftSDK.hostSwiftSDK(AbsolutePath(destinationToolchainBinDir))
     let hostSwiftPMToolchain = try UserToolchain(swiftSDK: hostSDK)
 
-    let bundleStore = try SwiftSDKBundleStore(
-      swiftSDKsDirectory: fileSystem.getSharedSwiftSDKsDirectory(
-        explicitDirectory: options.swiftPM.swiftSDKsDirectory.map { try AbsolutePath(validating: $0) }
-      ),
-      fileSystem: fileSystem,
-      observabilityScope: observabilitySystem.topScope,
-      outputHandler: { _ in }
-    )
-
     let destinationSDK = try SwiftSDK.deriveTargetSwiftSDK(
       hostSwiftSDK: hostSDK,
       hostTriple: hostSwiftPMToolchain.targetTriple,
       customCompileTriple: options.swiftPM.triple.map { try Triple($0) },
       swiftSDKSelector: options.swiftPM.swiftSDK,
-      store: bundleStore,
+      store: SwiftSDKBundleStore(
+        swiftSDKsDirectory: fileSystem.getSharedSwiftSDKsDirectory(
+          explicitDirectory: options.swiftPM.swiftSDKsDirectory.map { try AbsolutePath(validating: $0) }
+        ),
+        fileSystem: fileSystem,
+        observabilityScope: observabilitySystem.topScope,
+        outputHandler: { _ in }
+      ),
       observabilityScope: observabilitySystem.topScope,
       fileSystem: fileSystem
     )

--- a/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
@@ -305,17 +305,15 @@ final class SwiftPMBuildSystemTests: XCTestCase {
           """,
         ]
       )
-      let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.forTesting
 
       let options = SourceKitLSPOptions.SwiftPMOptions(
-        scratchPath: packageRoot.appending(component: "non_default_build_path").pathString,
         swiftSDKsDirectory: "/tmp/non_existent_sdks_dir",
         triple: "wasm32-unknown-wasi"
       )
 
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        workspacePath: tempDir.appending(component: "pkg"),
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(swiftPM: options),


### PR DESCRIPTION
Using `SwiftSDK.deriveTargetSwiftSDK`, which is the same method that SwiftPM's own CLI tools use to determine the SDK from passed-in info (target `--triple`, `--swift-sdk`, and host sdk). This allows us to better uphold the contract in the [Configuration File](https://github.com/swiftlang/sourcekit-lsp/blob/d11c101ce210ad23f917cf06fb13a7d9e243872b/Documentation/Configuration%20File.md#structure) docs, namely that the `swiftSDK` param is "Equivalent to SwiftPM's `--swift-sdk` option" and similarly for `triple`.

As concrete examples of where (AFAICT) the current implementation diverges:
- Passing a `--triple` of `wasm32-unknown-wasi` to `swift-build` will use the toolchain-integrated Wasm SDK if one exists. Passing the same value to sourcekit-lsp does not do this.
- Perhaps more relevant: after landing https://github.com/swiftlang/swift-package-manager/pull/6828, this change will make it so that building for iOS is as simple as setting `"triple": "arm64-apple-ios"` in the config! Currently, it's necessary to set C/Swift flags and hardcode the sysroot. Should close https://github.com/swiftlang/sourcekit-lsp/issues/1587.

This PR depends on:

- https://github.com/swiftlang/swift-package-manager/pull/7925

But I feel that the two PRs are worth discussing as one since this use case is the primary motivating factor. Will flesh out the SwiftPM PR if the SourceKit/SwiftPM teams agree that this is the right strategy.