### PR TITLE
Log full options with which SourceKit-LSP is initialized

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/LoggableMessageTypes.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/LoggableMessageTypes.swift
@@ -16,17 +16,21 @@ import SKLogging
 
 // MARK: - RequestType
 
-fileprivate struct AnyRequestType: CustomLogStringConvertible {
+package struct AnyRequestType: CustomLogStringConvertible {
   let request: any RequestType
 
-  public var description: String {
+  package init(request: any RequestType) {
+    self.request = request
+  }
+
+  package var description: String {
     return """
       \(type(of: request).method)
       \(request.prettyPrintedJSON)
       """
   }
 
-  public var redactedDescription: String {
+  package var redactedDescription: String {
     return """
       \(type(of: request).method)
       \(request.prettyPrintedRedactedJSON)
@@ -42,17 +46,21 @@ extension RequestType {
 
 // MARK: - NotificationType
 
-fileprivate struct AnyNotificationType: CustomLogStringConvertible {
+package struct AnyNotificationType: CustomLogStringConvertible {
   let notification: any NotificationType
 
-  public var description: String {
+  package init(notification: any NotificationType) {
+    self.notification = notification
+  }
+
+  package var description: String {
     return """
       \(type(of: notification).method)
       \(notification.prettyPrintedJSON)
       """
   }
 
-  public var redactedDescription: String {
+  package var redactedDescription: String {
     return """
       \(type(of: notification).method)
       \(notification.prettyPrintedRedactedJSON)
@@ -68,17 +76,21 @@ extension NotificationType {
 
 // MARK: - ResponseType
 
-fileprivate struct AnyResponseType: CustomLogStringConvertible {
+package struct AnyResponseType: CustomLogStringConvertible {
   let response: any ResponseType
 
-  var description: String {
+  package init(response: any ResponseType) {
+    self.response = response
+  }
+
+  package var description: String {
     return """
       \(type(of: response))
       \(response.prettyPrintedJSON)
       """
   }
 
-  var redactedDescription: String {
+  package var redactedDescription: String {
     return """
       \(type(of: response))
       \(response.prettyPrintedRedactedJSON)

--- a/Sources/LanguageServerProtocolJSONRPC/LoggableMessageTypes.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/LoggableMessageTypes.swift
@@ -14,23 +14,6 @@ import Foundation
 import LanguageServerProtocol
 import SKLogging
 
-fileprivate extension Encodable {
-  var prettyPrintJSON: String {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting.insert(.prettyPrinted)
-    encoder.outputFormatting.insert(.sortedKeys)
-    guard let data = try? encoder.encode(self) else {
-      return "\(self)"
-    }
-    guard let string = String(data: data, encoding: .utf8) else {
-      return "\(self)"
-    }
-    // Don't escape '/'. Most JSON readers don't need it escaped and it makes
-    // paths a lot easier to read and copy-paste.
-    return string.replacingOccurrences(of: "\\/", with: "/")
-  }
-}
-
 // MARK: - RequestType
 
 fileprivate struct AnyRequestType: CustomLogStringConvertible {
@@ -39,12 +22,15 @@ fileprivate struct AnyRequestType: CustomLogStringConvertible {
   public var description: String {
     return """
       \(type(of: request).method)
-      \(request.prettyPrintJSON)
+      \(request.prettyPrintedJSON)
       """
   }
 
   public var redactedDescription: String {
-    return "\(type(of: request).method)"
+    return """
+      \(type(of: request).method)
+      \(request.prettyPrintedRedactedJSON)
+      """
   }
 }
 
@@ -62,12 +48,15 @@ fileprivate struct AnyNotificationType: CustomLogStringConvertible {
   public var description: String {
     return """
       \(type(of: notification).method)
-      \(notification.prettyPrintJSON)
+      \(notification.prettyPrintedJSON)
       """
   }
 
   public var redactedDescription: String {
-    return "\(type(of: notification).method)"
+    return """
+      \(type(of: notification).method)
+      \(notification.prettyPrintedRedactedJSON)
+      """
   }
 }
 
@@ -85,13 +74,14 @@ fileprivate struct AnyResponseType: CustomLogStringConvertible {
   var description: String {
     return """
       \(type(of: response))
-      \(response.prettyPrintJSON)
+      \(response.prettyPrintedJSON)
       """
   }
 
   var redactedDescription: String {
     return """
       \(type(of: response))
+      \(response.prettyPrintedRedactedJSON)
       """
   }
 }

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -21,7 +21,7 @@ import struct TSCBasic.AbsolutePath
 ///
 /// See `ConfigurationFile.md` for a description of the configuration file's behavior.
 public struct SourceKitLSPOptions: Sendable, Codable, Equatable, CustomLogStringConvertible {
-  public struct SwiftPMOptions: Sendable, Codable, Equatable, CustomLogStringConvertible {
+  public struct SwiftPMOptions: Sendable, Codable, Equatable {
     /// Build configuration (debug|release).
     ///
     /// Equivalent to SwiftPM's `--configuration` option.
@@ -94,17 +94,9 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, CustomLogString
         disableSandbox: override?.disableSandbox ?? base.disableSandbox
       )
     }
-
-    public var description: String {
-      recursiveDescription(of: self)
-    }
-
-    public var redactedDescription: String {
-      recursiveRedactedDescription(of: self)
-    }
   }
 
-  public struct CompilationDatabaseOptions: Sendable, Codable, Equatable, CustomLogStringConvertible {
+  public struct CompilationDatabaseOptions: Sendable, Codable, Equatable {
     /// Additional paths to search for a compilation database, relative to a workspace root.
     public var searchPaths: [String]?
 
@@ -118,17 +110,9 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, CustomLogString
     ) -> CompilationDatabaseOptions {
       return CompilationDatabaseOptions(searchPaths: override?.searchPaths ?? base.searchPaths)
     }
-
-    public var description: String {
-      recursiveDescription(of: self)
-    }
-
-    public var redactedDescription: String {
-      recursiveRedactedDescription(of: self)
-    }
   }
 
-  public struct FallbackBuildSystemOptions: Sendable, Codable, Equatable, CustomLogStringConvertible {
+  public struct FallbackBuildSystemOptions: Sendable, Codable, Equatable {
     public var cCompilerFlags: [String]?
     public var cxxCompilerFlags: [String]?
     public var swiftCompilerFlags: [String]?
@@ -157,17 +141,9 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, CustomLogString
         sdk: override?.sdk ?? base.sdk
       )
     }
-
-    public var description: String {
-      recursiveDescription(of: self)
-    }
-
-    public var redactedDescription: String {
-      recursiveRedactedDescription(of: self)
-    }
   }
 
-  public struct IndexOptions: Sendable, Codable, Equatable, CustomLogStringConvertible {
+  public struct IndexOptions: Sendable, Codable, Equatable {
     public var indexStorePath: String?
     public var indexDatabasePath: String?
     public var indexPrefixMap: [String: String]?
@@ -210,17 +186,9 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, CustomLogString
         updateIndexStoreTimeout: override?.updateIndexStoreTimeout ?? base.updateIndexStoreTimeout
       )
     }
-
-    public var description: String {
-      recursiveDescription(of: self)
-    }
-
-    public var redactedDescription: String {
-      recursiveRedactedDescription(of: self)
-    }
   }
 
-  public struct LoggingOptions: Sendable, Codable, Equatable, CustomLogStringConvertible {
+  public struct LoggingOptions: Sendable, Codable, Equatable {
     /// The level from which one onwards log messages should be written.
     public var level: String?
     /// Whether potentially sensitive information should be redacted.
@@ -239,14 +207,6 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, CustomLogString
         level: override?.level ?? base.level,
         privacyLevel: override?.privacyLevel ?? base.privacyLevel
       )
-    }
-
-    public var description: String {
-      recursiveDescription(of: self)
-    }
-
-    public var redactedDescription: String {
-      recursiveRedactedDescription(of: self)
     }
   }
 
@@ -477,10 +437,10 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable, CustomLogString
   }
 
   public var description: String {
-    recursiveDescription(of: self)
+    self.prettyPrintedJSON
   }
 
   public var redactedDescription: String {
-    recursiveRedactedDescription(of: self)
+    self.prettyPrintedRedactedJSON
   }
 }

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -842,6 +842,7 @@ extension SourceKitLSPServer {
       )
     )
     logger.log("Creating workspace at \(workspaceFolder.forLogging) with options: \(options.forLogging)")
+    logger.logFullObjectInMultipleLogMessages(header: "Options for workspace", options)
 
     let workspace = await Workspace(
       sourceKitLSPServer: self,
@@ -923,7 +924,8 @@ extension SourceKitLSPServer {
       override: orLog("Parsing SourceKitLSPOptions", { try SourceKitLSPOptions(fromLSPAny: req.initializationOptions) })
     )
 
-    logger.log("Initialized SourceKit-LSP with options: \(self.options.forLogging)")
+    logger.log("Initialized SourceKit-LSP")
+    logger.logFullObjectInMultipleLogMessages(header: "SourceKit-LSP Options", self.options)
 
     await workspaceQueue.async { [testHooks] in
       if let workspaceFolders = req.workspaceFolders {

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -16,6 +16,7 @@ import Dispatch
 import Foundation
 import IndexStoreDB
 import LanguageServerProtocol
+import LanguageServerProtocolJSONRPC
 import PackageLoading
 import SKLogging
 import SKOptions
@@ -873,6 +874,7 @@ extension SourceKitLSPServer {
   }
 
   func initialize(_ req: InitializeRequest) async throws -> InitializeResult {
+    logger.logFullObjectInMultipleLogMessages(header: "Initialize request", AnyRequestType(request: req))
     // If the client can handle `PeekDocumentsRequest`, they can enable the
     // experimental client capability `"workspace/peekDocuments"` through the `req.capabilities.experimental`.
     //
@@ -983,12 +985,14 @@ extension SourceKitLSPServer {
 
     assert(!self.workspaces.isEmpty)
 
-    return InitializeResult(
+    let result = InitializeResult(
       capabilities: await self.serverCapabilities(
         for: req.capabilities,
         registry: self.capabilityRegistry!
       )
     )
+    logger.logFullObjectInMultipleLogMessages(header: "Initialize response", AnyRequestType(request: req))
+    return result
   }
 
   func serverCapabilities(

--- a/Tests/SKLoggingTests/LoggingTests.swift
+++ b/Tests/SKLoggingTests/LoggingTests.swift
@@ -212,46 +212,4 @@ final class LoggingTests: XCTestCase {
       $0.log("got \(LogStringConvertible().forLogging)")
     }
   }
-
-  func testRecursiveRedactedDescription() {
-    struct Outer {
-      struct Inner {
-        var publicValue: Int
-        var redactedValue: String
-      }
-      var inner: Inner
-    }
-
-    XCTAssertEqual(
-      recursiveRedactedDescription(of: Outer(inner: Outer.Inner(publicValue: 42, redactedValue: "password"))),
-      """
-      {inner: {publicValue: 42, redactedValue: MD5 digest: 5f4dcc3b5aa765d61d8327deb882cf99}}
-      """
-    )
-
-    XCTAssertEqual(recursiveRedactedDescription(of: (nil as Int?) as Any), "nil")
-
-    XCTAssertEqual(recursiveRedactedDescription(of: (42 as Int?) as Any), "42")
-
-    XCTAssertEqual(
-      recursiveRedactedDescription(of: ("abc" as String?) as Any),
-      "MD5 digest: 900150983cd24fb0d6963f7d28e17f72"
-    )
-
-    struct Something: CustomLogStringConvertible {
-      let x = 1
-      let y = "hi"
-
-      var redactedDescription: String {
-        recursiveRedactedDescription(of: self)
-      }
-
-      var description: String { "" }
-    }
-
-    XCTAssertEqual(
-      Something().redactedDescription,
-      "{x: 1, y: MD5 digest: 49f68a5c8493ec2c0bf489821c21fc3b}"
-    )
-  }
 }

--- a/Tests/SKLoggingTests/PrettyPrintedRedactedJSONTests.swift
+++ b/Tests/SKLoggingTests/PrettyPrintedRedactedJSONTests.swift
@@ -1,0 +1,103 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+@_spi(Testing) import SKLogging
+import SKTestSupport
+import XCTest
+
+class PrettyPrintedRedactedJSONTests: XCTestCase {
+  func testRecursiveRedactedDescription() {
+    struct Outer: Codable {
+      struct Inner: Codable {
+        var publicValue: Int
+        var redactedValue: String
+      }
+      var inner: Inner
+    }
+
+    XCTAssertEqual(
+      Outer(inner: Outer.Inner(publicValue: 42, redactedValue: "password")).prettyPrintedRedactedJSON,
+      """
+      {
+        "inner" : {
+          "publicValue" : 42,
+          "redactedValue" : "<private 5e884898da280471>"
+        }
+      }
+      """
+    )
+  }
+
+  func testOptionalInt() {
+    struct Struct: Codable {
+      var value: Int?
+    }
+
+    XCTAssertEqual(
+      Struct(value: 42).prettyPrintedRedactedJSON,
+      """
+      {
+        "value" : 42
+      }
+      """
+    )
+
+    XCTAssertEqual(
+      Struct(value: nil).prettyPrintedRedactedJSON,
+      """
+      {
+
+      }
+      """
+    )
+  }
+
+  func testOptionalString() {
+    struct Struct: Codable {
+      var value: String?
+    }
+
+    XCTAssertEqual(
+      Struct(value: "password").prettyPrintedRedactedJSON,
+      """
+      {
+        "value" : "<private 5e884898da280471>"
+      }
+      """
+    )
+
+    XCTAssertEqual(
+      Struct(value: nil).prettyPrintedRedactedJSON,
+      """
+      {
+
+      }
+      """
+    )
+  }
+
+  func testDouble() {
+    struct Struct: Codable {
+      var value: Double
+    }
+
+    XCTAssertEqual(
+      Struct(value: 4.5).prettyPrintedRedactedJSON,
+      """
+      {
+        "value" : 4.5
+      }
+      """
+    )
+  }
+}

--- a/Tests/SKLoggingTests/PrettyPrintedRedactedJSONTests.swift
+++ b/Tests/SKLoggingTests/PrettyPrintedRedactedJSONTests.swift
@@ -100,4 +100,22 @@ class PrettyPrintedRedactedJSONTests: XCTestCase {
       """
     )
   }
+
+  func testArrayOfStrings() {
+    struct Struct: Codable {
+      var value: [String]
+    }
+
+    XCTAssertEqual(
+      Struct(value: ["password", "admin"]).prettyPrintedRedactedJSON,
+      """
+      {
+        "value" : [
+          "<private 5e884898da280471>",
+          "<private 8c6976e5b5410415>"
+        ]
+      }
+      """
+    )
+  }
 }


### PR DESCRIPTION
Log the resolved options of the used `config.json` file as well as the initialize request and response. I have found that seeing these options is generally useful to debug issues with the SourceKit-LSP + Editor setup.

A nice side effect is that we can now also log the non-sensitive parts of requests and responses sent between SourceKit-LSP and the editor.