### PR TITLE
Remove custom decoding function from `SourceKitLSPOptions`

### DIFF
--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -121,7 +121,10 @@ package struct IndexedSingleSwiftFileTestProject {
 
     // Create the test client
     var options = SourceKitLSPOptions.testDefault()
-    options.index = SourceKitLSPOptions.IndexOptions(indexStorePath: indexURL.path, indexDatabasePath: indexDBURL.path)
+    options.indexOrDefault = SourceKitLSPOptions.IndexOptions(
+      indexStorePath: indexURL.path,
+      indexDatabasePath: indexDBURL.path
+    )
     self.testClient = try await TestSourceKitLSPClient(
       options: options,
       workspaceFolders: [

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -112,8 +112,8 @@ package final class TestSourceKitLSPClient: MessageHandler, Sendable {
   ) async throws {
     var options = options
     if let globalModuleCache {
-      options.swiftPM.swiftCompilerFlags =
-        (options.swiftPM.swiftCompilerFlags ?? []) + ["-module-cache-path", globalModuleCache.path]
+      options.swiftPMOrDefault.swiftCompilerFlags =
+        (options.swiftPMOrDefault.swiftCompilerFlags ?? []) + ["-module-cache-path", globalModuleCache.path]
     }
     options.backgroundIndexing = enableBackgroundIndexing
 

--- a/Sources/SourceKitLSP/CreateBuildSystem.swift
+++ b/Sources/SourceKitLSP/CreateBuildSystem.swift
@@ -48,7 +48,9 @@ func createBuildSystem(
   func createCompilationDatabaseBuildSystem(rootPath: AbsolutePath) -> CompilationDatabaseBuildSystem? {
     return CompilationDatabaseBuildSystem(
       projectRoot: rootPath,
-      searchPaths: (options.compilationDatabase.searchPaths ?? []).compactMap { try? RelativePath(validating: $0) }
+      searchPaths: (options.compilationDatabaseOrDefault.searchPaths ?? []).compactMap {
+        try? RelativePath(validating: $0)
+      }
     )
   }
 

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -225,7 +225,8 @@ package actor SourceKitLSPServer {
 
     self.client = client
     let processorCount = ProcessInfo.processInfo.processorCount
-    let lowPriorityCores = options.index.maxCoresPercentageToUseForBackgroundIndexingOrDefault * Double(processorCount)
+    let lowPriorityCores =
+      options.indexOrDefault.maxCoresPercentageToUseForBackgroundIndexingOrDefault * Double(processorCount)
     self.indexTaskScheduler = TaskScheduler(maxConcurrentTasksByPriority: [
       (TaskPriority.medium, processorCount),
       (TaskPriority.low, max(Int(lowPriorityCores), 1)),

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -107,7 +107,7 @@ package final class Workspace: Sendable {
     self._uncheckedIndex = ThreadSafeBox(initialValue: uncheckedIndex)
     self.buildSystemManager = await BuildSystemManager(
       buildSystem: underlyingBuildSystem,
-      fallbackBuildSystem: FallbackBuildSystem(options: options.fallbackBuildSystem),
+      fallbackBuildSystem: FallbackBuildSystem(options: options.fallbackBuildSystemOrDefault),
       mainFilesProvider: uncheckedIndex,
       toolchainRegistry: toolchainRegistry
     )
@@ -115,7 +115,7 @@ package final class Workspace: Sendable {
       self.semanticIndexManager = SemanticIndexManager(
         index: uncheckedIndex,
         buildSystemManager: buildSystemManager,
-        updateIndexStoreTimeout: options.index.updateIndexStoreTimeoutOrDefault,
+        updateIndexStoreTimeout: options.indexOrDefault.updateIndexStoreTimeoutOrDefault,
         testHooks: testHooks.indexTestHooks,
         indexTaskScheduler: indexTaskScheduler,
         logMessageToIndexLog: logMessageToIndexLog,
@@ -163,7 +163,7 @@ package final class Workspace: Sendable {
     var index: IndexStoreDB? = nil
     var indexDelegate: SourceKitIndexDelegate? = nil
 
-    let indexOptions = options.index
+    let indexOptions = options.indexOrDefault
     if let storePath = await firstNonNil(
       AbsolutePath(validatingOrNil: indexOptions.indexStorePath),
       await buildSystem?.indexStorePath

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -277,10 +277,12 @@ struct SourceKitLSP: AsyncParsableCommand {
     }
 
     let globalConfigurationOptions = globalConfigurationOptions
-    if let logLevelStr = globalConfigurationOptions.logging.level, let logLevel = NonDarwinLogLevel(logLevelStr) {
+    if let logLevelStr = globalConfigurationOptions.loggingOrDefault.level,
+      let logLevel = NonDarwinLogLevel(logLevelStr)
+    {
       LogConfig.logLevel.value = logLevel
     }
-    if let privacyLevelStr = globalConfigurationOptions.logging.privacyLevel,
+    if let privacyLevelStr = globalConfigurationOptions.loggingOrDefault.privacyLevel,
       let privacyLevel = NonDarwinLogPrivacy(privacyLevelStr)
     {
       LogConfig.privacyLevel.value = privacyLevel

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -965,7 +965,7 @@ final class BackgroundIndexingTests: XCTestCase {
 
   func testUseBuildFlagsDuringPreparation() async throws {
     var options = SourceKitLSPOptions.testDefault()
-    options.swiftPM.swiftCompilerFlags = ["-D", "MY_FLAG"]
+    options.swiftPMOrDefault.swiftCompilerFlags = ["-D", "MY_FLAG"]
     let project = try await SwiftPMTestProject(
       files: [
         "Lib/Lib.swift": """
@@ -1390,7 +1390,7 @@ final class BackgroundIndexingTests: XCTestCase {
 
     var options = SourceKitLSPOptions.testDefault()
     options.backgroundPreparationMode = SourceKitLSPOptions.BackgroundPreparationMode.enabled.rawValue
-    options.index.updateIndexStoreTimeout = 1 /* second */
+    options.indexOrDefault.updateIndexStoreTimeout = 1 /* second */
 
     let dateStarted = Date()
     _ = try await SwiftPMTestProject(

--- a/Tests/SourceKitLSPTests/LifecycleTests.swift
+++ b/Tests/SourceKitLSPTests/LifecycleTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import LanguageServerProtocol
+import SKOptions
 import SKTestSupport
 import XCTest
 
@@ -37,6 +38,13 @@ final class LifecycleTests: XCTestCase {
     }
     XCTAssertEqual(syncOptions.openClose, true)
     XCTAssertNotNil(initResult.capabilities.completionProvider)
+  }
+
+  func testEmptySourceKitLSPOptionsCanBeDecoded() {
+    // Check that none of the keys in `SourceKitLSPOptions` are required.
+    assertNoThrow {
+      try JSONDecoder().decode(SourceKitLSPOptions.self, from: "{}") == SourceKitLSPOptions()
+    }
   }
 
   func testCancellation() async throws {


### PR DESCRIPTION
We forgot to decode the following keys in the custom decode function, which meant that you couldn’t set them using SourceKit-LSP’s `config.json` file.
- `backgroundPreparationMode`
- `sourcekitdRequestTimeout`
- `cancelTextDocumentRequestsOnEditAndClose`

We had the custom decoder function so that the keys weren’t required in the JSON but we could access eg. `SwiftPMOptions` without needing to deal with optionals in the codebase.

Make the accesses to these nested options structs a little more verbose but eliminate the source of the above bug, which seems like a good tradeoff.