### PR TITLE
[6.0.1] Decode a few keys in `SourceKitLSPOptions` that we missed before

### DIFF
--- a/Sources/SKCore/SourceKitLSPOptions.swift
+++ b/Sources/SKCore/SourceKitLSPOptions.swift
@@ -379,6 +379,10 @@ public struct SourceKitLSPOptions: Sendable, Codable {
     )
     self.generatedFilesPath = try container.decodeIfPresent(String.self, forKey: CodingKeys.generatedFilesPath)
     self.backgroundIndexing = try container.decodeIfPresent(Bool.self, forKey: CodingKeys.backgroundIndexing)
+    self.backgroundPreparationMode = try container.decodeIfPresent(
+      String.self,
+      forKey: CodingKeys.backgroundPreparationMode
+    )
     self.experimentalFeatures = try container.decodeIfPresent(
       Set<ExperimentalFeature>.self,
       forKey: CodingKeys.experimentalFeatures
@@ -390,6 +394,10 @@ public struct SourceKitLSPOptions: Sendable, Codable {
     self.workDoneProgressDebounceDuration = try container.decodeIfPresent(
       Double.self,
       forKey: CodingKeys.workDoneProgressDebounceDuration
+    )
+    self.sourcekitdRequestTimeout = try container.decodeIfPresent(
+      Double.self,
+      forKey: CodingKeys.sourcekitdRequestTimeout
     )
   }
 }


### PR DESCRIPTION
- **Explanation**: We forgot to decode the following keys in the custom decode function, which meant that you couldn’t set them using SourceKit-LSP’s `config.json` file.
- `backgroundPreparationMode`
- `sourcekitdRequestTimeout`
In particular this meant that you couldn’t enable the `--experimental-prepare-for-indexing` preparation mode.
Add the necessary decoding functions in `release/6.0` and eliminate the custom decode logic entirely in `main`.
- **Scope**: Parsing of `.sourcekit-lsp/config.json` files
- **Risk**: Low, applies a common pattern to parse keys in JSON
- **Testing**: Manually tested that the `--experimental-prepare-for-indexing` mode can be enabled via `.sourcekit-lsp/config.json` now
- **Issue**: rdar://135436055
- **Reviewer**:   @bnbarham @hamishknight 