### PR TITLE
Create `BuiltInBuildSystem` in `BuildSystemAdapter`

### DIFF
--- a/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
@@ -15,6 +15,7 @@ import Foundation
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
 import SKLogging
+import SKOptions
 import SKSupport
 import SwiftExtensions
 import ToolchainRegistry
@@ -259,6 +260,13 @@ private func readReponseDataKey(data: LSPAny?, key: String) -> String? {
 }
 
 extension BuildServerBuildSystem: BuiltInBuildSystem {
+  static package func projectRoot(for workspaceFolder: AbsolutePath, options: SourceKitLSPOptions) -> AbsolutePath? {
+    guard localFileSystem.isFile(workspaceFolder.appending(component: "buildServer.json")) else {
+      return nil
+    }
+    return workspaceFolder
+  }
+
   package nonisolated var supportsPreparation: Bool { false }
 
   /// The build settings for the given file.

--- a/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
@@ -77,15 +77,12 @@ package actor BuildServerBuildSystem: MessageHandler {
 
   package weak var messageHandler: BuiltInBuildSystemMessageHandler?
 
-  package func setMessageHandler(_ messageHandler: any BuiltInBuildSystemMessageHandler) {
-    self.messageHandler = messageHandler
-  }
-
   /// The build settings that have been received from the build server.
   private var buildSettings: [DocumentURI: FileBuildSettings] = [:]
 
   package init(
     projectRoot: AbsolutePath,
+    messageHandler: BuiltInBuildSystemMessageHandler?,
     fileSystem: FileSystem = localFileSystem
   ) async throws {
     let configPath = projectRoot.appending(component: "buildServer.json")
@@ -105,17 +102,18 @@ package actor BuildServerBuildSystem: MessageHandler {
     #endif
     self.projectRoot = projectRoot
     self.serverConfig = config
+    self.messageHandler = messageHandler
     try await self.initializeBuildServer()
   }
 
   /// Creates a build system using the Build Server Protocol config.
   ///
   /// - Returns: nil if `projectRoot` has no config or there is an error parsing it.
-  package init?(projectRoot: AbsolutePath?) async {
+  package init?(projectRoot: AbsolutePath?, messageHandler: BuiltInBuildSystemMessageHandler?) async {
     guard let projectRoot else { return nil }
 
     do {
-      try await self.init(projectRoot: projectRoot)
+      try await self.init(projectRoot: projectRoot, messageHandler: messageHandler)
     } catch is FileSystemError {
       // config file was missing, no build server for this workspace
       return nil

--- a/Sources/BuildSystemIntegration/BuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuildSystem.swift
@@ -17,6 +17,7 @@ import SKOptions
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
+import struct TSCBasic.RelativePath
 
 /// Defines how well a `BuildSystem` can handle a file with a given URI.
 package enum FileHandlingCapability: Comparable, Sendable {
@@ -97,11 +98,6 @@ package protocol BuiltInBuildSystem: AnyObject, Sendable {
   /// - Note: Needed so we can set the delegate from a different actor isolation
   ///   context.
   func setDelegate(_ delegate: BuildSystemDelegate?) async
-
-  /// Set the message handler that is used to send messages from the build system to SourceKit-LSP.
-  // FIXME: (BSP Migration) This should be set in the initializer but can't right now because BuiltInBuildSystemAdapter is not
-  // responsible for creating the build system.
-  func setMessageHandler(_ messageHandler: BuiltInBuildSystemMessageHandler) async
 
   /// Whether the build system is capable of preparing a target for indexing, ie. if the `prepare` methods has been
   /// implemented.

--- a/Sources/BuildSystemIntegration/BuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuildSystem.swift
@@ -13,6 +13,7 @@
 import BuildServerProtocol
 import LanguageServerProtocol
 import SKLogging
+import SKOptions
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
@@ -67,6 +68,13 @@ package struct PrepareNotSupportedError: Error, CustomStringConvertible {
 /// For example, a SwiftPMWorkspace provides compiler arguments for the files
 /// contained in a SwiftPM package root directory.
 package protocol BuiltInBuildSystem: AnyObject, Sendable {
+  /// When opening an LSP workspace at `workspaceFolder`, determine the directory in which a project of this build system
+  /// starts. For example, a user might open the `Sources` folder of a SwiftPM project, then the project root is the
+  /// directory containing `Package.swift`.
+  ///
+  /// Returns `nil` if the build system can't handle the given workspace folder
+  static func projectRoot(for workspaceFolder: AbsolutePath, options: SourceKitLSPOptions) -> AbsolutePath?
+
   /// The root of the project that this build system manages. For example, for SwiftPM packages, this is the folder
   /// containing Package.swift. For compilation databases it is the root folder based on which the compilation database
   /// was found.

--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -76,7 +76,7 @@ package actor BuildSystemManager: BuiltInBuildSystemAdapterDelegate {
   /// The underlying primary build system.
   ///
   /// - Important: The only time this should be modified is in the initializer. Afterwards, it must be constant.
-  private(set) var buildSystem: BuiltInBuildSystemAdapter?
+  private(set) package var buildSystem: BuiltInBuildSystemAdapter?
 
   /// Timeout before fallback build settings are used.
   let fallbackSettingsTimeout: DispatchTimeInterval

--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -19,7 +19,6 @@ import SwiftExtensions
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
-import struct TSCBasic.RelativePath
 
 #if canImport(os)
 import os
@@ -55,35 +54,6 @@ fileprivate class RequestCache<Request: RequestType & Hashable> {
 
   func clearAll(isolation: isolated any Actor = #isolation) {
     storage.removeAll()
-  }
-}
-
-/// Create a build system of the given type.
-private func createBuildSystem(
-  ofType buildSystemType: WorkspaceType,
-  projectRoot: AbsolutePath,
-  options: SourceKitLSPOptions,
-  swiftpmTestHooks: SwiftPMTestHooks,
-  toolchainRegistry: ToolchainRegistry,
-  reloadPackageStatusCallback: @Sendable @escaping (ReloadPackageStatus) async -> Void
-) async -> BuiltInBuildSystem? {
-  switch buildSystemType {
-  case .buildServer:
-    return await BuildServerBuildSystem(projectRoot: projectRoot)
-  case .compilationDatabase:
-    return CompilationDatabaseBuildSystem(
-      projectRoot: projectRoot,
-      searchPaths: (options.compilationDatabaseOrDefault.searchPaths ?? [])
-        .compactMap { try? RelativePath(validating: $0) }
-    )
-  case .swiftPM:
-    return await SwiftPMBuildSystem(
-      projectRoot: projectRoot,
-      toolchainRegistry: toolchainRegistry,
-      options: options,
-      reloadPackageStatusCallback: reloadPackageStatusCallback,
-      testHooks: swiftpmTestHooks
-    )
   }
 }
 
@@ -136,7 +106,9 @@ package actor BuildSystemManager: BuiltInBuildSystemAdapterDelegate {
   }
 
   package var supportsPreparation: Bool {
-    return buildSystem?.underlyingBuildSystem.supportsPreparation ?? false
+    get async {
+      return await buildSystem?.underlyingBuildSystem.supportsPreparation ?? false
+    }
   }
 
   package init(
@@ -146,29 +118,16 @@ package actor BuildSystemManager: BuiltInBuildSystemAdapterDelegate {
     swiftpmTestHooks: SwiftPMTestHooks,
     reloadPackageStatusCallback: @Sendable @escaping (ReloadPackageStatus) async -> Void
   ) async {
-    let buildSystem: BuiltInBuildSystem?
-    if let (buildSystemType, projectRoot) = buildSystemKind {
-      buildSystem = await createBuildSystem(
-        ofType: buildSystemType,
-        projectRoot: projectRoot,
-        options: options,
-        swiftpmTestHooks: swiftpmTestHooks,
-        toolchainRegistry: toolchainRegistry,
-        reloadPackageStatusCallback: reloadPackageStatusCallback
-      )
-    } else {
-      buildSystem = nil
-    }
-    let buildSystemHasDelegate = await buildSystem?.delegate != nil
-    precondition(!buildSystemHasDelegate)
     self.fallbackBuildSystem = FallbackBuildSystem(options: options.fallbackBuildSystemOrDefault)
     self.toolchainRegistry = toolchainRegistry
-    self.buildSystem =
-      if let buildSystem {
-        await BuiltInBuildSystemAdapter(buildSystem: buildSystem, messageHandler: self)
-      } else {
-        nil
-      }
+    self.buildSystem = await BuiltInBuildSystemAdapter(
+      buildSystemKind: buildSystemKind,
+      toolchainRegistry: toolchainRegistry,
+      options: options,
+      swiftpmTestHooks: swiftpmTestHooks,
+      reloadPackageStatusCallback: reloadPackageStatusCallback,
+      messageHandler: self
+    )
     await self.buildSystem?.underlyingBuildSystem.setDelegate(self)
   }
 
@@ -189,7 +148,7 @@ package actor BuildSystemManager: BuiltInBuildSystemAdapterDelegate {
     self.toolchainRegistry = toolchainRegistry
     self.buildSystem =
       if let testBuildSystem {
-        await BuiltInBuildSystemAdapter(buildSystem: testBuildSystem, messageHandler: self)
+        await BuiltInBuildSystemAdapter(testBuildSystem: testBuildSystem, messageHandler: self)
       } else {
         nil
       }

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
@@ -31,7 +31,7 @@ package protocol BuiltInBuildSystemMessageHandler: AnyObject, Sendable {
 
 /// A type that outwardly acts as a build server conforming to the Build System Integration Protocol and internally uses
 /// a `BuiltInBuildSystem` to satisfy the requests.
-actor BuiltInBuildSystemAdapter: BuiltInBuildSystemMessageHandler {
+package actor BuiltInBuildSystemAdapter: BuiltInBuildSystemMessageHandler {
   /// The underlying build system
   // FIXME: (BSP Migration) This should be private, all messages should go through BSP. Only accessible from the outside for transition
   // purposes.
@@ -89,7 +89,7 @@ actor BuiltInBuildSystemAdapter: BuiltInBuildSystemMessageHandler {
     }
   }
 
-  func sendNotificationToSourceKitLSP(_ notification: some LanguageServerProtocol.NotificationType) async {
+  package func sendNotificationToSourceKitLSP(_ notification: some LanguageServerProtocol.NotificationType) async {
     logger.info(
       """
       Received notification from build system
@@ -99,7 +99,7 @@ actor BuiltInBuildSystemAdapter: BuiltInBuildSystemMessageHandler {
     await messageHandler.handle(notification)
   }
 
-  func sendRequestToSourceKitLSP<R: RequestType>(_ request: R) async throws -> R.Response {
+  package func sendRequestToSourceKitLSP<R: RequestType>(_ request: R) async throws -> R.Response {
     logger.info(
       """
       Received request from build system

--- a/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
@@ -14,6 +14,7 @@ import BuildServerProtocol
 import Dispatch
 import LanguageServerProtocol
 import SKLogging
+import SKOptions
 import SKSupport
 import ToolchainRegistry
 
@@ -100,6 +101,13 @@ package actor CompilationDatabaseBuildSystem {
 }
 
 extension CompilationDatabaseBuildSystem: BuiltInBuildSystem {
+  static package func projectRoot(for workspaceFolder: AbsolutePath, options: SourceKitLSPOptions) -> AbsolutePath? {
+    if tryLoadCompilationDatabase(directory: workspaceFolder) != nil {
+      return workspaceFolder
+    }
+    return nil
+  }
+
   package nonisolated var supportsPreparation: Bool { false }
 
   package var indexDatabasePath: AbsolutePath? {

--- a/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
@@ -50,10 +50,6 @@ package actor CompilationDatabaseBuildSystem {
 
   package weak var messageHandler: BuiltInBuildSystemMessageHandler?
 
-  package func setMessageHandler(_ messageHandler: any BuiltInBuildSystemMessageHandler) {
-    self.messageHandler = messageHandler
-  }
-
   package let projectRoot: AbsolutePath
 
   let searchPaths: [RelativePath]
@@ -87,11 +83,13 @@ package actor CompilationDatabaseBuildSystem {
   package init?(
     projectRoot: AbsolutePath,
     searchPaths: [RelativePath],
+    messageHandler: (any BuiltInBuildSystemMessageHandler)?,
     fileSystem: FileSystem = localFileSystem
   ) {
     self.fileSystem = fileSystem
     self.projectRoot = projectRoot
     self.searchPaths = searchPaths
+    self.messageHandler = messageHandler
     if let compdb = tryLoadCompilationDatabase(directory: projectRoot, additionalSearchPaths: searchPaths, fileSystem) {
       self.compdb = compdb
     } else {

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -182,10 +182,6 @@ package actor SwiftPMBuildSystem {
 
   package weak var messageHandler: BuiltInBuildSystemMessageHandler?
 
-  package func setMessageHandler(_ messageHandler: any BuiltInBuildSystemMessageHandler) {
-    self.messageHandler = messageHandler
-  }
-
   /// This callback is informed when `reloadPackage` starts and ends executing.
   private var reloadPackageStatusCallback: (ReloadPackageStatus) async -> Void
 
@@ -277,6 +273,7 @@ package actor SwiftPMBuildSystem {
     toolchainRegistry: ToolchainRegistry,
     fileSystem: FileSystem = localFileSystem,
     options: SourceKitLSPOptions,
+    messageHandler: (any BuiltInBuildSystemMessageHandler)?,
     reloadPackageStatusCallback: @escaping (ReloadPackageStatus) async -> Void = { _ in },
     testHooks: SwiftPMTestHooks
   ) async throws {
@@ -292,6 +289,7 @@ package actor SwiftPMBuildSystem {
 
     self.toolchain = toolchain
     self.testHooks = testHooks
+    self.messageHandler = messageHandler
 
     guard let destinationToolchainBinDir = toolchain.swiftc?.parentDirectory else {
       throw Error.cannotDetermineHostToolchain
@@ -408,6 +406,7 @@ package actor SwiftPMBuildSystem {
     projectRoot: TSCBasic.AbsolutePath,
     toolchainRegistry: ToolchainRegistry,
     options: SourceKitLSPOptions,
+    messageHandler: any BuiltInBuildSystemMessageHandler,
     reloadPackageStatusCallback: @escaping (ReloadPackageStatus) async -> Void,
     testHooks: SwiftPMTestHooks
   ) async {
@@ -417,6 +416,7 @@ package actor SwiftPMBuildSystem {
         toolchainRegistry: toolchainRegistry,
         fileSystem: localFileSystem,
         options: options,
+        messageHandler: messageHandler,
         reloadPackageStatusCallback: reloadPackageStatusCallback,
         testHooks: testHooks
       )

--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_library(SourceKitLSP STATIC
   CapabilityRegistry.swift
-  CreateBuildSystem.swift
+  DetermineBuildSystem.swift
   DocumentManager.swift
   DocumentSnapshot+FromFileContents.swift
   IndexProgressManager.swift

--- a/Sources/SourceKitLSP/DetermineBuildSystem.swift
+++ b/Sources/SourceKitLSP/DetermineBuildSystem.swift
@@ -57,33 +57,3 @@ func determineBuildSystem(
 
   return nil
 }
-
-/// Create a build system of the given type.
-func createBuildSystem(
-  ofType buildSystemType: WorkspaceType,
-  projectRoot: AbsolutePath,
-  options: SourceKitLSPOptions,
-  testHooks: TestHooks,
-  toolchainRegistry: ToolchainRegistry,
-  reloadPackageStatusCallback: @Sendable @escaping (ReloadPackageStatus) async -> Void
-) async -> BuiltInBuildSystem? {
-  switch buildSystemType {
-  case .buildServer:
-    return await BuildServerBuildSystem(projectRoot: projectRoot)
-  case .compilationDatabase:
-    return CompilationDatabaseBuildSystem(
-      projectRoot: projectRoot,
-      searchPaths: (options.compilationDatabaseOrDefault.searchPaths ?? []).compactMap {
-        try? RelativePath(validating: $0)
-      }
-    )
-  case .swiftPM:
-    return await SwiftPMBuildSystem(
-      projectRoot: projectRoot,
-      toolchainRegistry: toolchainRegistry,
-      options: options,
-      reloadPackageStatusCallback: reloadPackageStatusCallback,
-      testHooks: testHooks.swiftpmTestHooks
-    )
-  }
-}

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -273,21 +273,29 @@ package actor SourceKitLSPServer {
     }
     let rootURLs = workspacesAndIsImplicit.filter { !$0.isImplicit }.compactMap { $0.workspace.rootUri?.fileURL }
     while url.pathComponents.count > 1 && rootURLs.contains(where: { $0.isPrefix(of: url) }) {
+      defer {
+        url.deleteLastPathComponent()
+      }
       // Ignore workspaces that have the same project root as an existing workspace.
       // This might happen if there is an existing SwiftPM workspace that hasn't been reloaded after a new file
       // was added to it and thus currently doesn't know that it can handle that file. In that case, we shouldn't open
       // a new workspace for the same root. Instead, the existing workspace's build system needs to be reloaded.
-      let workspace = await self.createWorkspace(WorkspaceFolder(uri: DocumentURI(url))) { buildSystem in
-        guard let buildSystem else {
-          // If we didn't create a build system, `url` is not capable of handling the document.
-          return false
-        }
-        return !projectRoots.contains(await buildSystem.projectRoot)
+      let uri = DocumentURI(url)
+      guard let buildSystemKind = determineBuildSystem(forWorkspaceFolder: uri, options: self.options) else {
+        continue
       }
-      if let workspace {
-        return workspace
+      guard !projectRoots.contains(buildSystemKind.projectRoot) else {
+        continue
       }
-      url.deleteLastPathComponent()
+      guard
+        let workspace = await orLog(
+          "Creating workspace",
+          { try await createWorkspace(workspaceFolder: uri, buildSystemKind: buildSystemKind) }
+        )
+      else {
+        continue
+      }
+      return workspace
     }
     return nil
   }
@@ -933,35 +941,41 @@ extension SourceKitLSPServer {
   ///
   /// If the build system that was determined for the workspace does not satisfy `condition`, `nil` is returned.
   private func createWorkspace(
-    _ workspaceFolder: WorkspaceFolder,
-    condition: (BuiltInBuildSystem?) async -> Bool = { _ in true }
-  ) async -> Workspace? {
+    workspaceFolder: DocumentURI,
+    buildSystemKind: (type: WorkspaceType, projectRoot: AbsolutePath)?
+  ) async throws -> Workspace {
     guard let capabilityRegistry = capabilityRegistry else {
+      struct NoCapabilityRegistryError: Error {}
       logger.log("Cannot open workspace before server is initialized")
-      return nil
+      throw NoCapabilityRegistryError()
     }
     let testHooks = self.testHooks
     let options = SourceKitLSPOptions.merging(
       base: self.options,
       override: SourceKitLSPOptions(
-        path: workspaceFolder.uri.fileURL?
+        path: workspaceFolder.fileURL?
           .appendingPathComponent(".sourcekit-lsp")
           .appendingPathComponent("config.json")
       )
     )
-    logger.log("Creating workspace at \(workspaceFolder.uri.forLogging) with options: \(options.forLogging)")
-    let buildSystem = await createBuildSystem(
-      rootUri: workspaceFolder.uri,
-      options: options,
-      testHooks: testHooks,
-      toolchainRegistry: toolchainRegistry,
-      reloadPackageStatusCallback: { [weak self] status in
-        await self?.reloadPackageStatusCallback(status)
-      }
-    )
-    guard await condition(buildSystem) else {
-      return nil
+    logger.log("Creating workspace at \(workspaceFolder.forLogging) with options: \(options.forLogging)")
+
+    let buildSystem: BuiltInBuildSystem?
+    if let (buildSystemType, projectRoot) = buildSystemKind {
+      buildSystem = await createBuildSystem(
+        ofType: buildSystemType,
+        projectRoot: projectRoot,
+        options: options,
+        testHooks: testHooks,
+        toolchainRegistry: toolchainRegistry,
+        reloadPackageStatusCallback: { [weak self] status in
+          await self?.reloadPackageStatusCallback(status)
+        }
+      )
+    } else {
+      buildSystem = nil
     }
+
     await orLog("Initial build graph generation") {
       // Schedule an initial generation of the build graph. Once the build graph is loaded, the build system will send
       // call `fileHandlingCapabilityChanged`, which allows us to move documents to a workspace with this build
@@ -977,12 +991,12 @@ extension SourceKitLSPServer {
         "<fallback build system>"
       }
     logger.log(
-      "Created workspace at \(workspaceFolder.uri.forLogging) as \(buildSystemType, privacy: .public) with project root \(projectRoot ?? "<nil>")"
+      "Created workspace at \(workspaceFolder.forLogging) as \(buildSystemType, privacy: .public) with project root \(projectRoot ?? "<nil>")"
     )
 
-    let workspace = try? await Workspace(
+    let workspace = try await Workspace(
       documentManager: self.documentManager,
-      rootUri: workspaceFolder.uri,
+      rootUri: workspaceFolder,
       capabilityRegistry: capabilityRegistry,
       buildSystem: buildSystem,
       toolchainRegistry: self.toolchainRegistry,
@@ -999,7 +1013,7 @@ extension SourceKitLSPServer {
         self?.indexProgressManager.indexProgressStatusDidChange()
       }
     )
-    if let workspace, options.backgroundIndexingOrDefault, workspace.semanticIndexManager == nil,
+    if options.backgroundIndexingOrDefault, workspace.semanticIndexManager == nil,
       !self.didSendBackgroundIndexingNotSupportedNotification
     {
       self.sendNotificationToClient(
@@ -1072,20 +1086,34 @@ extension SourceKitLSPServer {
 
     await workspaceQueue.async { [testHooks] in
       if let workspaceFolders = req.workspaceFolders {
-        self.workspacesAndIsImplicit += await workspaceFolders.asyncCompactMap {
-          guard let workspace = await self.createWorkspace($0) else {
-            return nil
+        self.workspacesAndIsImplicit += await workspaceFolders.asyncCompactMap { workspaceFolder in
+          await orLog("Creating workspace from workspaceFolders") {
+            let workspace = try await self.createWorkspace(
+              workspaceFolder: workspaceFolder.uri,
+              buildSystemKind: determineBuildSystem(forWorkspaceFolder: workspaceFolder.uri, options: self.options)
+            )
+            return (workspace: workspace, isImplicit: false)
           }
-          return (workspace: workspace, isImplicit: false)
         }
       } else if let uri = req.rootURI {
-        let workspaceFolder = WorkspaceFolder(uri: uri)
-        if let workspace = await self.createWorkspace(workspaceFolder) {
+        let workspace = await orLog("Creating workspace from rootURI") {
+          try await self.createWorkspace(
+            workspaceFolder: uri,
+            buildSystemKind: determineBuildSystem(forWorkspaceFolder: uri, options: self.options)
+          )
+        }
+        if let workspace {
           self.workspacesAndIsImplicit.append((workspace: workspace, isImplicit: false))
         }
       } else if let path = req.rootPath {
-        let workspaceFolder = WorkspaceFolder(uri: DocumentURI(URL(fileURLWithPath: path)))
-        if let workspace = await self.createWorkspace(workspaceFolder) {
+        let uri = DocumentURI(URL(fileURLWithPath: path))
+        let workspace = await orLog("Creating workspace from rootPath") {
+          try await self.createWorkspace(
+            workspaceFolder: uri,
+            buildSystemKind: determineBuildSystem(forWorkspaceFolder: uri, options: self.options)
+          )
+        }
+        if let workspace {
           self.workspacesAndIsImplicit.append((workspace: workspace, isImplicit: false))
         }
       }
@@ -1535,7 +1563,14 @@ extension SourceKitLSPServer {
         }
       }
       if let added = notification.event.added {
-        let newWorkspaces = await added.asyncCompactMap { await self.createWorkspace($0) }
+        let newWorkspaces = await added.asyncCompactMap { workspaceFolder in
+          await orLog("Creating workspace after workspace folder change") {
+            try await self.createWorkspace(
+              workspaceFolder: workspaceFolder.uri,
+              buildSystemKind: determineBuildSystem(forWorkspaceFolder: workspaceFolder.uri, options: self.options)
+            )
+          }
+        }
         for workspace in newWorkspaces {
           await workspace.buildSystemManager.setDelegate(self)
         }

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -85,14 +85,13 @@ package final class Workspace: Sendable {
   /// `nil` if background indexing is not enabled.
   let semanticIndexManager: SemanticIndexManager?
 
-  init(
+  private init(
     documentManager: DocumentManager,
     rootUri: DocumentURI?,
     capabilityRegistry: CapabilityRegistry,
-    toolchainRegistry: ToolchainRegistry,
     options: SourceKitLSPOptions,
     testHooks: TestHooks,
-    underlyingBuildSystem: BuiltInBuildSystem?,
+    buildSystemManager: BuildSystemManager,
     index uncheckedIndex: UncheckedIndex?,
     indexDelegate: SourceKitIndexDelegate?,
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>,
@@ -105,12 +104,7 @@ package final class Workspace: Sendable {
     self.capabilityRegistry = capabilityRegistry
     self.options = options
     self._uncheckedIndex = ThreadSafeBox(initialValue: uncheckedIndex)
-    self.buildSystemManager = await BuildSystemManager(
-      buildSystem: underlyingBuildSystem,
-      fallbackBuildSystem: FallbackBuildSystem(options: options.fallbackBuildSystemOrDefault),
-      mainFilesProvider: uncheckedIndex,
-      toolchainRegistry: toolchainRegistry
-    )
+    self.buildSystemManager = buildSystemManager
     if options.backgroundIndexingOrDefault, let uncheckedIndex, await buildSystemManager.supportsPreparation {
       self.semanticIndexManager = SemanticIndexManager(
         index: uncheckedIndex,
@@ -128,7 +122,7 @@ package final class Workspace: Sendable {
     await indexDelegate?.addMainFileChangedCallback { [weak self] in
       await self?.buildSystemManager.mainFilesChanged()
     }
-    await underlyingBuildSystem?.addSourceFilesDidChangeCallback { [weak self] in
+    await buildSystemManager.buildSystem?.underlyingBuildSystem.addSourceFilesDidChangeCallback { [weak self] in
       guard let self else {
         return
       }
@@ -149,17 +143,50 @@ package final class Workspace: Sendable {
   ///   - toolchainRegistry: The toolchain registry.
   convenience init(
     documentManager: DocumentManager,
-    rootUri: DocumentURI,
+    rootUri: DocumentURI?,
     capabilityRegistry: CapabilityRegistry,
-    buildSystem: BuiltInBuildSystem?,
+    buildSystemKind: (WorkspaceType, projectRoot: AbsolutePath)?,
     toolchainRegistry: ToolchainRegistry,
     options: SourceKitLSPOptions,
     testHooks: TestHooks,
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>,
     logMessageToIndexLog: @escaping @Sendable (_ taskID: IndexTaskID, _ message: String) -> Void,
     indexTasksWereScheduled: @Sendable @escaping (Int) -> Void,
-    indexProgressStatusDidChange: @Sendable @escaping () -> Void
-  ) async throws {
+    indexProgressStatusDidChange: @Sendable @escaping () -> Void,
+    reloadPackageStatusCallback: @Sendable @escaping (ReloadPackageStatus) async -> Void
+  ) async {
+    let buildSystem: BuiltInBuildSystem?
+    if let (buildSystemType, projectRoot) = buildSystemKind {
+      buildSystem = await createBuildSystem(
+        ofType: buildSystemType,
+        projectRoot: projectRoot,
+        options: options,
+        testHooks: testHooks,
+        toolchainRegistry: toolchainRegistry,
+        reloadPackageStatusCallback: reloadPackageStatusCallback
+      )
+    } else {
+      buildSystem = nil
+    }
+
+    await orLog("Initial build graph generation") {
+      // Schedule an initial generation of the build graph. Once the build graph is loaded, the build system will send
+      // call `fileHandlingCapabilityChanged`, which allows us to move documents to a workspace with this build
+      // system.
+      try await buildSystem?.scheduleBuildGraphGeneration()
+    }
+
+    let projectRoot = await buildSystem?.projectRoot.pathString
+    let buildSystemType =
+      if let buildSystem {
+        String(describing: type(of: buildSystem))
+      } else {
+        "<fallback build system>"
+      }
+    logger.log(
+      "Created workspace at \(rootUri.forLogging) as \(buildSystemType, privacy: .public) with project root \(projectRoot ?? "<nil>")"
+    )
+
     var index: IndexStoreDB? = nil
     var indexDelegate: SourceKitIndexDelegate? = nil
 
@@ -192,14 +219,20 @@ package final class Workspace: Sendable {
       }
     }
 
+    let buildSystemManager = await BuildSystemManager(
+      buildSystem: buildSystem,
+      fallbackBuildSystem: FallbackBuildSystem(options: options.fallbackBuildSystemOrDefault),
+      mainFilesProvider: UncheckedIndex(index),
+      toolchainRegistry: toolchainRegistry
+    )
+
     await self.init(
       documentManager: documentManager,
       rootUri: rootUri,
       capabilityRegistry: capabilityRegistry,
-      toolchainRegistry: toolchainRegistry,
       options: options,
       testHooks: testHooks,
-      underlyingBuildSystem: buildSystem,
+      buildSystemManager: buildSystemManager,
       index: UncheckedIndex(index),
       indexDelegate: indexDelegate,
       indexTaskScheduler: indexTaskScheduler,
@@ -210,20 +243,18 @@ package final class Workspace: Sendable {
   }
 
   package static func forTesting(
-    toolchainRegistry: ToolchainRegistry,
     options: SourceKitLSPOptions,
     testHooks: TestHooks,
-    underlyingBuildSystem: BuiltInBuildSystem,
+    buildSystemManager: BuildSystemManager,
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>
   ) async -> Workspace {
     return await Workspace(
       documentManager: DocumentManager(),
       rootUri: nil,
       capabilityRegistry: CapabilityRegistry(clientCapabilities: ClientCapabilities()),
-      toolchainRegistry: toolchainRegistry,
       options: options,
       testHooks: testHooks,
-      underlyingBuildSystem: underlyingBuildSystem,
+      buildSystemManager: buildSystemManager,
       index: nil,
       indexDelegate: nil,
       indexTaskScheduler: indexTaskScheduler,

--- a/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
@@ -53,7 +53,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
   let buildFolder = try! AbsolutePath(validating: NSTemporaryDirectory())
 
   func testServerInitialize() async throws {
-    let buildSystem = try await BuildServerBuildSystem(projectRoot: root)
+    let buildSystem = try await BuildServerBuildSystem(projectRoot: root, messageHandler: nil)
 
     assertEqual(
       await buildSystem.indexDatabasePath,
@@ -66,7 +66,6 @@ final class BuildServerBuildSystemTests: XCTestCase {
   }
 
   func testFileRegistration() async throws {
-    let buildSystem = try await BuildServerBuildSystem(projectRoot: root)
 
     let fileUrl = URL(fileURLWithPath: "/some/file/path")
     let expectation = XCTestExpectation(description: "\(fileUrl) settings updated")
@@ -75,6 +74,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
       // BuildSystemManager has a weak reference to delegate. Keep it alive.
       _fixLifetime(buildSystemDelegate)
     }
+    let buildSystem = try await BuildServerBuildSystem(projectRoot: root, messageHandler: buildSystemDelegate)
     await buildSystem.setDelegate(buildSystemDelegate)
     await buildSystem.registerForChangeNotifications(for: DocumentURI(fileUrl))
 
@@ -82,7 +82,6 @@ final class BuildServerBuildSystemTests: XCTestCase {
   }
 
   func testBuildTargetsChanged() async throws {
-    let buildSystem = try await BuildServerBuildSystem(projectRoot: root)
 
     let fileUrl = URL(fileURLWithPath: "/some/file/path")
     let expectation = XCTestExpectation(description: "target changed")
@@ -102,7 +101,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
       // BuildSystemManager has a weak reference to delegate. Keep it alive.
       _fixLifetime(buildSystemDelegate)
     }
-    await buildSystem.setMessageHandler(buildSystemDelegate)
+    let buildSystem = try await BuildServerBuildSystem(projectRoot: root, messageHandler: buildSystemDelegate)
     await buildSystem.registerForChangeNotifications(for: DocumentURI(fileUrl))
 
     try await fulfillmentOfOrThrow([expectation])

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -464,12 +464,6 @@ class ManualBuildSystem: BuiltInBuildSystem {
     self.delegate = delegate
   }
 
-  weak var messageHandler: BuiltInBuildSystemMessageHandler?
-
-  func setMessageHandler(_ messageHandler: any BuiltInBuildSystemMessageHandler) {
-    self.messageHandler = messageHandler
-  }
-
   package nonisolated var supportsPreparation: Bool { false }
 
   func buildSettings(

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -447,6 +447,13 @@ private final actor ManualMainFilesProvider: MainFilesProvider {
 /// A simple `BuildSystem` that wraps a dictionary, for testing.
 @MainActor
 class ManualBuildSystem: BuiltInBuildSystem {
+  static nonisolated func projectRoot(
+    for workspaceFolder: AbsolutePath,
+    options: SourceKitLSPOptions
+  ) -> AbsolutePath? {
+    return workspaceFolder
+  }
+
   var projectRoot = try! AbsolutePath(validating: "/")
 
   var map: [DocumentURI: FileBuildSettings] = [:]

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -37,7 +37,7 @@ final class BuildSystemManagerTests: XCTestCase {
     )
 
     let bsm = await BuildSystemManager(
-      buildSystem: nil,
+      testBuildSystem: nil,
       fallbackBuildSystem: FallbackBuildSystem(options: SourceKitLSPOptions.FallbackBuildSystemOptions()),
       mainFilesProvider: mainFiles,
       toolchainRegistry: ToolchainRegistry.forTesting
@@ -96,7 +96,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let mainFiles = ManualMainFilesProvider([a: [a]])
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
-      buildSystem: bs,
+      testBuildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles,
       toolchainRegistry: ToolchainRegistry.forTesting
@@ -121,7 +121,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let mainFiles = ManualMainFilesProvider([a: [a]])
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
-      buildSystem: bs,
+      testBuildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles,
       toolchainRegistry: ToolchainRegistry.forTesting
@@ -145,7 +145,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let bs = ManualBuildSystem()
     let fallback = FallbackBuildSystem(options: SourceKitLSPOptions.FallbackBuildSystemOptions())
     let bsm = await BuildSystemManager(
-      buildSystem: bs,
+      testBuildSystem: bs,
       fallbackBuildSystem: fallback,
       mainFilesProvider: mainFiles,
       toolchainRegistry: ToolchainRegistry.forTesting
@@ -176,7 +176,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let mainFiles = ManualMainFilesProvider([a: [a], b: [b]])
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
-      buildSystem: bs,
+      testBuildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles,
       toolchainRegistry: ToolchainRegistry.forTesting
@@ -218,7 +218,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let mainFiles = ManualMainFilesProvider([a: [a], b: [b]])
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
-      buildSystem: bs,
+      testBuildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles,
       toolchainRegistry: ToolchainRegistry.forTesting
@@ -258,7 +258,7 @@ final class BuildSystemManagerTests: XCTestCase {
 
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
-      buildSystem: bs,
+      testBuildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles,
       toolchainRegistry: ToolchainRegistry.forTesting
@@ -314,7 +314,7 @@ final class BuildSystemManagerTests: XCTestCase {
 
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
-      buildSystem: bs,
+      testBuildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles,
       toolchainRegistry: ToolchainRegistry.forTesting
@@ -357,7 +357,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let mainFiles = ManualMainFilesProvider([a: [a], b: [b], c: [c]])
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
-      buildSystem: bs,
+      testBuildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles,
       toolchainRegistry: ToolchainRegistry.forTesting
@@ -401,7 +401,7 @@ final class BuildSystemManagerTests: XCTestCase {
 
     let bs = ManualBuildSystem()
     let bsm = await BuildSystemManager(
-      buildSystem: bs,
+      testBuildSystem: bs,
       fallbackBuildSystem: nil,
       mainFilesProvider: mainFiles,
       toolchainRegistry: ToolchainRegistry.forTesting

--- a/Tests/BuildSystemIntegrationTests/CompilationDatabaseTests.swift
+++ b/Tests/BuildSystemIntegrationTests/CompilationDatabaseTests.swift
@@ -421,6 +421,7 @@ private func checkCompilationDatabaseBuildSystem(
   let buildSystem = CompilationDatabaseBuildSystem(
     projectRoot: try AbsolutePath(validating: "/a"),
     searchPaths: try [RelativePath(validating: ".")],
+    messageHandler: nil,
     fileSystem: fs
   )
   try await block(XCTUnwrap(buildSystem))

--- a/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
@@ -47,16 +47,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appending(component: "pkg")
-      let tr = ToolchainRegistry.forTesting
-      await assertThrowsError(
-        try await SwiftPMBuildSystem(
-          workspacePath: packageRoot,
-          toolchainRegistry: tr,
-          fileSystem: fs,
-          options: SourceKitLSPOptions(),
-          testHooks: SwiftPMTestHooks()
-        )
-      )
+      XCTAssertNil(SwiftPMBuildSystem.projectRoot(for: packageRoot, options: .testDefault()))
     }
   }
 
@@ -77,7 +68,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.forTesting
       let buildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
@@ -107,7 +98,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let packageRoot = tempDir.appending(component: "pkg")
       await assertThrowsError(
         try await SwiftPMBuildSystem(
-          workspacePath: packageRoot,
+          projectRoot: packageRoot,
           toolchainRegistry: ToolchainRegistry(toolchains: []),
           fileSystem: fs,
           options: SourceKitLSPOptions(),
@@ -138,7 +129,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.forTesting
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
@@ -203,7 +194,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.forTesting
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: tr,
         fileSystem: localFileSystem,
         options: SourceKitLSPOptions(),
@@ -266,7 +257,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       )
 
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(swiftPM: options),
@@ -313,7 +304,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       )
 
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: tempDir.appending(component: "pkg"),
+        projectRoot: tempDir.appending(component: "pkg"),
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(swiftPM: options),
@@ -348,7 +339,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.forTesting
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
@@ -385,7 +376,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.forTesting
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
@@ -434,7 +425,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.forTesting
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
@@ -489,7 +480,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.forTesting
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
@@ -533,7 +524,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.forTesting
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
@@ -614,7 +605,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       )
       let packageRoot = tempDir.appending(component: "pkg")
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
@@ -666,7 +657,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
 
       let tr = ToolchainRegistry.forTesting
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: XCTUnwrap(SwiftPMBuildSystem.projectRoot(for: packageRoot, options: .testDefault())),
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
@@ -734,7 +725,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       )
 
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: symlinkRoot,
+        projectRoot: XCTUnwrap(SwiftPMBuildSystem.projectRoot(for: symlinkRoot, options: .testDefault())),
         toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
@@ -774,7 +765,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let packageRoot = try resolveSymlinks(tempDir.appending(component: "pkg"))
       let tr = ToolchainRegistry.forTesting
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
@@ -796,9 +787,8 @@ final class SwiftPMBuildSystemTests: XCTestCase {
   }
 
   func testNestedInvalidPackageSwift() async throws {
-    let fs = InMemoryFileSystem()
     try await withTestScratchDir { tempDir in
-      try fs.createFiles(
+      try localFileSystem.createFiles(
         root: tempDir,
         files: [
           "pkg/Sources/lib/Package.swift": "// not a valid package",
@@ -812,17 +802,10 @@ final class SwiftPMBuildSystemTests: XCTestCase {
           """,
         ]
       )
-      let packageRoot = try resolveSymlinks(tempDir.appending(components: "pkg", "Sources", "lib"))
-      let tr = ToolchainRegistry.forTesting
-      let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
-        toolchainRegistry: tr,
-        fileSystem: fs,
-        options: SourceKitLSPOptions(),
-        testHooks: SwiftPMTestHooks()
-      )
+      let workspaceRoot = try resolveSymlinks(tempDir.appending(components: "pkg", "Sources", "lib"))
+      let projectRoot = SwiftPMBuildSystem.projectRoot(for: workspaceRoot, options: .testDefault())
 
-      assertEqual(await swiftpmBuildSystem.projectRoot, try resolveSymlinks(tempDir.appending(component: "pkg")))
+      assertEqual(projectRoot, try resolveSymlinks(tempDir.appending(component: "pkg")))
     }
   }
 
@@ -850,7 +833,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let packageRoot = tempDir.appending(component: "pkg")
       let tr = ToolchainRegistry.forTesting
       let swiftpmBuildSystem = try await SwiftPMBuildSystem(
-        workspacePath: packageRoot,
+        projectRoot: packageRoot,
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),

--- a/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
@@ -72,6 +72,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       await assertThrowsError(try await buildSystem.schedulePackageReload().value)
@@ -102,6 +103,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
           toolchainRegistry: ToolchainRegistry(toolchains: []),
           fileSystem: fs,
           options: SourceKitLSPOptions(),
+          messageHandler: nil,
           testHooks: SwiftPMTestHooks()
         )
       )
@@ -133,6 +135,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -198,6 +201,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: localFileSystem,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -261,6 +265,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(swiftPM: options),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -308,6 +313,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(swiftPM: options),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       let path = await swiftpmBuildSystem.destinationBuildParameters.toolchain.sdkRootPath
@@ -343,6 +349,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -380,6 +387,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -429,6 +437,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -484,6 +493,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -528,6 +538,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -609,6 +620,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -661,6 +673,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -729,6 +742,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: ToolchainRegistry.forTesting,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -769,6 +783,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value
@@ -837,6 +852,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         toolchainRegistry: tr,
         fileSystem: fs,
         options: SourceKitLSPOptions(),
+        messageHandler: nil,
         testHooks: SwiftPMTestHooks()
       )
       try await swiftpmBuildSystem.schedulePackageReload().value

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -148,11 +148,17 @@ final class BuildSystemTests: XCTestCase {
 
     let server = testClient.server
 
+    let buildSystemManager = await BuildSystemManager(
+      buildSystem: buildSystem,
+      fallbackBuildSystem: FallbackBuildSystem(options: .init()),
+      mainFilesProvider: nil,
+      toolchainRegistry: ToolchainRegistry.forTesting
+    )
+
     self.workspace = await Workspace.forTesting(
-      toolchainRegistry: ToolchainRegistry.forTesting,
       options: SourceKitLSPOptions.testDefault(),
       testHooks: TestHooks(),
-      underlyingBuildSystem: buildSystem,
+      buildSystemManager: buildSystemManager,
       indexTaskScheduler: .forTesting
     )
 

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -149,7 +149,7 @@ final class BuildSystemTests: XCTestCase {
     let server = testClient.server
 
     let buildSystemManager = await BuildSystemManager(
-      buildSystem: buildSystem,
+      testBuildSystem: buildSystem,
       fallbackBuildSystem: FallbackBuildSystem(options: .init()),
       mainFilesProvider: nil,
       toolchainRegistry: ToolchainRegistry.forTesting

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -38,12 +38,6 @@ actor TestBuildSystem: BuiltInBuildSystem {
     self.delegate = delegate
   }
 
-  weak var messageHandler: BuiltInBuildSystemMessageHandler?
-
-  func setMessageHandler(_ messageHandler: any BuiltInBuildSystemMessageHandler) {
-    self.messageHandler = messageHandler
-  }
-
   /// Build settings by file.
   private var buildSettingsByFile: [DocumentURI: FileBuildSettings] = [:]
 

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -24,6 +24,10 @@ import XCTest
 /// Build system to be used for testing BuildSystem and BuildSystemDelegate functionality with SourceKitLSPServer
 /// and other components.
 actor TestBuildSystem: BuiltInBuildSystem {
+  static func projectRoot(for workspaceFolder: AbsolutePath, options: SourceKitLSPOptions) -> AbsolutePath? {
+    return workspaceFolder
+  }
+
   let projectRoot: AbsolutePath = try! AbsolutePath(validating: "/")
   let indexStorePath: AbsolutePath? = nil
   let indexDatabasePath: AbsolutePath? = nil


### PR DESCRIPTION
We currently create the `BuiltInBuildSystem` while constructing a `Workspace` and then pass it into the `BuildSystemManager`, which will do some final wiring up, setting itself as the message handler and delegate of the build system. 

This PR moves the creation of the `BuiltInBuildSystem` into the `BuiltInBuildSystemAdapter`. That way, the creation of a `BuiltInBuildSystem` is more like the initialization of a BSP server. 

To do so, we need to split the creation of a build system (now happening in `BuiltInBuildSystemAdapter`) and determining what kind of build system to use for a workspace (still happening during workspace creation). I have found that this split was generally beneficial and made the code easier to reason about.