### PR TITLE
Make `Workspace` the delegate of a `BuildSystemManager`

### DIFF
--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -87,7 +87,7 @@ package actor BuildSystemManager: BuiltInBuildSystemAdapterDelegate {
   var mainFilesProvider: MainFilesProvider?
 
   /// Build system delegate that will receive notifications about setting changes, etc.
-  var delegate: BuildSystemManagerDelegate?
+  private weak var delegate: BuildSystemManagerDelegate?
 
   /// The list of toolchains that are available.
   ///
@@ -157,6 +157,11 @@ package actor BuildSystemManager: BuiltInBuildSystemAdapterDelegate {
 
   package func filesDidChange(_ events: [FileEvent]) async {
     await self.buildSystem?.send(BuildServerProtocol.DidChangeWatchedFilesNotification(changes: events))
+    if let mainFilesProvider {
+      var mainFiles = await Set(events.asyncFlatMap { await mainFilesProvider.mainFilesContainingFile($0.uri) })
+      mainFiles.subtract(events.map(\.uri))
+      await self.filesDependenciesUpdated(mainFiles)
+    }
   }
 
   /// Implementation of `MessageHandler`, handling notifications from the build system.

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -417,6 +417,9 @@ extension SwiftLanguageService {
   }
 
   package func documentUpdatedBuildSettings(_ uri: DocumentURI) async {
+    guard (try? documentManager.openDocuments.contains(uri)) ?? false else {
+      return
+    }
     // Close and re-open the document internally to inform sourcekitd to update the compile command. At the moment
     // there's no better way to do this.
     // Schedule the document re-open in the SourceKit-LSP server. This ensures that the re-open happens exclusively with
@@ -425,6 +428,9 @@ extension SwiftLanguageService {
   }
 
   package func documentDependenciesUpdated(_ uri: DocumentURI) async {
+    guard (try? documentManager.openDocuments.contains(uri)) ?? false else {
+      return
+    }
     await orLog("Sending dependencyUpdated request to sourcekitd") {
       let req = sourcekitd.dictionary([
         keys.request: requests.dependencyUpdated

--- a/Sources/SwiftExtensions/Sequence+AsyncMap.swift
+++ b/Sources/SwiftExtensions/Sequence+AsyncMap.swift
@@ -25,6 +25,20 @@ extension Sequence {
     return result
   }
 
+  /// Just like `Sequence.flatMap` but allows an `async` transform function.
+  package func asyncFlatMap<SegmentOfResult: Sequence>(
+    @_inheritActorContext _ transform: @Sendable (Element) async throws -> SegmentOfResult
+  ) async rethrows -> [SegmentOfResult.Element] {
+    var result: [SegmentOfResult.Element] = []
+    result.reserveCapacity(self.underestimatedCount)
+
+    for element in self {
+      result += try await transform(element)
+    }
+
+    return result
+  }
+
   /// Just like `Sequence.compactMap` but allows an `async` transform function.
   package func asyncCompactMap<T>(
     @_inheritActorContext _ transform: @Sendable (Element) async throws -> T?

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -157,7 +157,7 @@ final class BuildSystemTests: XCTestCase {
     )
 
     await server.setWorkspaces([(workspace: workspace, isImplicit: false)])
-    await workspace.buildSystemManager.setDelegate(server)
+    await workspace.buildSystemManager.setDelegate(workspace)
   }
 
   override func tearDown() {

--- a/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
+++ b/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
@@ -40,7 +40,7 @@ final class DependencyTrackingTests: XCTestCase {
       usePullDiagnostics: false
     )
 
-    let (libBUri, _) = try project.openDocument("LibB.swift")
+    _ = try project.openDocument("LibB.swift")
 
     let initialDiags = try await project.testClient.nextDiagnosticsNotification()
     // Semantic analysis: expect module import error.
@@ -58,7 +58,14 @@ final class DependencyTrackingTests: XCTestCase {
 
     try await SwiftPMTestProject.build(at: project.scratchDirectory)
 
-    await project.testClient.server.filesDependenciesUpdated([libBUri])
+    project.testClient.send(
+      DidChangeWatchedFilesNotification(
+        changes:
+          FileManager.default.findFiles(withExtension: "swiftmodule", in: project.scratchDirectory).map {
+            FileEvent(uri: DocumentURI($0), type: .created)
+          }
+      )
+    )
 
     let updatedDiags = try await project.testClient.nextDiagnosticsNotification()
     // Semantic analysis: no more errors expected, import should resolve since we built.
@@ -102,7 +109,8 @@ final class DependencyTrackingTests: XCTestCase {
     let contents = "int libX(int value);"
     try contents.write(to: generatedHeaderURL, atomically: true, encoding: .utf8)
 
-    await project.testClient.server.filesDependenciesUpdated([mainUri])
+    let workspace = try await unwrap(project.testClient.server.workspaceForDocument(uri: mainUri))
+    await workspace.filesDependenciesUpdated([mainUri])
 
     let updatedDiags = try await project.testClient.nextDiagnosticsNotification()
     // No more errors expected, import should resolve since we the generated header file


### PR DESCRIPTION
`Workspace` is responsible for creating the `BuildSystemManager` and responds to most of the delegate calls. It should thus also be the delegate of `BuildSystemManager`.