### PR TITLE
Revert "Add an extra percent encoding layer when encoding DocumentURIs to LSP requests"

### DIFF
--- a/Sources/SKTestSupport/CheckCoding.swift
+++ b/Sources/SKTestSupport/CheckCoding.swift
@@ -43,12 +43,9 @@ package func checkCoding<T: Codable & Equatable>(
   XCTAssertEqual(json, str, file: file, line: line)
 
   let decoder = JSONDecoder()
-  XCTAssertNoThrow(
-    try {
-      let decodedValue = try decoder.decode(WrapFragment<T>.self, from: data).value
-      XCTAssertEqual(value, decodedValue, file: file, line: line)
-    }()
-  )
+  let decodedValue = try! decoder.decode(WrapFragment<T>.self, from: data).value
+
+  XCTAssertEqual(value, decodedValue, file: file, line: line)
 }
 
 /// JSONEncoder requires the top-level value to be encoded as a JSON container (array or object). Give it one.

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -1343,29 +1343,6 @@ final class CodingTests: XCTestCase {
         """
     )
   }
-
-  func testDocumentUriQueryParameterCoding() throws {
-    checkCoding(
-      try DocumentURI(string: "scheme://host?parent=scheme://host?line%3D2"),
-      json: #"""
-        "scheme:\/\/host?parent%3Dscheme:\/\/host%3Fline%253D2"
-        """#
-    )
-
-    checkCoding(
-      try DocumentURI(string: "scheme://host?parent=scheme://host?parent%3Dscheme://host%3Fkey%253Dvalue"),
-      json: #"""
-        "scheme:\/\/host?parent%3Dscheme:\/\/host%3Fparent%253Dscheme:\/\/host%253Fkey%25253Dvalue"
-        """#
-    )
-
-    checkCoding(
-      try DocumentURI(string: "scheme://host?parent=with%23hash"),
-      json: #"""
-        "scheme:\/\/host?parent%3Dwith%2523hash"
-        """#
-    )
-  }
 }
 
 func with<T>(_ value: T, mutate: (inout T) -> Void) -> T {


### PR DESCRIPTION
This reverts commit b2c17c748d32a3f7ed766e2a69f3ff0d132ab294.

The workaround isn’t needed anymore because we have a proper fix in the VS Code extension: https://github.com/swiftlang/vscode-swift/pull/1026