### PR TITLE
Migrate `fileHandlingCapability` and `prepare` to BSP and remove `registerForChangeNotifications`

### DIFF
--- a/Sources/BuildServerProtocol/CMakeLists.txt
+++ b/Sources/BuildServerProtocol/CMakeLists.txt
@@ -4,7 +4,9 @@ add_library(BuildServerProtocol STATIC
   DidChangeWatchedFilesNotification.swift
   InitializeBuild.swift
   InverseSourcesRequest.swift
+  LogMessageNotification.swift
   Messages.swift
+  PrepareTargetsRequest.swift
   RegisterForChangeNotifications.swift
   ShutdownBuild.swift
   SourceKitOptionsRequest.swift)

--- a/Sources/BuildServerProtocol/LogMessageNotification.swift
+++ b/Sources/BuildServerProtocol/LogMessageNotification.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+
+public enum LogMessageType: Int, Sendable, Codable {
+  /// An error message.
+  case error = 1
+
+  /// A warning message.
+  case warning = 2
+
+  /// An information message.
+  case info = 3
+
+  /// A log message.
+  case log = 4
+}
+
+public typealias TaskIdentifier = String
+
+public struct TaskId: Sendable, Codable {
+  /// A unique identifier
+  public var id: TaskIdentifier
+
+  ///  The parent task ids, if any. A non-empty parents field means
+  /// this task is a sub-task of every parent task id. The child-parent
+  /// relationship of tasks makes it possible to render tasks in
+  /// a tree-like user interface or inspect what caused a certain task
+  /// execution.
+  /// OriginId should not be included in the parents field, there is a separate
+  /// field for that.
+  public var parents: [TaskIdentifier]?
+
+  public init(id: TaskIdentifier, parents: [TaskIdentifier]? = nil) {
+    self.id = id
+    self.parents = parents
+  }
+}
+
+/// The log message notification is sent from a server to a client to ask the client to log a particular message in its console.
+///
+/// A `build/logMessage`` notification is similar to LSP's `window/logMessage``, except for a few additions like id and originId.
+public struct LogMessageNotification: NotificationType {
+  public static let method: String = "build/logMessage"
+
+  /// The message type.
+  public var type: LogMessageType
+
+  /// The task id if any.
+  public var task: TaskId?
+
+  /// The actual message.
+  public var message: String
+
+  public init(type: LogMessageType, task: TaskId? = nil, message: String) {
+    self.type = type
+    self.task = task
+    self.message = message
+  }
+}

--- a/Sources/BuildServerProtocol/PrepareTargetsRequest.swift
+++ b/Sources/BuildServerProtocol/PrepareTargetsRequest.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+
+public typealias OriginId = String
+
+public struct PrepareTargetsRequest: RequestType, Hashable {
+  public static let method: String = "buildTarget/prepare"
+  public typealias Response = VoidResponse
+
+  /// A list of build targets to prepare.
+  public var targets: [BuildTargetIdentifier]
+
+  public var originId: OriginId?
+
+  public init(targets: [BuildTargetIdentifier], originId: OriginId? = nil) {
+    self.targets = targets
+    self.originId = originId
+  }
+}

--- a/Sources/BuildServerProtocol/RegisterForChangeNotifications.swift
+++ b/Sources/BuildServerProtocol/RegisterForChangeNotifications.swift
@@ -9,6 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
 import LanguageServerProtocol
 
 /// The register for changes request is sent from the language

--- a/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
@@ -331,29 +331,6 @@ extension BuildServerBuildSystem: BuiltInBuildSystem {
 
   package func didChangeWatchedFiles(notification: BuildServerProtocol.DidChangeWatchedFilesNotification) {}
 
-  package func fileHandlingCapability(for uri: DocumentURI) -> FileHandlingCapability {
-    guard
-      let fileUrl = uri.fileURL,
-      let path = try? AbsolutePath(validating: fileUrl.path)
-    else {
-      return .unhandled
-    }
-
-    // TODO: We should not make any assumptions about which files the build server can handle.
-    // Instead we should query the build server which files it can handle
-    // (https://github.com/swiftlang/sourcekit-lsp/issues/492).
-
-    if projectRoot.isAncestorOfOrEqual(to: path) {
-      return .handled
-    }
-
-    if let realpath = try? resolveSymlinks(path), realpath != path, projectRoot.isAncestorOfOrEqual(to: realpath) {
-      return .handled
-    }
-
-    return .unhandled
-  }
-
   package func sourceFiles() async -> [SourceFileInfo] {
     // BuildServerBuildSystem does not support syntactic test discovery or background indexing.
     // (https://github.com/swiftlang/sourcekit-lsp/issues/1173).

--- a/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
@@ -80,6 +80,8 @@ package actor BuildServerBuildSystem: MessageHandler {
   /// The build settings that have been received from the build server.
   private var buildSettings: [DocumentURI: SourceKitOptionsResponse] = [:]
 
+  private var urisRegisteredForChanges: Set<URI> = []
+
   package init(
     projectRoot: AbsolutePath,
     messageHandler: BuiltInBuildSystemMessageHandler?,
@@ -269,7 +271,38 @@ extension BuildServerBuildSystem: BuiltInBuildSystem {
   package nonisolated var supportsPreparation: Bool { false }
 
   package func sourceKitOptions(request: SourceKitOptionsRequest) async throws -> SourceKitOptionsResponse? {
-    return buildSettings[request.textDocument.uri]
+    // FIXME: (BSP Migration) If the BSP server supports it, send the `SourceKitOptions` request to it. Only do the
+    // `RegisterForChanges` dance if we are in the legacy mode.
+
+    // Support the pre Swift 6.1 build settings workflow where SourceKit-LSP registers for changes for a file and then
+    // expects updates to those build settings to get pushed to SourceKit-LSP with `FileOptionsChangedNotification`.
+    // We do so by registering for changes when requesting build settings for a document for the first time. We never
+    // unregister for changes. The expectation is that all BSP servers migrate to the `SourceKitOptionsRequest` soon,
+    // which renders this code path dead.
+    let uri = request.textDocument.uri
+    if !urisRegisteredForChanges.contains(uri) {
+      let request = RegisterForChanges(uri: uri, action: .register)
+      _ = self.buildServer?.send(request) { result in
+        if let error = result.failure {
+          logger.error("Error registering \(request.uri): \(error.forLogging)")
+
+          Task {
+            // BuildServer registration failed, so tell our delegate that no build
+            // settings are available.
+            await self.buildSettingsChanged(for: request.uri, settings: nil)
+          }
+        }
+      }
+    }
+
+    guard let buildSettings = buildSettings[uri] else {
+      return nil
+    }
+
+    return SourceKitOptionsResponse(
+      compilerArguments: buildSettings.compilerArguments,
+      workingDirectory: buildSettings.workingDirectory
+    )
   }
 
   package func defaultLanguage(for document: DocumentURI) async -> Language? {
@@ -301,32 +334,6 @@ extension BuildServerBuildSystem: BuiltInBuildSystem {
     logMessageToIndexLog: @Sendable (_ taskID: IndexTaskID, _ message: String) -> Void
   ) async throws {
     throw PrepareNotSupportedError()
-  }
-
-  package func registerForChangeNotifications(for uri: DocumentURI) {
-    let request = RegisterForChanges(uri: uri, action: .register)
-    _ = self.buildServer?.send(request) { result in
-      if let error = result.failure {
-        logger.error("Error registering \(uri): \(error.forLogging)")
-
-        Task {
-          // BuildServer registration failed, so tell our delegate that no build
-          // settings are available.
-          await self.buildSettingsChanged(for: uri, settings: nil)
-        }
-      }
-    }
-  }
-
-  /// Unregister the given file for build-system level change notifications, such as command
-  /// line flag changes, dependency changes, etc.
-  package func unregisterForChangeNotifications(for uri: DocumentURI) {
-    let request = RegisterForChanges(uri: uri, action: .unregister)
-    _ = self.buildServer?.send(request) { result in
-      if let error = result.failure {
-        logger.error("Error unregistering \(uri.forLogging): \(error.forLogging)")
-      }
-    }
   }
 
   package func didChangeWatchedFiles(notification: BuildServerProtocol.DidChangeWatchedFilesNotification) {}

--- a/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuildServerBuildSystem.swift
@@ -329,10 +329,7 @@ extension BuildServerBuildSystem: BuiltInBuildSystem {
     return nil
   }
 
-  package func prepare(
-    targets: [BuildTargetIdentifier],
-    logMessageToIndexLog: @Sendable (_ taskID: IndexTaskID, _ message: String) -> Void
-  ) async throws {
+  package func prepare(request: PrepareTargetsRequest) async throws -> VoidResponse {
     throw PrepareNotSupportedError()
   }
 

--- a/Sources/BuildSystemIntegration/BuildSystemDelegate.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemDelegate.swift
@@ -22,11 +22,6 @@ package protocol BuildSystemDelegate: AnyObject, Sendable {
   /// The callee should refresh ASTs unless it is able to determine that a
   /// refresh is not necessary.
   func filesDependenciesUpdated(_ changedFiles: Set<DocumentURI>) async
-
-  /// Notify the delegate that the file handling capability of this build system
-  /// for some file has changed. The delegate should discard any cached file
-  /// handling capability.
-  func fileHandlingCapabilityChanged() async
 }
 
 /// Handles build system events, such as file build settings changes.
@@ -42,8 +37,7 @@ package protocol BuildSystemManagerDelegate: AnyObject, Sendable {
   /// refresh is not necessary.
   func filesDependenciesUpdated(_ changedFiles: Set<DocumentURI>) async
 
-  /// Notify the delegate that the file handling capability of this build system
-  /// for some file has changed. The delegate should discard any cached file
-  /// handling capability.
-  func fileHandlingCapabilityChanged() async
+  /// Notify the delegate that some information about the given build targets has changed and that it should recompute
+  /// any information based on top of it.
+  func buildTargetsChanged(_ changes: [BuildTargetEvent]?) async
 }

--- a/Sources/BuildSystemIntegration/BuildSystemDelegate.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemDelegate.swift
@@ -40,4 +40,7 @@ package protocol BuildSystemManagerDelegate: AnyObject, Sendable {
   /// Notify the delegate that some information about the given build targets has changed and that it should recompute
   /// any information based on top of it.
   func buildTargetsChanged(_ changes: [BuildTargetEvent]?) async
+
+  /// Log the given message to the client's index log.
+  func logMessageToIndexLog(taskID: IndexTaskID, message: String)
 }

--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -376,26 +376,10 @@ package actor BuildSystemManager: BuiltInBuildSystemAdapterDelegate {
     logger.debug("registerForChangeNotifications(\(uri.forLogging))")
     let mainFile = await mainFile(for: uri, language: language)
     self.watchedFiles[uri] = (mainFile, language)
-
-    // Register for change notifications of the main file in the underlying build
-    // system. That way, iff the main file changes, we will also notify the
-    // delegate about build setting changes of all header files that are based
-    // on that main file.
-    await buildSystem?.underlyingBuildSystem.registerForChangeNotifications(for: mainFile)
   }
 
   package func unregisterForChangeNotifications(for uri: DocumentURI) async {
-    guard let mainFile = self.watchedFiles[uri]?.mainFile else {
-      logger.fault("Unbalanced calls for registerForChangeNotifications and unregisterForChangeNotifications")
-      return
-    }
     self.watchedFiles[uri] = nil
-
-    if watchedFilesReferencing(mainFiles: [mainFile]).isEmpty {
-      // Nobody is interested in this main file anymore.
-      // We are no longer interested in change notifications for it.
-      await self.buildSystem?.underlyingBuildSystem.unregisterForChangeNotifications(for: mainFile)
-    }
   }
 
   package func sourceFiles() async -> [SourceFileInfo] {

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
@@ -145,18 +145,6 @@ package protocol BuiltInBuildSystem: AnyObject, Sendable {
   /// If `nil` is returned, then the default toolchain for the given language is used.
   func toolchain(for uri: DocumentURI, _ language: Language) async -> Toolchain?
 
-  /// Register the given file for build-system level change notifications, such
-  /// as command line flag changes, dependency changes, etc.
-  ///
-  /// IMPORTANT: When first receiving a register request, the `BuildSystem` MUST asynchronously
-  /// inform its delegate of any initial settings for the given file via the
-  /// `fileBuildSettingsChanged` method, even if unavailable.
-  func registerForChangeNotifications(for: DocumentURI) async
-
-  /// Unregister the given file for build-system level change notifications,
-  /// such as command line flag changes, dependency changes, etc.
-  func unregisterForChangeNotifications(for: DocumentURI) async
-
   /// Called when files in the project change.
   func didChangeWatchedFiles(notification: BuildServerProtocol.DidChangeWatchedFilesNotification) async
 

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
@@ -19,18 +19,6 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
 
-/// Defines how well a `BuildSystem` can handle a file with a given URI.
-package enum FileHandlingCapability: Comparable, Sendable {
-  /// The build system can't handle the file at all
-  case unhandled
-
-  /// The build system has fallback build settings for the file
-  case fallback
-
-  /// The build system knows how to handle the file
-  case handled
-}
-
 package struct SourceFileInfo: Sendable {
   /// The URI of the source file.
   package let uri: DocumentURI
@@ -171,8 +159,6 @@ package protocol BuiltInBuildSystem: AnyObject, Sendable {
 
   /// Called when files in the project change.
   func didChangeWatchedFiles(notification: BuildServerProtocol.DidChangeWatchedFilesNotification) async
-
-  func fileHandlingCapability(for uri: DocumentURI) async -> FileHandlingCapability
 
   /// Returns the list of source files in the project.
   ///

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
@@ -128,10 +128,7 @@ package protocol BuiltInBuildSystem: AnyObject, Sendable {
 
   /// Prepare the given targets for indexing and semantic functionality. This should build all swift modules of target
   /// dependencies.
-  func prepare(
-    targets: [BuildTargetIdentifier],
-    logMessageToIndexLog: @escaping @Sendable (_ taskID: IndexTaskID, _ message: String) -> Void
-  ) async throws
+  func prepare(request: PrepareTargetsRequest) async throws -> VoidResponse
 
   /// If the build system has knowledge about the language that this document should be compiled in, return it.
   ///

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
@@ -140,6 +140,8 @@ package actor BuiltInBuildSystemAdapter: BuiltInBuildSystemMessageHandler {
     switch request {
     case let request as InverseSourcesRequest:
       return try await handle(request, underlyingBuildSystem.inverseSources)
+    case let request as PrepareTargetsRequest:
+      return try await handle(request, underlyingBuildSystem.prepare)
     case let request as SourceKitOptionsRequest:
       return try await handle(request, underlyingBuildSystem.sourceKitOptions)
     default:

--- a/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
@@ -149,11 +149,6 @@ extension CompilationDatabaseBuildSystem: BuiltInBuildSystem {
     return nil
   }
 
-  package func registerForChangeNotifications(for uri: DocumentURI) {}
-
-  /// We don't support change watching.
-  package func unregisterForChangeNotifications(for uri: DocumentURI) {}
-
   private func database(for uri: DocumentURI) -> CompilationDatabase? {
     if let url = uri.fileURL, let path = try? AbsolutePath(validating: url.path) {
       return database(for: path)

--- a/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
@@ -210,14 +210,6 @@ extension CompilationDatabaseBuildSystem: BuiltInBuildSystem {
     }
   }
 
-  package func fileHandlingCapability(for uri: DocumentURI) -> FileHandlingCapability {
-    if database(for: uri) != nil {
-      return .handled
-    } else {
-      return .unhandled
-    }
-  }
-
   package func sourceFiles() async -> [SourceFileInfo] {
     guard let compdb else {
       return []

--- a/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
@@ -130,10 +130,7 @@ extension CompilationDatabaseBuildSystem: BuiltInBuildSystem {
     return InverseSourcesResponse(targets: [BuildTargetIdentifier.dummy])
   }
 
-  package func prepare(
-    targets: [BuildTargetIdentifier],
-    logMessageToIndexLog: @Sendable (_ taskID: IndexTaskID, _ message: String) -> Void
-  ) async throws {
+  package func prepare(request: PrepareTargetsRequest) async throws -> VoidResponse {
     throw PrepareNotSupportedError()
   }
 

--- a/Sources/BuildSystemIntegration/IndexTaskID.swift
+++ b/Sources/BuildSystemIntegration/IndexTaskID.swift
@@ -44,4 +44,23 @@ package enum IndexTaskID: Sendable {
       return Self.numberToEmojis((id * 2 + 1).hashValue, numEmojis: numEmojis)
     }
   }
+
+  package var rawValue: String {
+    switch self {
+    case .preparation(id: let id): return "preparation-\(id)"
+    case .updateIndexStore(id: let id): return "updateIndexStore-\(id)"
+    }
+  }
+
+  package init?(rawValue: String) {
+    let split = rawValue.split(separator: "-", maxSplits: 2)
+    guard split.count == 2, let id = UInt32(split[1]) else {
+      return nil
+    }
+    switch split[0] {
+    case "preparation": self = .preparation(id: id)
+    case "updateIndexStore": self = .updateIndexStore(id: id)
+    default: return nil
+    }
+  }
 }

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -489,10 +489,7 @@ extension SwiftPMBuildSystem {
       targets[targetIdentifier] = (buildTarget, depth)
     }
 
-    if let delegate = self.delegate {
-      await delegate.fileHandlingCapabilityChanged()
-      await messageHandler?.sendNotificationToSourceKitLSP(DidChangeBuildTargetNotification(changes: nil))
-    }
+    await messageHandler?.sendNotificationToSourceKitLSP(DidChangeBuildTargetNotification(changes: nil))
     for testFilesDidChangeCallback in testFilesDidChangeCallbacks {
       await testFilesDidChangeCallback()
     }
@@ -849,13 +846,6 @@ extension SwiftPMBuildSystem: BuildSystemIntegration.BuiltInBuildSystem {
       filesWithUpdatedDependencies.formUnion(self.fileToTargets.keys)
     }
     await self.fileDependenciesUpdatedDebouncer.scheduleCall(filesWithUpdatedDependencies)
-  }
-
-  package func fileHandlingCapability(for uri: DocumentURI) -> FileHandlingCapability {
-    if targets(for: uri).isEmpty {
-      return .unhandled
-    }
-    return .handled
   }
 
   package func sourceFiles() -> [SourceFileInfo] {

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -188,10 +188,6 @@ package actor SwiftPMBuildSystem {
   /// Callbacks that should be called if the list of possible test files has changed.
   private var testFilesDidChangeCallbacks: [() async -> Void] = []
 
-  /// The URIs for which the delegate has registered for change notifications,
-  /// mapped to the language the delegate specified when registering for change notifications.
-  private var watchedFiles: Set<DocumentURI> = []
-
   /// Debounces calls to `delegate.filesDependenciesUpdated`.
   ///
   /// This is to ensure we don't call `filesDependenciesUpdated` for the same file multiple time if the client does not
@@ -765,16 +761,6 @@ extension SwiftPMBuildSystem: BuildSystemIntegration.BuiltInBuildSystem {
         logger.error("Preparation of target \(target.forLogging) exited abnormally \(exception)")
       }
     }
-  }
-
-  package func registerForChangeNotifications(for uri: DocumentURI) async {
-    self.watchedFiles.insert(uri)
-  }
-
-  /// Unregister the given file for build-system level change notifications, such as command
-  /// line flag changes, dependency changes, etc.
-  package func unregisterForChangeNotifications(for uri: DocumentURI) {
-    self.watchedFiles.remove(uri)
   }
 
   /// Returns the resolved target descriptions for the given file, if one is known.

--- a/Sources/BuildSystemIntegration/TestBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/TestBuildSystem.swift
@@ -70,10 +70,7 @@ package actor TestBuildSystem: BuiltInBuildSystem {
     return InverseSourcesResponse(targets: [BuildTargetIdentifier.dummy])
   }
 
-  package func prepare(
-    targets: [BuildTargetIdentifier],
-    logMessageToIndexLog: @escaping @Sendable (_ taskID: IndexTaskID, _ message: String) -> Void
-  ) async throws {
+  package func prepare(request: PrepareTargetsRequest) async throws -> VoidResponse {
     throw PrepareNotSupportedError()
   }
 

--- a/Sources/BuildSystemIntegration/TestBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/TestBuildSystem.swift
@@ -39,9 +39,6 @@ package actor TestBuildSystem: BuiltInBuildSystem {
   /// Build settings by file.
   private var buildSettingsByFile: [DocumentURI: SourceKitOptionsResponse] = [:]
 
-  /// Files currently being watched by our delegate.
-  private var watchedFiles: Set<DocumentURI> = []
-
   package func setBuildSettings(for uri: DocumentURI, to buildSettings: SourceKitOptionsResponse?) async {
     buildSettingsByFile[uri] = buildSettings
     await self.messageHandler?.sendNotificationToSourceKitLSP(DidChangeBuildTargetNotification(changes: nil))
@@ -90,14 +87,6 @@ package actor TestBuildSystem: BuiltInBuildSystem {
 
   package func targets(dependingOn targets: [BuildTargetIdentifier]) -> [BuildTargetIdentifier]? {
     return nil
-  }
-
-  package func registerForChangeNotifications(for uri: DocumentURI) async {
-    watchedFiles.insert(uri)
-  }
-
-  package func unregisterForChangeNotifications(for uri: DocumentURI) {
-    watchedFiles.remove(uri)
   }
 
   package func didChangeWatchedFiles(notification: BuildServerProtocol.DidChangeWatchedFilesNotification) async {}

--- a/Sources/BuildSystemIntegration/TestBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/TestBuildSystem.swift
@@ -102,14 +102,6 @@ package actor TestBuildSystem: BuiltInBuildSystem {
 
   package func didChangeWatchedFiles(notification: BuildServerProtocol.DidChangeWatchedFilesNotification) async {}
 
-  package func fileHandlingCapability(for uri: DocumentURI) -> FileHandlingCapability {
-    if buildSettingsByFile[uri] != nil {
-      return .handled
-    } else {
-      return .unhandled
-    }
-  }
-
   package func sourceFiles() async -> [SourceFileInfo] {
     return []
   }

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -832,7 +832,7 @@ extension SourceKitLSPServer: MessageHandler {
 }
 
 extension SourceKitLSPServer {
-  nonisolated func logMessageToIndexLog(taskID: IndexTaskID, message: String) {
+  nonisolated package func logMessageToIndexLog(taskID: IndexTaskID, message: String) {
     var message: Substring = message[...]
     while message.last?.isNewline ?? false {
       message = message.dropLast(1)

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BuildServerProtocol
 import BuildSystemIntegration
 import IndexStoreDB
 import LanguageServerProtocol
@@ -82,7 +83,8 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
   /// `nil` if background indexing is not enabled.
   let semanticIndexManager: SemanticIndexManager?
 
-  /// A callback that should be called when the file handling capability of this workspace changes.
+  /// A callback that should be called when the file handling capability (ie. the presence of a target for a source
+  /// files) of this workspace changes.
   private let fileHandlingCapabilityChangedCallback: @Sendable () async -> Void
 
   private init(
@@ -316,7 +318,7 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
     }
   }
 
-  package func fileHandlingCapabilityChanged() async {
+  package func buildTargetsChanged(_ changes: [BuildTargetEvent]?) async {
     await self.fileHandlingCapabilityChangedCallback()
   }
 }

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -83,6 +83,9 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
   /// `nil` if background indexing is not enabled.
   let semanticIndexManager: SemanticIndexManager?
 
+  /// A callback that should be called when the build system wants to log a message to the index log.
+  private let logMessageToIndexLogCallback: @Sendable (_ taskID: IndexTaskID, _ message: String) -> Void
+
   /// A callback that should be called when the file handling capability (ie. the presence of a target for a source
   /// files) of this workspace changes.
   private let fileHandlingCapabilityChangedCallback: @Sendable () async -> Void
@@ -106,6 +109,7 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
     self.options = options
     self._uncheckedIndex = ThreadSafeBox(initialValue: uncheckedIndex)
     self.buildSystemManager = buildSystemManager
+    self.logMessageToIndexLogCallback = logMessageToIndexLog
     self.fileHandlingCapabilityChangedCallback = fileHandlingCapabilityChanged
     if options.backgroundIndexingOrDefault, let uncheckedIndex, await buildSystemManager.supportsPreparation {
       self.semanticIndexManager = SemanticIndexManager(
@@ -320,6 +324,10 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
 
   package func buildTargetsChanged(_ changes: [BuildTargetEvent]?) async {
     await self.fileHandlingCapabilityChangedCallback()
+  }
+
+  package func logMessageToIndexLog(taskID: IndexTaskID, message: String) {
+    self.logMessageToIndexLogCallback(taskID, message)
   }
 }
 

--- a/Sources/SwiftExtensions/Sequence+AsyncMap.swift
+++ b/Sources/SwiftExtensions/Sequence+AsyncMap.swift
@@ -68,4 +68,17 @@ extension Sequence {
 
     return result
   }
+
+  /// Just like `Sequence.first` but allows an `async` predicate function.
+  package func asyncFirst(
+    @_inheritActorContext _ predicate: @Sendable (Element) async throws -> Bool
+  ) async rethrows -> Element? {
+    for element in self {
+      if try await predicate(element) {
+        return element
+      }
+    }
+
+    return nil
+  }
 }

--- a/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
@@ -134,8 +134,6 @@ final class TestDelegate: BuildSystemDelegate, BuiltInBuildSystemMessageHandler 
     }
   }
 
-  func fileHandlingCapabilityChanged() {}
-
   func sendRequestToSourceKitLSP<R: RequestType>(_ request: R) async throws -> R.Response {
     throw ResponseError.methodNotFound(R.method)
   }

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -449,5 +449,5 @@ private actor BSMDelegate: BuildSystemManagerDelegate {
     }
   }
 
-  func fileHandlingCapabilityChanged() {}
+  func buildTargetsChanged(_ changes: [BuildTargetEvent]?) async {}
 }

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -450,4 +450,6 @@ private actor BSMDelegate: BuildSystemManagerDelegate {
   }
 
   func buildTargetsChanged(_ changes: [BuildTargetEvent]?) async {}
+
+  nonisolated func logMessageToIndexLog(taskID: BuildSystemIntegration.IndexTaskID, message: String) {}
 }


### PR DESCRIPTION
Three somewhat unrelated commits:
- Instead of having `FileHandlingCapability` for a source file, check if it belongs to any targets
- Remove `registerForChangeNotifications`
  - This was only really used for the legacy BSP integration, which we are phasing out in favor of the new `SourceKitOptions` request.
- Migrate `BuildSystem.prepare` to a BSP request