### PR TITLE
Fix a memory leak

### DIFF
--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -206,7 +206,7 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
       toolchainRegistry: toolchainRegistry,
       options: options,
       buildSystemTestHooks: buildSystemTestHooks,
-      messagesToSourceKitLSPHandler: self
+      messagesToSourceKitLSPHandler: WeakMessageHandler(self)
     )
     if let buildSystem {
       let connectionToBuildSystem = LocalConnection(receiverName: "Build system")


### PR DESCRIPTION
We had a retain cycle from `BuildSystemManager` to `LocalConnection`. Fix it by making `LocalConnection` have a weak reference to `BuildSystemManager`.