### PR TITLE
Only reopen files for which the build settings actually changed

### DIFF
--- a/Sources/BuildSystemIntegration/BuildSystemManagerDelegate.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManagerDelegate.swift
@@ -15,7 +15,8 @@ import LanguageServerProtocol
 
 /// Handles build system events, such as file build settings changes.
 package protocol BuildSystemManagerDelegate: AnyObject, Sendable {
-  /// Notify the delegate that the given files' build settings have changed.
+  /// Notify the delegate that the result of `BuildSystemManager.buildSettingsInferredFromMainFile` might have changed
+  /// for the given files.
   func fileBuildSettingsChanged(_ changedFiles: Set<DocumentURI>) async
 
   /// Notify the delegate that the dependencies of the given files have changed

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -159,6 +159,12 @@ package actor SwiftLanguageService: LanguageService, Sendable {
     }
   }
 
+  /// The build settings that were used to open the given files.
+  ///
+  ///  - Note: Not all documents open in `SwiftLanguageService` are necessarily in this dictionary because files where
+  ///    `buildSettings(for:)` returns `nil` are not included.
+  private var buildSettingsForOpenFiles: [DocumentURI: SwiftCompileCommand] = [:]
+
   /// Calling `scheduleCall` on `refreshDiagnosticsDebouncer` schedules a `DiagnosticsRefreshRequest` to be sent to
   /// to the client.
   ///
@@ -400,10 +406,12 @@ extension SwiftLanguageService {
         try await self.sendSourcekitdRequest(closeReq, fileContents: nil)
       }
 
+      let buildSettings = await buildSettings(for: snapshot.uri)
       let openReq = openDocumentSourcekitdRequest(
         snapshot: snapshot,
-        compileCommand: await buildSettings(for: snapshot.uri)
+        compileCommand: buildSettings
       )
+      self.buildSettingsForOpenFiles[snapshot.uri] = buildSettings
       _ = await orLog("Re-opening document") {
         try await self.sendSourcekitdRequest(openReq, fileContents: snapshot.text)
       }
@@ -420,11 +428,14 @@ extension SwiftLanguageService {
     guard (try? documentManager.openDocuments.contains(uri)) ?? false else {
       return
     }
-    // Close and re-open the document internally to inform sourcekitd to update the compile command. At the moment
-    // there's no better way to do this.
-    // Schedule the document re-open in the SourceKit-LSP server. This ensures that the re-open happens exclusively with
-    // no other request running at the same time.
-    sourceKitLSPServer?.handle(ReopenTextDocumentNotification(textDocument: TextDocumentIdentifier(uri)))
+    let newBuildSettings = await self.buildSettings(for: uri)
+    if newBuildSettings != buildSettingsForOpenFiles[uri] {
+      // Close and re-open the document internally to inform sourcekitd to update the compile command. At the moment
+      // there's no better way to do this.
+      // Schedule the document re-open in the SourceKit-LSP server. This ensures that the re-open happens exclusively with
+      // no other request running at the same time.
+      sourceKitLSPServer?.handle(ReopenTextDocumentNotification(textDocument: TextDocumentIdentifier(uri)))
+    }
   }
 
   package func documentDependenciesUpdated(_ uris: Set<DocumentURI>) async {
@@ -445,8 +456,7 @@ extension SwiftLanguageService {
 
     for uri in uris {
       await macroExpansionManager.purge(primaryFile: uri)
-      // `documentUpdatedBuildSettings` already handles reopening the document, so we do that here as well.
-      await self.documentUpdatedBuildSettings(uri)
+      sourceKitLSPServer?.handle(ReopenTextDocumentNotification(textDocument: TextDocumentIdentifier(uri)))
     }
   }
 
@@ -485,6 +495,7 @@ extension SwiftLanguageService {
       await diagnosticReportManager.removeItemsFromCache(with: notification.textDocument.uri)
 
       let buildSettings = await self.buildSettings(for: snapshot.uri)
+      buildSettingsForOpenFiles[snapshot.uri] = buildSettings
 
       let req = openDocumentSourcekitdRequest(snapshot: snapshot, compileCommand: buildSettings)
       _ = try? await self.sendSourcekitdRequest(req, fileContents: snapshot.text)
@@ -500,6 +511,7 @@ extension SwiftLanguageService {
       cancelInFlightPublishDiagnosticsTask(for: notification.textDocument.uri)
       inFlightPublishDiagnosticsTasks[notification.textDocument.uri] = nil
       await diagnosticReportManager.removeItemsFromCache(with: notification.textDocument.uri)
+      buildSettingsForOpenFiles[notification.textDocument.uri] = nil
 
       let req = closeDocumentSourcekitdRequest(uri: notification.textDocument.uri)
       _ = try? await self.sendSourcekitdRequest(req, fileContents: nil)


### PR DESCRIPTION
Whenever we got a notification that the build settings of a file might have changed (eg. because the Package manifest was reloaded), we would re-open it in sourcekitd. But we only need to re-open it if the build settings actually changed.