### PR TITLE
Mark all transitive dependents of a modified target as being unprepared

### DIFF
--- a/Sources/SKTestSupport/LocationsOrLocationLinksResponse+Locations.swift
+++ b/Sources/SKTestSupport/LocationsOrLocationLinksResponse+Locations.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+
+extension LocationsOrLocationLinksResponse {
+  /// If this is the `locations` case, return the locations, otherwise return `nil`.
+  public var locations: [Location]? {
+    switch self {
+    case .locations(let locations): return locations
+    case .locationLinks: return nil
+    }
+  }
+}

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -417,6 +417,11 @@ package struct DocumentPositions {
     self.positions = positions
   }
 
+  package static func extract(from markedText: String) -> (positions: DocumentPositions, textWithoutMarkers: String) {
+    let (markers, textWithoutMarkers) = extractMarkers(markedText)
+    return (DocumentPositions(markers: markers, textWithoutMarkers: textWithoutMarkers), textWithoutMarkers)
+  }
+
   /// Returns the position of the given marker and traps if the document from which these `DocumentPositions` were
   /// derived didn't contain the marker.
   package subscript(_ marker: String) -> Position {

--- a/Sources/SwiftExtensions/CMakeLists.txt
+++ b/Sources/SwiftExtensions/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(SwiftExtensions STATIC
   Sequence+ContainsAnyIn.swift
   Task+WithPriorityChangedHandler.swift
   ThreadSafeBox.swift
+  TransitiveClosure.swift
 )
 set_target_properties(SwiftExtensions PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/SwiftExtensions/TransitiveClosure.swift
+++ b/Sources/SwiftExtensions/TransitiveClosure.swift
@@ -1,0 +1,24 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+package func transitiveClosure<T: Hashable>(of values: Set<T>, successors: (T) -> Set<T>) -> Set<T> {
+  var transitiveClosure: Set<T> = []
+  var workList = Array(values)
+  while let element = workList.popLast() {
+    for successor in successors(element) {
+      if transitiveClosure.insert(successor).inserted {
+        workList.append(successor)
+      }
+    }
+  }
+  return transitiveClosure
+}

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -422,17 +422,18 @@ final class BackgroundIndexingTests: XCTestCase {
     )
     XCTAssertEqual(callsBeforeEdit, [])
 
-    let otherFileMarkedContents = """
-      func 2️⃣bar() {
-        3️⃣foo()
-      }
-      """
+    let (otherFilePositions, otherFileMarkedContents) = DocumentPositions.extract(
+      from: """
+        func 2️⃣bar() {
+          3️⃣foo()
+        }
+        """
+    )
 
     let otherFileUri = try project.uri(for: "MyOtherFile.swift")
     let otherFileUrl = try XCTUnwrap(otherFileUri.fileURL)
-    let otherFilePositions = DocumentPositions(markedText: otherFileMarkedContents)
 
-    try extractMarkers(otherFileMarkedContents).textWithoutMarkers.write(
+    try otherFileMarkedContents.write(
       to: otherFileUrl,
       atomically: true,
       encoding: .utf8
@@ -489,16 +490,17 @@ final class BackgroundIndexingTests: XCTestCase {
     )
     XCTAssertEqual(callsBeforeEdit, [])
 
-    let headerNewMarkedContents = """
-      void someFunc();
+    let (newPositions, headerNewMarkedContents) = DocumentPositions.extract(
+      from: """
+        void someFunc();
 
-      void 2️⃣test() {
-        3️⃣someFunc();
-      };
-      """
-    let newPositions = DocumentPositions(markedText: headerNewMarkedContents)
+        void 2️⃣test() {
+          3️⃣someFunc();
+        };
+        """
+    )
 
-    try extractMarkers(headerNewMarkedContents).textWithoutMarkers.write(
+    try headerNewMarkedContents.write(
       to: try XCTUnwrap(uri.fileURL),
       atomically: true,
       encoding: .utf8

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -353,9 +353,7 @@ class DefinitionTests: XCTestCase {
     )
     XCTAssertNil(beforeChangingFileA)
 
-    let updatedAMarkedCode = "func 2️⃣sayHello() {}"
-    let updatedACode = extractMarkers(updatedAMarkedCode).textWithoutMarkers
-    let updatedAPositions = DocumentPositions(markedText: updatedAMarkedCode)
+    let (updatedAPositions, updatedACode) = DocumentPositions.extract(from: "func 2️⃣sayHello() {}")
 
     let aUri = try project.uri(for: "FileA.swift")
     try updatedACode.write(to: try XCTUnwrap(aUri.fileURL), atomically: true, encoding: .utf8)

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -33,11 +33,7 @@ class DefinitionTests: XCTestCase {
     let response = try await testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
     )
-    guard case .locations(let locations) = response else {
-      XCTFail("Expected locations response")
-      return
-    }
-    XCTAssertEqual(locations, [Location(uri: uri, range: Range(positions["1️⃣"]))])
+    XCTAssertEqual(response?.locations, [Location(uri: uri, range: Range(positions["1️⃣"]))])
   }
 
   func testJumpToDefinitionIncludesOverrides() async throws {
@@ -60,12 +56,8 @@ class DefinitionTests: XCTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["3️⃣"])
     )
-    guard case .locations(let locations) = response else {
-      XCTFail("Expected locations response")
-      return
-    }
     XCTAssertEqual(
-      locations,
+      response?.locations,
       [
         Location(uri: project.fileURI, range: Range(project.positions["1️⃣"])),
         Location(uri: project.fileURI, range: Range(project.positions["2️⃣"])),
@@ -96,12 +88,8 @@ class DefinitionTests: XCTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["3️⃣"])
     )
-    guard case .locations(let locations) = response else {
-      XCTFail("Expected locations response")
-      return
-    }
     XCTAssertEqual(
-      locations,
+      response?.locations,
       [
         Location(uri: project.fileURI, range: Range(project.positions["1️⃣"])),
         Location(uri: project.fileURI, range: Range(project.positions["2️⃣"])),
@@ -134,12 +122,8 @@ class DefinitionTests: XCTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["3️⃣"])
     )
-    guard case .locations(let locations) = response else {
-      XCTFail("Expected locations response")
-      return
-    }
     XCTAssertEqual(
-      locations,
+      response?.locations,
       [
         Location(uri: uri, range: Range(positions["1️⃣"])),
         Location(uri: uri, range: Range(positions["2️⃣"])),
@@ -182,13 +166,8 @@ class DefinitionTests: XCTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
     )
-    guard case .locations(let locations) = response else {
-      XCTFail("Expected locations response")
-      return
-    }
 
-    XCTAssertEqual(locations.count, 1)
-    let location = try XCTUnwrap(locations.first)
+    let location = try XCTUnwrap(response?.locations?.only)
     XCTAssertEqual(
       location,
       Location(uri: try project.uri(for: "test.c"), range: Range(try project.position(of: "1️⃣", in: "test.c")))
@@ -284,13 +263,7 @@ class DefinitionTests: XCTestCase {
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["3️⃣"])
     )
 
-    guard case .locations(let locations) = response else {
-      XCTFail("Expected locations response")
-      return
-    }
-
-    XCTAssertEqual(locations.count, 1)
-    let location = try XCTUnwrap(locations.first)
+    let location = try XCTUnwrap(response?.locations?.only)
     XCTAssertEqual(location, try project.location(from: "1️⃣", to: "2️⃣", in: "LibA.h"))
   }
 
@@ -331,13 +304,7 @@ class DefinitionTests: XCTestCase {
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["3️⃣"])
     )
 
-    guard case .locations(let locations) = response else {
-      XCTFail("Expected locations response")
-      return
-    }
-
-    XCTAssertEqual(locations.count, 1)
-    let location = try XCTUnwrap(locations.first)
+    let location = try XCTUnwrap(response?.locations?.only)
     XCTAssertEqual(location, try project.location(from: "1️⃣", to: "2️⃣", in: "LibA.h"))
   }
 
@@ -359,12 +326,8 @@ class DefinitionTests: XCTestCase {
     let response = try await testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
     )
-    guard case .locations(let locations) = response else {
-      XCTFail("Expected locations response")
-      return
-    }
     XCTAssertEqual(
-      locations,
+      response?.locations,
       [Location(uri: uri, range: Range(positions["1️⃣"]))]
     )
   }
@@ -625,10 +588,6 @@ class DefinitionTests: XCTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
     )
-    guard case .locations(let locations) = response else {
-      XCTFail("Expected locations response")
-      return
-    }
-    XCTAssertEqual(locations, [Location(uri: project.fileURI, range: Range(project.positions["2️⃣"]))])
+    XCTAssertEqual(response?.locations, [Location(uri: project.fileURI, range: Range(project.positions["2️⃣"]))])
   }
 }

--- a/Tests/SourceKitLSPTests/ImplementationTests.swift
+++ b/Tests/SourceKitLSPTests/ImplementationTests.swift
@@ -32,14 +32,10 @@ final class ImplementationTests: XCTestCase {
         position: project.positions["1️⃣"]
       )
     )
-    guard case .locations(let implementations) = response else {
-      XCTFail("Response was not locations", line: line)
-      return
-    }
     let expectedLocations = expectedLocationMarkers.map {
       Location(uri: project.fileURI, range: Range(project.positions[$0]))
     }
-    XCTAssertEqual(implementations, expectedLocations, line: line)
+    XCTAssertEqual(response?.locations, expectedLocations, line: line)
   }
 
   // MARK: - Tests
@@ -306,12 +302,8 @@ final class ImplementationTests: XCTestCase {
         position: aPositions["1️⃣"]
       )
     )
-    guard case .locations(let implementations) = response else {
-      XCTFail("Response was not locations")
-      return
-    }
     XCTAssertEqual(
-      implementations,
+      response?.locations,
       [Location(uri: try project.uri(for: "b.swift"), range: Range(try project.position(of: "2️⃣", in: "b.swift")))]
     )
   }

--- a/Tests/SourceKitLSPTests/IndexTests.swift
+++ b/Tests/SourceKitLSPTests/IndexTests.swift
@@ -63,10 +63,7 @@ final class IndexTests: XCTestCase {
         position: libCPositions["3️⃣"]
       )
     )
-    guard case .locations(let jump) = response else {
-      XCTFail("Response is not locations")
-      return
-    }
+    let jump = try XCTUnwrap(response?.locations)
 
     XCTAssertEqual(jump.count, 1)
     XCTAssertEqual(jump.first?.uri, libAUri)
@@ -126,10 +123,7 @@ final class IndexTests: XCTestCase {
           position: project.positions["2️⃣"]
         )
       )
-      guard case .locations(let jump) = response else {
-        XCTFail("Response is not locations")
-        return nil
-      }
+      let jump = try XCTUnwrap(response?.locations)
       XCTAssertEqual(jump.count, 1)
       XCTAssertEqual(jump.first?.uri, project.fileURI)
       XCTAssertEqual(jump.first?.range.lowerBound, project.positions["1️⃣"])


### PR DESCRIPTION
We weren’t considering transitive dependencies in `BuildSystemManager.targets(dependingOn:)` before.

rdar://136039234