### PR TITLE
Adopt faster `traverseModules` implementation in SwiftPM

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -404,7 +404,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
     self.swiftPMTargets = [:]
     self.targetDependencies = [:]
 
-    buildDescription.traverseModules { buildTarget, parent, depth in
+    buildDescription.traverseModules { buildTarget, parent in
       let targetIdentifier = orLog("Getting build target identifier") { try BuildTargetIdentifier(buildTarget) }
       guard let targetIdentifier else {
         return


### PR DESCRIPTION
Companion of https://github.com/swiftlang/swift-package-manager/pull/7977

---

Adjustments because `traverseModules` no longer returns depth

We no longer need `depth`. Adopt a faster version of `traverseModules` that doesn’t return the depth.

rdar://136107035