### PR TITLE
Only scan test targets for tests

### DIFF
--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -727,6 +727,12 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
     return result
   }
 
+  package func buildTarget(named identifier: BuildTargetIdentifier) async -> BuildTarget? {
+    return await orLog("Getting built target with ID") {
+      try await buildTargets()[identifier]?.target
+    }
+  }
+
   package func sourceFiles(in targets: Set<BuildTargetIdentifier>) async throws -> [SourcesItem] {
     guard let connectionToBuildSystem else {
       return []

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -462,7 +462,10 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
 
   package func buildTargets(request: WorkspaceBuildTargetsRequest) async throws -> WorkspaceBuildTargetsResponse {
     var targets = self.swiftPMTargets.map { (targetId, target) in
-      var tags: [BuildTargetTag] = [.test]
+      var tags: [BuildTargetTag] = []
+      if target.isTestTarget {
+        tags.append(.test)
+      }
       if !target.isPartOfRootPackage {
         tags.append(.dependency)
       }

--- a/Sources/SwiftExtensions/Sequence+AsyncMap.swift
+++ b/Sources/SwiftExtensions/Sequence+AsyncMap.swift
@@ -81,4 +81,11 @@ extension Sequence {
 
     return nil
   }
+
+  /// Just like `Sequence.contains` but allows an `async` predicate function.
+  package func asyncContains(
+    @_inheritActorContext where predicate: @Sendable (Element) async throws -> Bool
+  ) async rethrows -> Bool {
+    return try await asyncFirst(predicate) != nil
+  }
 }

--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -1424,4 +1424,21 @@ final class DocumentTestDiscoveryTests: XCTestCase {
       ]
     )
   }
+
+  func testSwiftTestingTestsAreNotReportedInNonTestTargets() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "FileA.swift": """
+          @Suite struct MyTests {
+          @Test func inStruct() {}
+        }
+        """
+      ]
+    )
+
+    let (uri, _) = try project.openDocument("FileA.swift")
+
+    let tests = try await project.testClient.send(DocumentTestsRequest(textDocument: TextDocumentIdentifier(uri)))
+    XCTAssertEqual(tests, [])
+  }
 }

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -1063,6 +1063,21 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       ]
     )
   }
+
+  func testSwiftTestingTestsAreNotDiscoveredInNonTestTargets() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "FileA.swift": """
+          @Suite struct MyTests {
+          @Test func inStruct() {}
+        }
+        """
+      ]
+    )
+
+    let tests = try await project.testClient.send(WorkspaceTestsRequest())
+    XCTAssertEqual(tests, [])
+  }
 }
 
 extension TestItem {


### PR DESCRIPTION
Don’t run the syntactic test scanner on files that we know are only part of non-test targets.

rdar://126493903