### PR TITLE
Consistently use `SOURCEKITLSP_` as prefix of environment variables instead of `SOURCEKIT_LSP`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
   "swift.swiftEnvironmentVariables": {
     // Show log messages when running tests on macOS
-    "SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER": "1",
+    "SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER": "1",
     // Decrease timeout to 10s locally from the default 3min we allow by default. This is usually sufficient and makes test fail faster.
     "SOURCEKIT_LSP_TEST_TIMEOUT": "10"
   },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,21 +9,21 @@ SourceKit-LSP is a SwiftPM package, so you can build and test it using anything 
 SourceKit-LSP builds with the latest released Swift version and all its tests pass or, if unsupported by the latest Swift version, are skipped. Using the `main` development branch of SourceKit-LSP with an older Swift versions is not supported.
 
 > [!TIP]
-> SourceKit-LSP’s logging is usually very useful to debug test failures. On macOS these logs are written to the system log by default. To redirect them to stderr, build SourceKit-LSP with the `SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER` environment variable set to `1`:
+> SourceKit-LSP’s logging is usually very useful to debug test failures. On macOS these logs are written to the system log by default. To redirect them to stderr, build SourceKit-LSP with the `SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER` environment variable set to `1`:
 > - In VS Code: Add the following to your `settings.json`:
 >   ```json
->   "swift.swiftEnvironmentVariables": { "SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER": "1" },
+>   "swift.swiftEnvironmentVariables": { "SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER": "1" },
 >   ```
 > - In Xcode
 >   1. Product -> Scheme -> Edit Scheme…
 >   2. Select the Arguments tab in the Run section
->   3. Add a `SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER` environment variable with value `1`
-> - On the command line: Set the `SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER` environment variable to `1` when running tests, e.g by running `SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER=1 swift test --parallel`
+>   3. Add a `SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER` environment variable with value `1`
+> - On the command line: Set the `SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER` environment variable to `1` when running tests, e.g by running `SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER=1 swift test --parallel`
 
 > [!TIP]
 > Other useful environment variables during test execution are:
 > - `SKIP_LONG_TESTS`: Skips tests that usually take longer than 1 second to execute. This significantly speeds up test time, especially with `swift test --parallel`
-> - `SOURCEKITLSP_KEEP_TEST_SCRATCH_DIR`: Does not delete the temporary files created during test execution. Allows inspection of the test projects after the test finishes.
+> - `SOURCEKIT_LSP_KEEP_TEST_SCRATCH_DIR`: Does not delete the temporary files created during test execution. Allows inspection of the test projects after the test finishes.
 
 ### Linux
 

--- a/Documentation/Environment Variables.md
+++ b/Documentation/Environment Variables.md
@@ -4,17 +4,17 @@ The following environment variables can be used to control some behavior in Sour
 
 ## Build time
 
-- `SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER`: Use the `NonDarwinLogger` to log to stderr, even when building SourceKit-LSP on macOS. This is useful when running tests using `swift test` because it writes the log messages to stderr, which is displayed during the `swift test` invocation.
+- `SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER`: Use the `NonDarwinLogger` to log to stderr, even when building SourceKit-LSP on macOS. This is useful when running tests using `swift test` because it writes the log messages to stderr, which is displayed during the `swift test` invocation.
 - `SOURCEKIT_LSP_CI_INSTALL`: Modifies rpaths in a way that’s necessary to build SourceKit-LSP to be included in a distributed toolchain. Should not be used locally.
 - `SWIFTCI_USE_LOCAL_DEPS`: Assume that all of SourceKit-LSP’s dependencies are checked out next to it and use those instead of cloning the repositories. Primarily intended for CI environments that check out related branches.
 
 ## Runtime
 
-- `SOURCEKITLSP_LOG_LEVEL`: When using `NonDarwinLogger`, specify the level at which messages should be logged. Defaults to `debug` in debug build and `default` in release builds. Primarily used to increase the log level when running tests from a release build in Swift CI. To adjust the logging on user devices, use the [Configuration file](Configuration%20File.md).
-- `SOURCEKITLSP_LOG_PRIVACY_LEVEL`: When using `NonDarwinLogger`, specifies whether information that might contain sensitive information (essentially source code) should be logged. Defaults to `private` in debug build and `public` in release builds. Primarily used to log sensitive information when running tests from a release build in Swift CI. To adjust the logging on user devices, use the [Configuration file](Configuration%20File.md).
+- `SOURCEKIT_LSP_LOG_LEVEL`: When using `NonDarwinLogger`, specify the level at which messages should be logged. Defaults to `debug` in debug build and `default` in release builds. Primarily used to increase the log level when running tests from a release build in Swift CI. To adjust the logging on user devices, use the [Configuration file](Configuration%20File.md).
+- `SOURCEKIT_LSP_LOG_PRIVACY_LEVEL`: When using `NonDarwinLogger`, specifies whether information that might contain sensitive information (essentially source code) should be logged. Defaults to `private` in debug build and `public` in release builds. Primarily used to log sensitive information when running tests from a release build in Swift CI. To adjust the logging on user devices, use the [Configuration file](Configuration%20File.md).
 
 ## Testing
 - `SKIP_LONG_TESTS`: Skip tests that typically take more than 1s to execute.
-- `SOURCEKITLSP_KEEP_TEST_SCRATCH_DIR`: Does not delete the temporary files created during test execution. Allows inspection of the test projects after the test finishes.
+- `SOURCEKIT_LSP_KEEP_TEST_SCRATCH_DIR`: Does not delete the temporary files created during test execution. Allows inspection of the test projects after the test finishes.
 - `SOURCEKIT_LSP_TEST_MODULE_CACHE`: Specifies where tests should store their shared module cache. Defaults to writing the module cache to a temporary directory. Intended so that CI systems can clean the module cache directory after running.
 - `SOURCEKIT_LSP_TEST_TIMEOUT`: Override the timeout duration for tests, in seconds.

--- a/Package.swift
+++ b/Package.swift
@@ -420,7 +420,7 @@ func hasEnvironmentVariable(_ name: String) -> Bool {
 ///
 /// This is useful when running tests using `swift test` because xctest will not display the output from `os_log` on the
 /// command line.
-var forceNonDarwinLogger: Bool { hasEnvironmentVariable("SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER") }
+var forceNonDarwinLogger: Bool { hasEnvironmentVariable("SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER") }
 
 // When building the toolchain on the CI, don't add the CI's runpath for the
 // final build before installing.
@@ -474,7 +474,7 @@ var sourcekitLSPLinkSettings: [LinkerSetting] {
 
 var lspLoggingSwiftSettings: [SwiftSetting] {
   if forceNonDarwinLogger {
-    return [.define("SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER")]
+    return [.define("SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER")]
   } else {
     return []
   }

--- a/Sources/SKLogging/Logging.swift
+++ b/Sources/SKLogging/Logging.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-#if canImport(os) && !SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER
+#if canImport(os) && !SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER
 import os  // os_log
 
 package typealias LogLevel = os.OSLogType

--- a/Sources/SKLogging/NonDarwinLogging.swift
+++ b/Sources/SKLogging/NonDarwinLogging.swift
@@ -25,7 +25,7 @@ package enum LogConfig {
   /// The globally set log level
   package static let logLevel = ThreadSafeBox<NonDarwinLogLevel>(
     initialValue: {
-      if let envVar = ProcessInfo.processInfo.environment["SOURCEKITLSP_LOG_LEVEL"],
+      if let envVar = ProcessInfo.processInfo.environment["SOURCEKIT_LSP_LOG_LEVEL"],
         let logLevel = NonDarwinLogLevel(envVar)
       {
         return logLevel
@@ -41,7 +41,7 @@ package enum LogConfig {
   /// The globally set privacy level
   package static let privacyLevel = ThreadSafeBox<NonDarwinLogPrivacy>(
     initialValue: {
-      if let envVar = ProcessInfo.processInfo.environment["SOURCEKITLSP_LOG_PRIVACY_LEVEL"],
+      if let envVar = ProcessInfo.processInfo.environment["SOURCEKIT_LSP_LOG_PRIVACY_LEVEL"],
         let privacyLevel = NonDarwinLogPrivacy(envVar)
       {
         return privacyLevel

--- a/Sources/SKLogging/SetGlobalLogFileHandler.swift
+++ b/Sources/SKLogging/SetGlobalLogFileHandler.swift
@@ -23,7 +23,7 @@ import Foundation
 import WinSDK
 #endif
 
-#if !canImport(os) || SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER
+#if !canImport(os) || SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER
 fileprivate struct FailedToCreateFileError: Error, CustomStringConvertible {
   let logFile: URL
 
@@ -188,7 +188,7 @@ private func cleanOldLogFilesImpl(logFileDirectory: URL, maxAge: TimeInterval) {
 ///
 /// No-op when using OSLog.
 package func setUpGlobalLogFileHandler(logFileDirectory: URL, logFileMaxBytes: Int, logRotateCount: Int) async {
-  #if !canImport(os) || SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER
+  #if !canImport(os) || SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER
   await setUpGlobalLogFileHandlerImpl(
     logFileDirectory: logFileDirectory,
     logFileMaxBytes: logFileMaxBytes,
@@ -202,7 +202,7 @@ package func setUpGlobalLogFileHandler(logFileDirectory: URL, logFileMaxBytes: I
 ///
 /// No-op when using OSLog.
 package func cleanOldLogFiles(logFileDirectory: URL, maxAge: TimeInterval) {
-  #if !canImport(os) || SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER
+  #if !canImport(os) || SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER
   cleanOldLogFilesImpl(logFileDirectory: logFileDirectory, maxAge: maxAge)
   #endif
 }

--- a/Sources/SKTestSupport/Utils.swift
+++ b/Sources/SKTestSupport/Utils.swift
@@ -49,7 +49,8 @@ extension DocumentURI {
   }
 }
 
-package let cleanScratchDirectories = (ProcessInfo.processInfo.environment["SOURCEKITLSP_KEEP_TEST_SCRATCH_DIR"] == nil)
+package let cleanScratchDirectories =
+  (ProcessInfo.processInfo.environment["SOURCEKIT_LSP_KEEP_TEST_SCRATCH_DIR"] == nil)
 
 /// An empty directory in which a test with `#function` name `testName` can store temporary data.
 package func testScratchDir(testName: String = #function) throws -> URL {
@@ -72,7 +73,7 @@ package func testScratchDir(testName: String = #function) throws -> URL {
 /// test name.
 ///
 /// The temporary directory will be deleted at the end of `directory` unless the
-/// `SOURCEKITLSP_KEEP_TEST_SCRATCH_DIR` environment variable is set.
+/// `SOURCEKIT_LSP_KEEP_TEST_SCRATCH_DIR` environment variable is set.
 package func withTestScratchDir<T>(
   @_inheritActorContext _ body: @Sendable (AbsolutePath) async throws -> T,
   testName: String = #function

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -210,13 +210,13 @@ def run_tests(swift_exec: str, args: argparse.Namespace) -> None:
     # 'swift test' doesn't print os_log output to the command line. Use the
     # `NonDarwinLogger` that prints to stderr so we can view the log output in CI test
     # runs.
-    additional_env['SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER'] = '1'
+    additional_env['SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER'] = '1'
 
     # CI doesn't contain any sensitive information. Log everything.
-    additional_env['SOURCEKITLSP_LOG_PRIVACY_LEVEL'] = 'sensitive'
+    additional_env['SOURCEKIT_LSP_LOG_PRIVACY_LEVEL'] = 'sensitive'
 
     # Log with the highest log level to simplify debugging of CI failures.
-    additional_env['SOURCEKITLSP_LOG_LEVEL'] = 'debug'
+    additional_env['SOURCEKIT_LSP_LOG_LEVEL'] = 'debug'
 
     bin_path = swiftpm_bin_path(swift_exec, swiftpm_args, additional_env=additional_env)
     tests = os.path.join(bin_path, 'sk-tests')


### PR DESCRIPTION
We were inconsistently using `SOURCEKITLSP_` and `SOURCEKIT_LSP_` as the prefix for environment variables. Make it consistent and always use `SOURCEKITLSP_`.