### PR TITLE
When running tests, raise in `XCTFail` if `logger.fault` is called 🚥 #1701

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "swift.swiftEnvironmentVariables": {
+    // Show log messages when running tests on macOS
+    "SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER": "1",
+    // Decrease timeout to 10s locally from the default 3min we allow by default. This is usually sufficient and makes test fail faster.
+    "SOURCEKIT_LSP_TEST_TIMEOUT": "10"
+  },
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
     // Show log messages when running tests on macOS
     "SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER": "1",
     // Decrease timeout to 10s locally from the default 3min we allow by default. This is usually sufficient and makes test fail faster.
-    "SOURCEKIT_LSP_TEST_TIMEOUT": "10"
+    "SOURCEKITLSP_TEST_TIMEOUT": "10"
   },
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,8 @@
     // Show log messages when running tests on macOS
     "SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER": "1",
     // Decrease timeout to 10s locally from the default 3min we allow by default. This is usually sufficient and makes test fail faster.
-    "SOURCEKITLSP_TEST_TIMEOUT": "10"
+    "SOURCEKITLSP_TEST_TIMEOUT": "10",
+    // Logging faults indicates that there is an issue in the code. Raise an XCTFail to catch these cases.
+    "SOURCEKITLSP_XCTFAIL_ON_FAULT": "1",
   },
 }

--- a/Documentation/Environment Variables.md
+++ b/Documentation/Environment Variables.md
@@ -5,6 +5,7 @@ The following environment variables can be used to control some behavior in Sour
 ## Build time
 
 - `SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER`: Use the `NonDarwinLogger` to log to stderr, even when building SourceKit-LSP on macOS. This is useful when running tests using `swift test` because it writes the log messages to stderr, which is displayed during the `swift test` invocation.
+- `SOURCEKITLSP_XCTFAIL_ON_FAULT`: When a fault is logged, record it using `XCTFail`, verifying that no faults are logged during test execution, since faults indicate Must only be set when running tests. A `sourcekit-lsp` binary built with this flag will not launch because it can’t load XCTest. Has no effect if os_log is used (ie. when building on macOS without `SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER` set).
 - `SOURCEKITLSP_CI_INSTALL`: Modifies rpaths in a way that’s necessary to build SourceKit-LSP to be included in a distributed toolchain. Should not be used locally.
 - `SWIFTCI_USE_LOCAL_DEPS`: Assume that all of SourceKit-LSP’s dependencies are checked out next to it and use those instead of cloning the repositories. Primarily intended for CI environments that check out related branches.
 

--- a/Documentation/Environment Variables.md
+++ b/Documentation/Environment Variables.md
@@ -5,7 +5,7 @@ The following environment variables can be used to control some behavior in Sour
 ## Build time
 
 - `SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER`: Use the `NonDarwinLogger` to log to stderr, even when building SourceKit-LSP on macOS. This is useful when running tests using `swift test` because it writes the log messages to stderr, which is displayed during the `swift test` invocation.
-- `SOURCEKIT_LSP_CI_INSTALL`: Modifies rpaths in a way that’s necessary to build SourceKit-LSP to be included in a distributed toolchain. Should not be used locally.
+- `SOURCEKITLSP_CI_INSTALL`: Modifies rpaths in a way that’s necessary to build SourceKit-LSP to be included in a distributed toolchain. Should not be used locally.
 - `SWIFTCI_USE_LOCAL_DEPS`: Assume that all of SourceKit-LSP’s dependencies are checked out next to it and use those instead of cloning the repositories. Primarily intended for CI environments that check out related branches.
 
 ## Runtime
@@ -16,5 +16,5 @@ The following environment variables can be used to control some behavior in Sour
 ## Testing
 - `SKIP_LONG_TESTS`: Skip tests that typically take more than 1s to execute.
 - `SOURCEKITLSP_KEEP_TEST_SCRATCH_DIR`: Does not delete the temporary files created during test execution. Allows inspection of the test projects after the test finishes.
-- `SOURCEKIT_LSP_TEST_MODULE_CACHE`: Specifies where tests should store their shared module cache. Defaults to writing the module cache to a temporary directory. Intended so that CI systems can clean the module cache directory after running.
-- `SOURCEKIT_LSP_TEST_TIMEOUT`: Override the timeout duration for tests, in seconds.
+- `SOURCEKITLSP_TEST_MODULE_CACHE`: Specifies where tests should store their shared module cache. Defaults to writing the module cache to a temporary directory. Intended so that CI systems can clean the module cache directory after running.
+- `SOURCEKITLSP_TEST_TIMEOUT`: Override the timeout duration for tests, in seconds.

--- a/Package.swift
+++ b/Package.swift
@@ -423,7 +423,7 @@ var forceNonDarwinLogger: Bool { hasEnvironmentVariable("SOURCEKITLSP_FORCE_NON_
 
 // When building the toolchain on the CI, don't add the CI's runpath for the
 // final build before installing.
-var installAction: Bool { hasEnvironmentVariable("SOURCEKIT_LSP_CI_INSTALL") }
+var installAction: Bool { hasEnvironmentVariable("SOURCEKITLSP_CI_INSTALL") }
 
 /// Assume that all the package dependencies are checked out next to sourcekit-lsp and use that instead of fetching a
 /// remote dependency.

--- a/Package.swift
+++ b/Package.swift
@@ -421,6 +421,12 @@ func hasEnvironmentVariable(_ name: String) -> Bool {
 /// command line.
 var forceNonDarwinLogger: Bool { hasEnvironmentVariable("SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER") }
 
+/// Call `XCTFail` when a fault is logged using `NonDarwinLogger`.
+///
+/// A logged fault should always indicate a bug in SourceKit-LSP. This is useful to verify that we don't log any faults
+/// during test execution.
+var xctfailOnFault: Bool { hasEnvironmentVariable("SOURCEKITLSP_XCTFAIL_ON_FAULT") }
+
 // When building the toolchain on the CI, don't add the CI's runpath for the
 // final build before installing.
 var installAction: Bool { hasEnvironmentVariable("SOURCEKITLSP_CI_INSTALL") }

--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -248,7 +248,7 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
     ) {
       [weak self] (filesWithUpdatedDependencies) in
       guard let self, let delegate = await self.delegate else {
-        logger.fault("Not calling filesDependenciesUpdated because no delegate exists in SwiftPMBuildSystem")
+        logger.log("Not calling filesDependenciesUpdated because no delegate exists in SwiftPMBuildSystem")
         return
       }
       let changedWatchedFiles = await self.watchedFilesReferencing(mainFiles: filesWithUpdatedDependencies)
@@ -761,14 +761,11 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
           logger.fault("Did not compute depth for target \(buildTarget.id)")
           depth = 0
         }
-        let targetDependents: Set<BuildTargetIdentifier>
-        if let d = dependents[buildTarget.id] {
-          targetDependents = d
-        } else {
-          logger.fault("Did not compute dependents for target \(buildTarget.id)")
-          targetDependents = []
-        }
-        result[buildTarget.id] = BuildTargetInfo(target: buildTarget, depth: depth, dependents: targetDependents)
+        result[buildTarget.id] = BuildTargetInfo(
+          target: buildTarget,
+          depth: depth,
+          dependents: dependents[buildTarget.id] ?? []
+        )
       }
       return result
     }

--- a/Sources/SKTestSupport/Timeouts.swift
+++ b/Sources/SKTestSupport/Timeouts.swift
@@ -15,7 +15,7 @@ import Foundation
 /// The default duration how long tests should wait for responses from
 /// SourceKit-LSP / sourcekitd / clangd.
 package let defaultTimeout: TimeInterval = {
-  if let customTimeoutStr = ProcessInfo.processInfo.environment["SOURCEKIT_LSP_TEST_TIMEOUT"],
+  if let customTimeoutStr = ProcessInfo.processInfo.environment["SOURCEKITLSP_TEST_TIMEOUT"],
     let customTimeout = TimeInterval(customTimeoutStr)
   {
     return customTimeout

--- a/Sources/SKTestSupport/Utils.swift
+++ b/Sources/SKTestSupport/Utils.swift
@@ -113,7 +113,7 @@ fileprivate extension URL {
 }
 
 let globalModuleCache: URL? = {
-  if let customModuleCache = ProcessInfo.processInfo.environment["SOURCEKIT_LSP_TEST_MODULE_CACHE"] {
+  if let customModuleCache = ProcessInfo.processInfo.environment["SOURCEKITLSP_TEST_MODULE_CACHE"] {
     if customModuleCache.isEmpty {
       return nil
     }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -198,7 +198,7 @@ package actor SwiftLanguageService: LanguageService, Sendable {
     // The debounce duration of 500ms was chosen arbitrarily without scientific research.
     self.refreshDiagnosticsDebouncer = Debouncer(debounceDuration: .milliseconds(500)) { [weak sourceKitLSPServer] in
       guard let sourceKitLSPServer else {
-        logger.fault("Not sending DiagnosticRefreshRequest to client because sourceKitLSPServer has been deallocated")
+        logger.log("Not sending DiagnosticRefreshRequest to client because sourceKitLSPServer has been deallocated")
         return
       }
       _ = await orLog("Sending DiagnosticRefreshRequest to client after document dependencies updated") {

--- a/Tests/SKLoggingTests/LoggingTests.swift
+++ b/Tests/SKLoggingTests/LoggingTests.swift
@@ -111,38 +111,41 @@ final class LoggingTests: XCTestCase {
   }
 
   func testLogLevels() async {
-    await assertLogging(
-      logLevel: .default,
-      expected: ["d", "e", "f"]
-    ) {
-      $0.fault("d")
-      $0.error("e")
-      $0.log("f")
-      $0.info("g")
-      $0.debug("h")
+    await withLoggingFaultsAllowed {
+      await assertLogging(
+        logLevel: .default,
+        expected: ["d", "e", "f"]
+      ) {
+        $0.fault("d")
+        $0.error("e")
+        $0.log("f")
+        $0.info("g")
+        $0.debug("h")
+      }
+
+      await assertLogging(
+        logLevel: .error,
+        expected: ["d", "e"]
+      ) {
+        $0.fault("d")
+        $0.error("e")
+        $0.log("f")
+        $0.info("g")
+        $0.debug("h")
+      }
+
+      await assertLogging(
+        logLevel: .fault,
+        expected: ["d"]
+      ) {
+        $0.fault("d")
+        $0.error("e")
+        $0.log("f")
+        $0.info("g")
+        $0.debug("h")
+      }
     }
 
-    await assertLogging(
-      logLevel: .error,
-      expected: ["d", "e"]
-    ) {
-      $0.fault("d")
-      $0.error("e")
-      $0.log("f")
-      $0.info("g")
-      $0.debug("h")
-    }
-
-    await assertLogging(
-      logLevel: .fault,
-      expected: ["d"]
-    ) {
-      $0.fault("d")
-      $0.error("e")
-      $0.log("f")
-      $0.info("g")
-      $0.debug("h")
-    }
   }
 
   func testPrivacyMaskingLevels() async {

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SKLogging
 import SKSupport
 import TSCBasic
 import XCTest
@@ -129,25 +130,35 @@ final class SupportTests: XCTestCase {
     checkLineAndColumns(t1, 9, (line: 1, utf16Column: 4))
     checkLineAndColumns(t1, 10, (line: 2, utf16Column: 0))
     checkLineAndColumns(t1, 14, (line: 2, utf16Column: 4))
-    checkLineAndColumns(t1, 15, (line: 2, utf16Column: 4))
+    withLoggingFaultsAllowed {
+      checkLineAndColumns(t1, 15, (line: 2, utf16Column: 4))  // Recovers to end of file
+    }
 
     checkUTF8OffsetOf(t1, (line: 0, utf16Column: 0), 0)
     checkUTF8OffsetOf(t1, (line: 0, utf16Column: 2), 2)
     checkUTF8OffsetOf(t1, (line: 0, utf16Column: 4), 4)
     checkUTF8OffsetOf(t1, (line: 0, utf16Column: 5), 5)
-    checkUTF8OffsetOf(t1, (line: 0, utf16Column: 6), 5)  // Recovers to end of line 0
+    withLoggingFaultsAllowed {
+      checkUTF8OffsetOf(t1, (line: 0, utf16Column: 6), 5)  // Recovers to end of line 0
+    }
     checkUTF8OffsetOf(t1, (line: 1, utf16Column: 0), 5)
     checkUTF8OffsetOf(t1, (line: 1, utf16Column: 4), 9)
     checkUTF8OffsetOf(t1, (line: 2, utf16Column: 0), 10)
     checkUTF8OffsetOf(t1, (line: 2, utf16Column: 4), 14)
-    checkUTF8OffsetOf(t1, (line: 2, utf16Column: 5), 14)  // Recovers to end of line 2
-    checkUTF8OffsetOf(t1, (line: 3, utf16Column: 0), 14)  // Recovers to end of source file
+    withLoggingFaultsAllowed {
+      checkUTF8OffsetOf(t1, (line: 2, utf16Column: 5), 14)  // Recovers to end of line 2
+      checkUTF8OffsetOf(t1, (line: 3, utf16Column: 0), 14)  // Recovers to end of source file
+    }
 
     checkUTF16ColumnAt(t1, (line: 0, utf8Column: 4), 4)
     checkUTF16ColumnAt(t1, (line: 0, utf8Column: 5), 5)
-    checkUTF16ColumnAt(t1, (line: 0, utf8Column: 6), 5)  // Recovers to end of line 0
+    withLoggingFaultsAllowed {
+      checkUTF16ColumnAt(t1, (line: 0, utf8Column: 6), 5)  // Recovers to end of line 0
+    }
     checkUTF16ColumnAt(t1, (line: 2, utf8Column: 0), 0)
-    checkUTF16ColumnAt(t1, (line: 3, utf8Column: 0), 0)  // Line out of bounds, so keeps column
+    withLoggingFaultsAllowed {
+      checkUTF16ColumnAt(t1, (line: 3, utf8Column: 0), 0)  // Line out of bounds, so keeps column
+    }
 
     let t2 = LineTable(
       """
@@ -168,11 +179,15 @@ final class SupportTests: XCTestCase {
     checkUTF8OffsetOf(t2, (line: 0, utf16Column: 6), 16)
     checkUTF8OffsetOf(t2, (line: 1, utf16Column: 1), 19)
     checkUTF8OffsetOf(t2, (line: 1, utf16Column: 6), 32)
-    checkUTF8OffsetOf(t2, (line: 1, utf16Column: 7), 32)  // Recovers to end of line 1
+    withLoggingFaultsAllowed {
+      checkUTF8OffsetOf(t2, (line: 1, utf16Column: 7), 32)  // Recovers to end of line 1
+    }
     checkUTF8OffsetOf(t2, (line: 2, utf16Column: 0), 32)
     checkUTF8OffsetOf(t2, (line: 2, utf16Column: 2), 36)
     checkUTF8OffsetOf(t2, (line: 2, utf16Column: 4), 40)
-    checkUTF8OffsetOf(t2, (line: 2, utf16Column: 5), 40)  // Recovers to end of line 2
+    withLoggingFaultsAllowed {
+      checkUTF8OffsetOf(t2, (line: 2, utf16Column: 5), 40)  // Recovers to end of line 2
+    }
 
     checkUTF16ColumnAt(t2, (line: 0, utf8Column: 3), 1)
     checkUTF16ColumnAt(t2, (line: 0, utf8Column: 15), 5)

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import LanguageServerProtocol
+import SKLogging
 import SKTestSupport
 import SourceKitLSP
 import XCTest
@@ -236,21 +237,23 @@ final class SwiftCompletionTests: XCTestCase {
       XCTAssertFalse(inOrAfterFoo.items.isEmpty)
     }
 
-    let outOfRange1 = try await testClient.send(
-      CompletionRequest(
-        textDocument: TextDocumentIdentifier(uri),
-        position: Position(line: 0, utf16index: 4)
+    try await withLoggingFaultsAllowed {
+      let outOfRange1 = try await testClient.send(
+        CompletionRequest(
+          textDocument: TextDocumentIdentifier(uri),
+          position: Position(line: 0, utf16index: 4)
+        )
       )
-    )
-    XCTAssertTrue(outOfRange1.isIncomplete)
+      XCTAssertTrue(outOfRange1.isIncomplete)
 
-    let outOfRange2 = try await testClient.send(
-      CompletionRequest(
-        textDocument: TextDocumentIdentifier(uri),
-        position: Position(line: 1, utf16index: 0)
+      let outOfRange2 = try await testClient.send(
+        CompletionRequest(
+          textDocument: TextDocumentIdentifier(uri),
+          position: Position(line: 1, utf16index: 0)
+        )
       )
-    )
-    XCTAssertTrue(outOfRange2.isIncomplete)
+      XCTAssertTrue(outOfRange2.isIncomplete)
+    }
   }
 
   func testCompletionOptional() async throws {

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -186,7 +186,7 @@ def get_swiftpm_environment_variables(swift_exec: str, args: argparse.Namespace)
         env['SKIP_LONG_TESTS'] = '1'
 
     if args.action == 'install':
-        env['SOURCEKIT_LSP_CI_INSTALL'] = "1"
+        env['SOURCEKITLSP_CI_INSTALL'] = "1"
 
     return env
 
@@ -230,7 +230,7 @@ def run_tests(swift_exec: str, args: argparse.Namespace) -> None:
     ] + swiftpm_args
 
     with tempfile.TemporaryDirectory() as test_module_cache:
-        additional_env['SOURCEKIT_LSP_TEST_MODULE_CACHE'] = f"{test_module_cache}/module-cache"
+        additional_env['SOURCEKITLSP_TEST_MODULE_CACHE'] = f"{test_module_cache}/module-cache"
         # Try running tests in parallel. If that fails, run tests in serial to get capture more readable output.
         try:
             check_call(cmd + ['--parallel'], additional_env=additional_env, verbose=args.verbose)

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -211,6 +211,8 @@ def run_tests(swift_exec: str, args: argparse.Namespace) -> None:
     # `NonDarwinLogger` that prints to stderr so we can view the log output in CI test
     # runs.
     additional_env['SOURCEKITLSP_FORCE_NON_DARWIN_LOGGER'] = '1'
+    # Logging faults indicates that there is an issue in the code. Raise an XCTFail to catch these cases.
+    additional_env['SOURCEKITLSP_XCTFAIL_ON_FAULT'] = '1'
 
     # CI doesn't contain any sensitive information. Log everything.
     additional_env['SOURCEKITLSP_LOG_PRIVACY_LEVEL'] = 'sensitive'


### PR DESCRIPTION
Depends on #1701

---

`logger.fault` indicates that there was an internal error in SourceKit-LSP. We should ensure that we don’t hit any situation that causes a `logger.fault` while running tests by raising an `XCTFail` if `logger.fault` is called in `NonDarwinLogger` (which is the logger that we’re using in Swift CI).

rdar://136014548
Resolves #1669