### PR TITLE
Revert "When a JSON-RPC connection is closed, send an error response to all outstanding requests"

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -165,9 +165,6 @@ public final class JSONRPCConnection: Connection {
     ioGroup.notify(queue: queue) { [weak self] in
       guard let self = self else { return }
       Task {
-        for outstandingRequest in outstandingRequests.values {
-          outstandingRequest.replyHandler(LSPResult.failure(ResponseError.internalError("JSON-RPC Connection closed")))
-        }
         await self.closeHandler?()
         self.receiveHandler = nil  // break retain cycle
       }


### PR DESCRIPTION
Reverts swiftlang/sourcekit-lsp#1688

This seems to be breaking toolchain builds:

```
JSONRPCConnection.swift:168:35: error: reference to property 'outstandingRequests' in closure
requires explicit use of 'self' to make capture semantics explicit
        for outstandingRequest in outstandingRequests.values {
```

https://ci.swift.org/job/swift-PR-toolchain-macos/1519/console