### PR TITLE
Don't sort CodeActions

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -844,7 +844,8 @@ extension SwiftLanguageService {
         // Ignore any providers that failed to provide refactoring actions.
         return []
       }
-    }.flatMap { $0 }.sorted { $0.title < $1.title }
+    }
+    .flatMap { $0 }
   }
 
   func retrieveSyntaxCodeActions(_ request: CodeActionRequest) async throws -> [CodeAction] {


### PR DESCRIPTION
Returned code actions are often sorted in a predetermined, preferred order. For instance, when proposing actions to handle error propagation on a throwing function the option to handle the error with `try` should appear before the more dangerous option to disable error propagation with `try!`.

Fixes #1696