### PR TITLE
Adopt `InternalImportsByDefault`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-enable-upcoming-feature InternalImportsByDefault>")
+
 find_package(dispatch QUIET)
 find_package(Foundation QUIET)
 find_package(TSC QUIET)

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,11 @@
 import Foundation
 import PackageDescription
 
+/// Swift settings that should be applied to every Swift target.
+let globalSwiftSettings: [SwiftSetting] = [
+  .enableUpcomingFeature("InternalImportsByDefault")
+]
+
 let package = Package(
   name: "SourceKitLSP",
   platforms: [.macOS(.v13)],
@@ -36,6 +41,7 @@ let package = Package(
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ],
       exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings,
       linkerSettings: sourcekitLSPLinkSettings
     ),
 
@@ -46,7 +52,8 @@ let package = Package(
       dependencies: [
         "LanguageServerProtocol"
       ],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: BuildSystemIntegration
@@ -67,7 +74,8 @@ let package = Package(
         .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     .testTarget(
@@ -79,7 +87,8 @@ let package = Package(
         "SKTestSupport",
         "SourceKitLSP",
         "ToolchainRegistry",
-      ]
+      ],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: CAtomics
@@ -124,7 +133,8 @@ let package = Package(
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     .testTarget(
@@ -137,7 +147,8 @@ let package = Package(
         "SourceKitD",
         "ToolchainRegistry",
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ]
+      ],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: InProcessClient
@@ -152,7 +163,8 @@ let package = Package(
         "SourceKitLSP",
         "ToolchainRegistry",
       ],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: LanguageServerProtocol
@@ -160,7 +172,8 @@ let package = Package(
     .target(
       name: "LanguageServerProtocol",
       dependencies: [],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     .testTarget(
@@ -168,7 +181,8 @@ let package = Package(
       dependencies: [
         "LanguageServerProtocol",
         "SKTestSupport",
-      ]
+      ],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: LanguageServerProtocolJSONRPC
@@ -180,7 +194,8 @@ let package = Package(
         "SKLogging",
         "SwiftExtensions",
       ],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     .testTarget(
@@ -188,7 +203,8 @@ let package = Package(
       dependencies: [
         "LanguageServerProtocolJSONRPC",
         "SKTestSupport",
-      ]
+      ],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: SemanticIndex
@@ -203,7 +219,8 @@ let package = Package(
         "ToolchainRegistry",
         .product(name: "IndexStoreDB", package: "indexstore-db"),
       ],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     .testTarget(
@@ -212,7 +229,8 @@ let package = Package(
         "SemanticIndex",
         "SKLogging",
         "SKTestSupport",
-      ]
+      ],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: SKLogging
@@ -224,7 +242,7 @@ let package = Package(
         .product(name: "Crypto", package: "swift-crypto"),
       ],
       exclude: ["CMakeLists.txt"],
-      swiftSettings: lspLoggingSwiftSettings
+      swiftSettings: globalSwiftSettings + lspLoggingSwiftSettings
     ),
 
     .testTarget(
@@ -232,7 +250,8 @@ let package = Package(
       dependencies: [
         "SKLogging",
         "SKTestSupport",
-      ]
+      ],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: SKOptions
@@ -245,7 +264,8 @@ let package = Package(
         "SKSupport",
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: SKSupport
@@ -260,7 +280,8 @@ let package = Package(
         "SwiftExtensions",
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     .testTarget(
@@ -269,7 +290,8 @@ let package = Package(
         "SKSupport",
         "SKTestSupport",
         "SwiftExtensions",
-      ]
+      ],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: SKTestSupport
@@ -291,7 +313,8 @@ let package = Package(
         .product(name: "ISDBTestSupport", package: "indexstore-db"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ],
-      resources: [.copy("INPUTS")]
+      resources: [.copy("INPUTS")],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: SourceKitD
@@ -304,7 +327,8 @@ let package = Package(
         "SwiftExtensions",
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ],
-      exclude: ["CMakeLists.txt", "sourcekitd_uids.swift.gyb"]
+      exclude: ["CMakeLists.txt", "sourcekitd_uids.swift.gyb"],
+      swiftSettings: globalSwiftSettings
     ),
 
     .testTarget(
@@ -315,7 +339,8 @@ let package = Package(
         "SKTestSupport",
         "SwiftExtensions",
         "ToolchainRegistry",
-      ]
+      ],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: SourceKitLSP
@@ -346,7 +371,8 @@ let package = Package(
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
         .product(name: "SwiftPM-auto", package: "swift-package-manager"),
       ],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     .testTarget(
@@ -372,7 +398,8 @@ let package = Package(
         // be used by test cases that test macros (see `SwiftPMTestProject.macroPackageManifest`).
         .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-      ]
+      ],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: SwiftExtensions
@@ -380,7 +407,8 @@ let package = Package(
     .target(
       name: "SwiftExtensions",
       dependencies: ["CAtomics"],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     // MARK: ToolchainRegistry
@@ -394,7 +422,8 @@ let package = Package(
         .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
       ],
-      exclude: ["CMakeLists.txt"]
+      exclude: ["CMakeLists.txt"],
+      swiftSettings: globalSwiftSettings
     ),
 
     .testTarget(
@@ -404,7 +433,8 @@ let package = Package(
         "ToolchainRegistry",
         .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
         .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ]
+      ],
+      swiftSettings: globalSwiftSettings
     ),
   ],
   swiftLanguageVersions: [.v5, .version("6")]

--- a/Sources/BuildServerProtocol/Messages.swift
+++ b/Sources/BuildServerProtocol/Messages.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 fileprivate let requestTypes: [_RequestType.Type] = [
   BuildShutdownRequest.self,

--- a/Sources/BuildServerProtocol/Messages/BuildShutdownRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/BuildShutdownRequest.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// Like the language server protocol, the shutdown build request is
 /// sent from the client to the server. It asks the server to shut down,

--- a/Sources/BuildServerProtocol/Messages/BuildTargetPrepareRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/BuildTargetPrepareRequest.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 public typealias OriginId = String
 

--- a/Sources/BuildServerProtocol/Messages/BuildTargetSourcesRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/BuildTargetSourcesRequest.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// The build target sources request is sent from the client to the server to
 /// query for the list of text documents and directories that are belong to a

--- a/Sources/BuildServerProtocol/Messages/InitializeBuildRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/InitializeBuildRequest.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// Like the language server protocol, the initialize request is sent
 /// as the first request from the client to the server. If the server

--- a/Sources/BuildServerProtocol/Messages/OnBuildExitNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/OnBuildExitNotification.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// Like the language server protocol, a notification to ask the
 /// server to exit its process. The server should exit with success

--- a/Sources/BuildServerProtocol/Messages/OnBuildInitializedNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/OnBuildInitializedNotification.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// Like the language server protocol, the initialized notification is sent from the client to the server after the client received the result of the initialize request but before the client is sending any other request or notification to the server. The server can use the initialized notification for example to initialize intensive computation such as dependency resolution or compilation. The initialized notification may only be sent once.
 public struct OnBuildInitializedNotification: NotificationType {

--- a/Sources/BuildServerProtocol/Messages/OnBuildLogMessageNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/OnBuildLogMessageNotification.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// The log message notification is sent from a server to a client to ask the client to log a particular message in its console.
 ///

--- a/Sources/BuildServerProtocol/Messages/OnBuildTargetDidChangeNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/OnBuildTargetDidChangeNotification.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// The build target changed notification is sent from the server to the client
 /// to signal a change in a build target. The server communicates during the

--- a/Sources/BuildServerProtocol/Messages/OnWatchedFilesDidChangeNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/OnWatchedFilesDidChangeNotification.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// Notification sent from SourceKit-LSP to the build system to indicate that files within the project have been modified.
 public typealias OnWatchedFilesDidChangeNotification = LanguageServerProtocol.DidChangeWatchedFilesNotification

--- a/Sources/BuildServerProtocol/Messages/RegisterForChangeNotifications.swift
+++ b/Sources/BuildServerProtocol/Messages/RegisterForChangeNotifications.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// The register for changes request is sent from the language
 /// server to the build server to register or unregister for

--- a/Sources/BuildServerProtocol/Messages/TextDocumentSourceKitOptionsRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/TextDocumentSourceKitOptionsRequest.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// The `TextDocumentSourceKitOptionsRequest` request is sent from the client to the server to query for the list of
 /// compiler options necessary to compile this file in the given target.

--- a/Sources/BuildServerProtocol/Messages/WorkDoneProgress.swift
+++ b/Sources/BuildServerProtocol/Messages/WorkDoneProgress.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 public typealias CreateWorkDoneProgressRequest = LanguageServerProtocol.CreateWorkDoneProgressRequest
 public typealias WorkDoneProgress = LanguageServerProtocol.WorkDoneProgress

--- a/Sources/BuildServerProtocol/Messages/WorkspaceBuildTargetsRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/WorkspaceBuildTargetsRequest.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// The workspace build targets request is sent from the client to the server to
 /// ask for the list of all available build targets in the workspace.

--- a/Sources/BuildServerProtocol/Messages/WorkspaceWaitForBuildSystemUpdates.swift
+++ b/Sources/BuildServerProtocol/Messages/WorkspaceWaitForBuildSystemUpdates.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// This request is a no-op and doesn't have any effects.
 ///

--- a/Sources/BuildServerProtocol/SupportTypes/BuildTarget.swift
+++ b/Sources/BuildServerProtocol/SupportTypes/BuildTarget.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// Build target contains metadata about an artifact (for example library, test, or binary artifact).
 /// Using vocabulary of other build tools:

--- a/Sources/BuildSystemIntegration/BuildSettingsLogger.swift
+++ b/Sources/BuildSystemIntegration/BuildSettingsLogger.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+package import SKLogging
+#else
 import LanguageServerProtocol
 import SKLogging
+#endif
 
 // MARK: - Build settings logger
 

--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -10,6 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildServerProtocol
+import Dispatch
+import Foundation
+package import LanguageServerProtocol
+import SKLogging
+package import SKOptions
+package import SKSupport
+package import SwiftExtensions
+package import ToolchainRegistry
+
+package import struct TSCBasic.AbsolutePath
+package import struct TSCBasic.RelativePath
+package import func TSCBasic.resolveSymlinks
+#else
 import BuildServerProtocol
 import Dispatch
 import Foundation
@@ -23,6 +38,7 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
 import func TSCBasic.resolveSymlinks
+#endif
 
 fileprivate typealias RequestCache<Request: RequestType & Hashable> = Cache<Request, Request.Response>
 

--- a/Sources/BuildSystemIntegration/BuildSystemManagerDelegate.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManagerDelegate.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildServerProtocol
+package import LanguageServerProtocol
+#else
 import BuildServerProtocol
 import LanguageServerProtocol
+#endif
 
 /// Handles build system events, such as file build settings changes.
 package protocol BuildSystemManagerDelegate: AnyObject, Sendable {

--- a/Sources/BuildSystemIntegration/BuildTargetIdentifierExtensions.swift
+++ b/Sources/BuildSystemIntegration/BuildTargetIdentifierExtensions.swift
@@ -10,13 +10,29 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildServerProtocol
+import SKLogging
+#else
 import BuildServerProtocol
 import SKLogging
+#endif
 
 extension BuildTargetIdentifier {
   package static let dummy: BuildTargetIdentifier = BuildTargetIdentifier(uri: try! URI(string: "dummy://dummy"))
 }
 
+#if compiler(>=6)
+extension BuildTargetIdentifier: CustomLogStringConvertible {
+  package var description: String {
+    return uri.stringValue
+  }
+
+  package var redactedDescription: String {
+    return uri.stringValue.hashForLogging
+  }
+}
+#else
 extension BuildTargetIdentifier: CustomLogStringConvertible {
   public var description: String {
     return uri.stringValue
@@ -26,3 +42,4 @@ extension BuildTargetIdentifier: CustomLogStringConvertible {
     return uri.stringValue.hashForLogging
   }
 }
+#endif

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
@@ -10,6 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildServerProtocol
+package import LanguageServerProtocol
+import SKLogging
+import SKOptions
+import ToolchainRegistry
+
+package import struct TSCBasic.AbsolutePath
+package import struct TSCBasic.RelativePath
+#else
 import BuildServerProtocol
 import LanguageServerProtocol
 import SKLogging
@@ -18,6 +28,7 @@ import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
+#endif
 
 /// An error build systems can throw from `prepare` if they don't support preparation of targets.
 package struct PrepareNotSupportedError: Error, CustomStringConvertible {

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
@@ -19,8 +19,13 @@ import SKSupport
 import SwiftExtensions
 import ToolchainRegistry
 
+#if compiler(>=6)
+package import struct TSCBasic.AbsolutePath
+package import struct TSCBasic.RelativePath
+#else
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
+#endif
 
 package enum BuildSystemKind {
   case buildServer(projectRoot: AbsolutePath)

--- a/Sources/BuildSystemIntegration/CompilationDatabase.swift
+++ b/Sources/BuildSystemIntegration/CompilationDatabase.swift
@@ -10,6 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildServerProtocol
+import Foundation
+package import LanguageServerProtocol
+import SKLogging
+import SKSupport
+
+package import struct TSCBasic.AbsolutePath
+package import protocol TSCBasic.FileSystem
+package import struct TSCBasic.RelativePath
+package import var TSCBasic.localFileSystem
+package import func TSCBasic.resolveSymlinks
+#else
 import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
@@ -21,6 +34,7 @@ import protocol TSCBasic.FileSystem
 import struct TSCBasic.RelativePath
 import var TSCBasic.localFileSystem
 import func TSCBasic.resolveSymlinks
+#endif
 
 /// A single compilation database command.
 ///

--- a/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
@@ -10,6 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildServerProtocol
+import Dispatch
+package import LanguageServerProtocol
+import SKLogging
+package import SKOptions
+import SKSupport
+import ToolchainRegistry
+
+import struct Foundation.URL
+package import struct TSCBasic.AbsolutePath
+package import protocol TSCBasic.FileSystem
+package import struct TSCBasic.RelativePath
+package import var TSCBasic.localFileSystem
+#else
 import BuildServerProtocol
 import Dispatch
 import LanguageServerProtocol
@@ -23,6 +38,7 @@ import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.FileSystem
 import struct TSCBasic.RelativePath
 import var TSCBasic.localFileSystem
+#endif
 
 fileprivate enum Cachable<Value> {
   case noValue

--- a/Sources/BuildSystemIntegration/DetermineBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/DetermineBuildSystem.swift
@@ -10,12 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+import SKLogging
+package import SKOptions
+import ToolchainRegistry
+
+import struct TSCBasic.AbsolutePath
+#else
 import LanguageServerProtocol
 import SKLogging
 import SKOptions
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
+#endif
 
 /// Determine which build system should be started to handle the given workspace folder and at which folder that build
 /// system's project root is (see `BuiltInBuildSystem.projectRoot(for:options:)`).

--- a/Sources/BuildSystemIntegration/FallbackBuildSettings.swift
+++ b/Sources/BuildSystemIntegration/FallbackBuildSettings.swift
@@ -10,12 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+package import SKOptions
+
+import enum PackageLoading.Platform
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+#else
 import LanguageServerProtocol
 import SKOptions
 
 import enum PackageLoading.Platform
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
+#endif
 
 /// The path to the SDK.
 private let sdkpath: AbsolutePath? = {

--- a/Sources/BuildSystemIntegration/MainFilesProvider.swift
+++ b/Sources/BuildSystemIntegration/MainFilesProvider.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// A type that can provide the set of main files that include a particular file.
 package protocol MainFilesProvider: Sendable {

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -10,6 +10,37 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Basics
+@preconcurrency import Build
+package import BuildServerProtocol
+import Dispatch
+import Foundation
+package import LanguageServerProtocol
+@preconcurrency import PackageGraph
+import PackageLoading
+import PackageModel
+import SKLogging
+package import SKOptions
+import SKSupport
+@preconcurrency package import SPMBuildCore
+import SourceControl
+package import SourceKitLSPAPI
+import SwiftExtensions
+package import ToolchainRegistry
+@preconcurrency import Workspace
+
+package import struct Basics.AbsolutePath
+package import struct Basics.IdentifiableSet
+package import struct Basics.TSCAbsolutePath
+import struct Foundation.URL
+package import struct TSCBasic.AbsolutePath
+package import protocol TSCBasic.FileSystem
+package import class TSCBasic.Process
+package import var TSCBasic.localFileSystem
+package import func TSCBasic.resolveSymlinks
+package import class ToolchainRegistry.Toolchain
+#else
 import Basics
 @preconcurrency import Build
 import BuildServerProtocol
@@ -22,6 +53,7 @@ import PackageModel
 import SKLogging
 import SKOptions
 import SKSupport
+@preconcurrency import SPMBuildCore
 import SourceControl
 import SourceKitLSPAPI
 import SwiftExtensions
@@ -38,12 +70,9 @@ import class TSCBasic.Process
 import var TSCBasic.localFileSystem
 import func TSCBasic.resolveSymlinks
 import class ToolchainRegistry.Toolchain
+#endif
 
 fileprivate typealias AbsolutePath = Basics.AbsolutePath
-
-#if canImport(SPMBuildCore)
-@preconcurrency import SPMBuildCore
-#endif
 
 /// A build target in SwiftPM
 package typealias SwiftBuildTarget = SourceKitLSPAPI.BuildTarget

--- a/Sources/BuildSystemIntegration/TestBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/TestBuildSystem.swift
@@ -10,12 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildServerProtocol
+package import LanguageServerProtocol
+import SKOptions
+import ToolchainRegistry
+
+package import struct TSCBasic.AbsolutePath
+#else
 import BuildServerProtocol
 import LanguageServerProtocol
 import SKOptions
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
+#endif
 
 /// Build system to be used for testing BuildSystem and BuildSystemDelegate functionality with SourceKitLSPServer
 /// and other components.

--- a/Sources/Diagnose/ActiveRequestsCommand.swift
+++ b/Sources/Diagnose/ActiveRequestsCommand.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import ArgumentParser
+import Foundation
+import RegexBuilder
+
+import class TSCBasic.Process
+#else
 import ArgumentParser
 import Foundation
 import RegexBuilder
 
 import class TSCBasic.Process
+#endif
 
 package struct ActiveRequestsCommand: AsyncParsableCommand {
   package static let configuration: CommandConfiguration = CommandConfiguration(

--- a/Sources/Diagnose/DebugCommand.swift
+++ b/Sources/Diagnose/DebugCommand.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import ArgumentParser
+#else
 import ArgumentParser
+#endif
 
 package struct DebugCommand: ParsableCommand {
   package static let configuration = CommandConfiguration(

--- a/Sources/Diagnose/DiagnoseCommand.swift
+++ b/Sources/Diagnose/DiagnoseCommand.swift
@@ -10,6 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import ArgumentParser
+import Foundation
+import ToolchainRegistry
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+import class TSCUtility.PercentProgressAnimation
+#else
 import ArgumentParser
 import Foundation
 import ToolchainRegistry
@@ -17,6 +26,7 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import class TSCUtility.PercentProgressAnimation
+#endif
 
 /// When diagnosis is started, a progress bar displayed on the terminal that shows how far the diagnose command has
 /// progressed.

--- a/Sources/Diagnose/IndexCommand.swift
+++ b/Sources/Diagnose/IndexCommand.swift
@@ -10,6 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import ArgumentParser
+import Foundation
+import InProcessClient
+import LanguageServerProtocol
+import SKOptions
+import SKSupport
+import SourceKitLSP
+import SwiftExtensions
+import ToolchainRegistry
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+import class TSCUtility.PercentProgressAnimation
+#else
 import ArgumentParser
 import Foundation
 import InProcessClient
@@ -23,6 +38,7 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import class TSCUtility.PercentProgressAnimation
+#endif
 
 private actor IndexLogMessageHandler: MessageHandler {
   var hasSeenError: Bool = false

--- a/Sources/Diagnose/ReduceCommand.swift
+++ b/Sources/Diagnose/ReduceCommand.swift
@@ -10,6 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import ArgumentParser
+import Foundation
+import ToolchainRegistry
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+import class TSCUtility.PercentProgressAnimation
+#else
 import ArgumentParser
 import Foundation
 import ToolchainRegistry
@@ -17,6 +26,7 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import class TSCUtility.PercentProgressAnimation
+#endif
 
 package struct ReduceCommand: AsyncParsableCommand {
   package static let configuration: CommandConfiguration = CommandConfiguration(

--- a/Sources/Diagnose/ReduceFrontendCommand.swift
+++ b/Sources/Diagnose/ReduceFrontendCommand.swift
@@ -10,6 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import ArgumentParser
+import Foundation
+import ToolchainRegistry
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+import class TSCUtility.PercentProgressAnimation
+#else
 import ArgumentParser
 import Foundation
 import ToolchainRegistry
@@ -17,6 +26,7 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import class TSCUtility.PercentProgressAnimation
+#endif
 
 package struct ReduceFrontendCommand: AsyncParsableCommand {
   package static let configuration: CommandConfiguration = CommandConfiguration(

--- a/Sources/Diagnose/RequestInfo.swift
+++ b/Sources/Diagnose/RequestInfo.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+import RegexBuilder
+#else
 import Foundation
 import RegexBuilder
+#endif
 
 /// All the information necessary to replay a sourcektid request.
 package struct RequestInfo: Sendable {

--- a/Sources/Diagnose/RunSourcekitdRequestCommand.swift
+++ b/Sources/Diagnose/RunSourcekitdRequestCommand.swift
@@ -10,6 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import ArgumentParser
+import Foundation
+import SKSupport
+import SourceKitD
+import ToolchainRegistry
+
+import struct TSCBasic.AbsolutePath
+#else
 import ArgumentParser
 import Foundation
 import SKSupport
@@ -17,6 +26,7 @@ import SourceKitD
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
+#endif
 
 package struct RunSourceKitdRequestCommand: AsyncParsableCommand {
   package static let configuration = CommandConfiguration(

--- a/Sources/Diagnose/SourceKitD+RunWithYaml.swift
+++ b/Sources/Diagnose/SourceKitD+RunWithYaml.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import SourceKitD
+#else
 import SourceKitD
+#endif
 
 extension SourceKitD {
   /// Parse the request from YAML and execute it.

--- a/Sources/Diagnose/SourceKitDRequestExecutor.swift
+++ b/Sources/Diagnose/SourceKitDRequestExecutor.swift
@@ -10,12 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+import SourceKitD
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+import struct TSCBasic.ProcessResult
+#else
 import Foundation
 import SourceKitD
 
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import struct TSCBasic.ProcessResult
+#endif
 
 /// The different states in which a sourcekitd request can finish.
 package enum SourceKitDRequestResult: Sendable {

--- a/Sources/Diagnose/Toolchain+SwiftFrontend.swift
+++ b/Sources/Diagnose/Toolchain+SwiftFrontend.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+import ToolchainRegistry
+#else
 import Foundation
 import ToolchainRegistry
+#endif
 
 extension Toolchain {
   /// The path to `swift-frontend` in the toolchain, found relative to `swift`.

--- a/Sources/InProcessClient/InProcessSourceKitLSPClient.swift
+++ b/Sources/InProcessClient/InProcessSourceKitLSPClient.swift
@@ -10,6 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import BuildSystemIntegration
+public import LanguageServerProtocol
+public import SKOptions
+import SKSupport
+public import SourceKitLSP
+import SwiftExtensions
+public import ToolchainRegistry
+#else
 import BuildSystemIntegration
 import LanguageServerProtocol
 import SKOptions
@@ -17,6 +26,7 @@ import SKSupport
 import SourceKitLSP
 import SwiftExtensions
 import ToolchainRegistry
+#endif
 
 /// Launches a `SourceKitLSPServer` in-process and allows sending messages to it.
 public final class InProcessSourceKitLSPClient: Sendable {

--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import Foundation
+#else
 import Foundation
+#endif
 
 struct FailedToConstructDocumentURIFromStringError: Error, CustomStringConvertible {
   let string: String

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import Dispatch
+public import Foundation
+public import LanguageServerProtocol
+import SKLogging
+import SwiftExtensions
+#else
 import Dispatch
 import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SwiftExtensions
+#endif
 
 #if canImport(CDispatch)
 import struct CDispatch.dispatch_fd_t

--- a/Sources/LanguageServerProtocolJSONRPC/LoggableMessageTypes.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/LoggableMessageTypes.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+package import LanguageServerProtocol
+package import SKLogging
+#else
 import Foundation
 import LanguageServerProtocol
 import SKLogging
+#endif
 
 // MARK: - RequestType
 

--- a/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 @_spi(Testing) public enum JSONRPCMessage {
   case notification(NotificationType)

--- a/Sources/SKLogging/CustomLogStringConvertible.swift
+++ b/Sources/SKLogging/CustomLogStringConvertible.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Crypto
+package import Foundation
+#else
 import Crypto
 import Foundation
+#endif
 
 /// An object that can printed for logging and also offers a redacted description
 /// when logging in contexts in which private information shouldn't be captured.

--- a/Sources/SKLogging/Logging.swift
+++ b/Sources/SKLogging/Logging.swift
@@ -13,7 +13,11 @@
 import Foundation
 
 #if canImport(os) && !SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER
+#if compiler(>=6)
+package import os  // os_log
+#else
 import os  // os_log
+#endif
 
 package typealias LogLevel = os.OSLogType
 package typealias Logger = os.Logger

--- a/Sources/SKLogging/NonDarwinLogging.swift
+++ b/Sources/SKLogging/NonDarwinLogging.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import SwiftExtensions
+#else
 import SwiftExtensions
+#endif
 
 #if canImport(Darwin)
 import Foundation

--- a/Sources/SKLogging/SetGlobalLogFileHandler.swift
+++ b/Sources/SKLogging/SetGlobalLogFileHandler.swift
@@ -13,10 +13,18 @@
 import RegexBuilder
 
 #if canImport(Darwin)
+#if compiler(>=6)
+package import Foundation
+#else
 import Foundation
+#endif
 #else
 // TODO: @preconcurrency needed because stderr is not sendable on Linux https://github.com/swiftlang/swift/issues/75601
+#if compiler(>=6)
+@preconcurrency package import Foundation
+#else
 @preconcurrency import Foundation
+#endif
 #endif
 
 #if os(Windows)

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -10,12 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import Foundation
+public import LanguageServerProtocol
+public import SKLogging
+public import SKSupport
+
+public import struct TSCBasic.AbsolutePath
+#else
 import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SKSupport
 
 import struct TSCBasic.AbsolutePath
+#endif
 
 /// Options that can be used to modify SourceKit-LSP's behavior.
 ///

--- a/Sources/SKSupport/ByteString.swift
+++ b/Sources/SKSupport/ByteString.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import Foundation
+
+public import struct TSCBasic.ByteString
+#else
 import Foundation
 
 import struct TSCBasic.ByteString
+#endif
 
 extension ByteString {
 

--- a/Sources/SKSupport/Connection+Send.swift
+++ b/Sources/SKSupport/Connection+Send.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+import SwiftExtensions
+#else
 import LanguageServerProtocol
 import SwiftExtensions
+#endif
 
 extension Connection {
   /// Send the given request to the connection and await its result.

--- a/Sources/SKSupport/FileSystem.swift
+++ b/Sources/SKSupport/FileSystem.swift
@@ -13,7 +13,11 @@
 import Foundation
 import SwiftExtensions
 
+#if compiler(>=6)
+package import struct TSCBasic.AbsolutePath
+#else
 import struct TSCBasic.AbsolutePath
+#endif
 
 extension AbsolutePath {
 

--- a/Sources/SKSupport/LocalConnection.swift
+++ b/Sources/SKSupport/LocalConnection.swift
@@ -10,10 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Dispatch
+package import LanguageServerProtocol
+import LanguageServerProtocolJSONRPC
+import SKLogging
+#else
 import Dispatch
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
 import SKLogging
+#endif
 
 /// A connection between two message handlers in the same process.
 ///

--- a/Sources/SKSupport/Process+Run.swift
+++ b/Sources/SKSupport/Process+Run.swift
@@ -14,11 +14,19 @@ import Foundation
 import SKLogging
 import SwiftExtensions
 
+#if compiler(>=6)
+package import struct TSCBasic.AbsolutePath
+package import class TSCBasic.Process
+package import enum TSCBasic.ProcessEnv
+package import struct TSCBasic.ProcessEnvironmentBlock
+package import struct TSCBasic.ProcessResult
+#else
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import enum TSCBasic.ProcessEnv
 import struct TSCBasic.ProcessEnvironmentBlock
 import struct TSCBasic.ProcessResult
+#endif
 
 #if os(Windows)
 import WinSDK

--- a/Sources/SKSupport/RequestAndReply.swift
+++ b/Sources/SKSupport/RequestAndReply.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+import SwiftExtensions
+#else
 import LanguageServerProtocol
 import SwiftExtensions
+#endif
 
 /// A request and a callback that returns the request's reply
 package final class RequestAndReply<Params: RequestType>: Sendable {

--- a/Sources/SKSupport/WorkDoneProgressManager.swift
+++ b/Sources/SKSupport/WorkDoneProgressManager.swift
@@ -10,10 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+package import LanguageServerProtocol
+import SKLogging
+import SwiftExtensions
+#else
 import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SwiftExtensions
+#endif
 
 /// Represents a single `WorkDoneProgress` task that gets communicated with the client.
 ///

--- a/Sources/SKTestSupport/Assertions.swift
+++ b/Sources/SKTestSupport/Assertions.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import XCTest
+#else
 import XCTest
+#endif
 
 /// Same as `XCTAssertNoThrow` but executes the trailing closure.
 package func assertNoThrow<T>(

--- a/Sources/SKTestSupport/DocumentDiagnosticReport+full.swift
+++ b/Sources/SKTestSupport/DocumentDiagnosticReport+full.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 extension DocumentDiagnosticReport {
   /// If this is a full diagnostic report, return it. Otherwise return `nil`.

--- a/Sources/SKTestSupport/FileManager+findFiles.swift
+++ b/Sources/SKTestSupport/FileManager+findFiles.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+#else
 import Foundation
+#endif
 
 extension FileManager {
   /// Returns the URLs of all files with the given file extension in the given directory (recursively).

--- a/Sources/SKTestSupport/FileSystem.swift
+++ b/Sources/SKTestSupport/FileSystem.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import struct TSCBasic.AbsolutePath
+package import struct TSCBasic.ByteString
+package import protocol TSCBasic.FileSystem
+#else
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.ByteString
 import protocol TSCBasic.FileSystem
+#endif
 
 extension FileSystem {
 

--- a/Sources/SKTestSupport/FindTool.swift
+++ b/Sources/SKTestSupport/FindTool.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+
+import class TSCBasic.Process
+#else
 import Foundation
 
 import class TSCBasic.Process
+#endif
 
 #if os(Windows)
 import WinSDK

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -10,6 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+@_spi(Testing) import BuildSystemIntegration
+package import Foundation
+package import LanguageServerProtocol
+import SKOptions
+import SourceKitLSP
+import TSCBasic
+import ToolchainRegistry
+#else
 @_spi(Testing) import BuildSystemIntegration
 import Foundation
 import LanguageServerProtocol
@@ -17,6 +26,7 @@ import SKOptions
 import SourceKitLSP
 import TSCBasic
 import ToolchainRegistry
+#endif
 
 package struct IndexedSingleSwiftFileTestProject {
   enum Error: Swift.Error {

--- a/Sources/SKTestSupport/LocationsOrLocationLinksResponse+Locations.swift
+++ b/Sources/SKTestSupport/LocationsOrLocationLinksResponse+Locations.swift
@@ -10,11 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 extension LocationsOrLocationLinksResponse {
   /// If this is the `locations` case, return the locations, otherwise return `nil`.
-  public var locations: [Location]? {
+  package var locations: [Location]? {
     switch self {
     case .locations(let locations): return locations
     case .locationLinks: return nil

--- a/Sources/SKTestSupport/MultiFileTestProject.swift
+++ b/Sources/SKTestSupport/MultiFileTestProject.swift
@@ -10,10 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+package import LanguageServerProtocol
+package import SKOptions
+package import SourceKitLSP
+#else
 import Foundation
 import LanguageServerProtocol
 import SKOptions
 import SourceKitLSP
+#endif
 
 /// The location of a test file within test workspace.
 package struct RelativeFileLocation: Hashable, ExpressibleByStringLiteral {

--- a/Sources/SKTestSupport/PerfTestCase.swift
+++ b/Sources/SKTestSupport/PerfTestCase.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import XCTest
+#else
 import XCTest
+#endif
 
 /// Base class for a performance test case in SourceKit-LSP.
 ///

--- a/Sources/SKTestSupport/RepeatUntilExpectedResult.swift
+++ b/Sources/SKTestSupport/RepeatUntilExpectedResult.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import XCTest
+#else
 import XCTest
+#endif
 
 /// Runs the body repeatedly once per second until it returns `true`, giving up after `timeout`.
 ///

--- a/Sources/SKTestSupport/SwiftPMDependencyProject.swift
+++ b/Sources/SKTestSupport/SwiftPMDependencyProject.swift
@@ -10,6 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+import SKSupport
+import XCTest
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+import enum TSCBasic.ProcessEnv
+import struct TSCBasic.ProcessResult
+#else
 import Foundation
 import SKSupport
 import XCTest
@@ -18,6 +28,7 @@ import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import enum TSCBasic.ProcessEnv
 import struct TSCBasic.ProcessResult
+#endif
 
 /// A SwiftPM package that gets written to disk and for which a Git repository is initialized with a commit tagged
 /// `1.0.0`. This repository can then be used as a dependency for another package, usually a `SwiftPMTestProject`.

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -10,12 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+package import LanguageServerProtocol
+package import SKOptions
+package import SourceKitLSP
+import TSCBasic
+import ToolchainRegistry
+#else
 import Foundation
 import LanguageServerProtocol
 import SKOptions
 import SourceKitLSP
 import TSCBasic
 import ToolchainRegistry
+#endif
 
 private struct SwiftSyntaxCShimsModulemapNotFoundError: Error {}
 

--- a/Sources/SKTestSupport/TestBundle.swift
+++ b/Sources/SKTestSupport/TestBundle.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+#else
 import Foundation
+#endif
 
 /// The bundle of the currently executing test.
 package let testBundle: Bundle = {

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -10,6 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import InProcessClient
+public import LanguageServerProtocol
+package import LanguageServerProtocolJSONRPC
+package import SKSupport
+import SwiftExtensions
+import XCTest
+
+package import class Foundation.Pipe
+#else
 import InProcessClient
 import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
@@ -18,6 +28,7 @@ import SwiftExtensions
 import XCTest
 
 import class Foundation.Pipe
+#endif
 
 package final class TestJSONRPCConnection: Sendable {
   package let clientToServer: Pipe = Pipe()

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -10,6 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+import InProcessClient
+package import LanguageServerProtocol
+import LanguageServerProtocolJSONRPC
+package import SKOptions
+package import SKSupport
+package import SourceKitLSP
+import SwiftExtensions
+import SwiftSyntax
+import ToolchainRegistry
+import XCTest
+#else
 import Foundation
 import InProcessClient
 import LanguageServerProtocol
@@ -21,6 +34,7 @@ import SwiftExtensions
 import SwiftSyntax
 import ToolchainRegistry
 import XCTest
+#endif
 
 extension SourceKitLSPOptions {
   package static func testDefault(experimentalFeatures: Set<ExperimentalFeature>? = nil) -> SourceKitLSPOptions {

--- a/Sources/SKTestSupport/TextDocumentIdentifier+URI.swift
+++ b/Sources/SKTestSupport/TextDocumentIdentifier+URI.swift
@@ -10,10 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+package import LanguageServerProtocol
+
+import struct TSCBasic.AbsolutePath
+#else
 import Foundation
 import LanguageServerProtocol
 
 import struct TSCBasic.AbsolutePath
+#endif
 
 package extension TextDocumentIdentifier {
   init(_ url: URL) {

--- a/Sources/SKTestSupport/Timeouts.swift
+++ b/Sources/SKTestSupport/Timeouts.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+#else
 import Foundation
+#endif
 
 /// The default duration how long tests should wait for responses from
 /// SourceKit-LSP / sourcekitd / clangd.

--- a/Sources/SKTestSupport/Utils.swift
+++ b/Sources/SKTestSupport/Utils.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+package import LanguageServerProtocol
+package import struct TSCBasic.AbsolutePath
+#else
 import Foundation
 import LanguageServerProtocol
-import TSCBasic
+import struct TSCBasic.AbsolutePath
+#endif
 
 extension Language {
   var fileExtension: String {

--- a/Sources/SKTestSupport/WrappedSemaphore.swift
+++ b/Sources/SKTestSupport/WrappedSemaphore.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Dispatch
+import XCTest
+#else
 import Dispatch
 import XCTest
+#endif
 
 /// Wrapper around `DispatchSemaphore` so that Swift Concurrency doesn't complain about the usage of semaphores in the
 /// tests.

--- a/Sources/SemanticIndex/CheckedIndex.swift
+++ b/Sources/SemanticIndex/CheckedIndex.swift
@@ -10,10 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+@preconcurrency package import IndexStoreDB
+package import LanguageServerProtocol
+import SKLogging
+#else
 import Foundation
 @preconcurrency import IndexStoreDB
 import LanguageServerProtocol
 import SKLogging
+#endif
 
 /// Essentially a `DocumentManager` from the `SourceKitLSP` module.
 ///

--- a/Sources/SemanticIndex/PreparationTaskDescription.swift
+++ b/Sources/SemanticIndex/PreparationTaskDescription.swift
@@ -10,6 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildServerProtocol
+import BuildSystemIntegration
+import Foundation
+import LanguageServerProtocol
+import SKLogging
+import SKSupport
+import SwiftExtensions
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+#else
 import BuildServerProtocol
 import BuildSystemIntegration
 import Foundation
@@ -20,6 +32,7 @@ import SwiftExtensions
 
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
+#endif
 
 private let preparationIDForLogging = AtomicUInt32(initialValue: 1)
 

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -10,12 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildServerProtocol
+package import BuildSystemIntegration
+import Foundation
+package import LanguageServerProtocol
+import SKLogging
+import SwiftExtensions
+#else
 import BuildServerProtocol
 import BuildSystemIntegration
 import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SwiftExtensions
+#endif
 
 /// The logging subsystem that should be used for all index-related logging.
 let indexLoggingSubsystem = "org.swift.sourcekit-lsp.indexing"

--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -10,10 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+package import SKLogging
+import SKSupport
+import SwiftExtensions
+#else
 import Foundation
 import SKLogging
 import SKSupport
 import SwiftExtensions
+#endif
 
 /// See comment on ``TaskDescriptionProtocol/dependencies(to:taskPriority:)``
 package enum TaskDependencyAction<TaskDescription: TaskDescriptionProtocol> {

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -10,6 +10,20 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildServerProtocol
+import BuildSystemIntegration
+import Foundation
+package import LanguageServerProtocol
+import SKLogging
+import SKSupport
+import SwiftExtensions
+import ToolchainRegistry
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+import struct TSCBasic.ProcessResult
+#else
 import BuildServerProtocol
 import BuildSystemIntegration
 import Foundation
@@ -22,6 +36,7 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import struct TSCBasic.ProcessResult
+#endif
 
 private let updateIndexStoreIDForLogging = AtomicUInt32(initialValue: 1)
 

--- a/Sources/SourceKitD/DynamicallyLoadedSourceKitD.swift
+++ b/Sources/SourceKitD/DynamicallyLoadedSourceKitD.swift
@@ -14,7 +14,11 @@ import Foundation
 import SKLogging
 import SwiftExtensions
 
+#if compiler(>=6)
+package import struct TSCBasic.AbsolutePath
+#else
 import struct TSCBasic.AbsolutePath
+#endif
 
 extension sourcekitd_api_keys: @unchecked Sendable {}
 extension sourcekitd_api_requests: @unchecked Sendable {}

--- a/Sources/SourceKitD/SKDRequestArray.swift
+++ b/Sources/SourceKitD/SKDRequestArray.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Csourcekitd
+#else
 import Csourcekitd
+#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/SourceKitD/SKDRequestDictionary.swift
+++ b/Sources/SourceKitD/SKDRequestDictionary.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Csourcekitd
+import SKLogging
+#else
 import Csourcekitd
 import SKLogging
+#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/SourceKitD/SKDResponse.swift
+++ b/Sources/SourceKitD/SKDResponse.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Csourcekitd
+import SKLogging
+#else
 import Csourcekitd
 import SKLogging
+#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Csourcekitd
+#else
 import Csourcekitd
+#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/SourceKitD/SKDResponseDictionary.swift
+++ b/Sources/SourceKitD/SKDResponseDictionary.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Csourcekitd
+#else
 import Csourcekitd
+#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -10,10 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+@_exported public import Csourcekitd
+import Dispatch
+import Foundation
+import SwiftExtensions
+#else
 @_exported import Csourcekitd
 import Dispatch
 import Foundation
 import SwiftExtensions
+#endif
 
 fileprivate struct SourceKitDRequestHandle: Sendable {
   /// `nonisolated(unsafe)` is fine because we just use the handle as an opaque value.

--- a/Sources/SourceKitD/SourceKitDRegistry.swift
+++ b/Sources/SourceKitD/SourceKitDRegistry.swift
@@ -12,7 +12,11 @@
 
 import Foundation
 
+#if compiler(>=6)
+package import struct TSCBasic.AbsolutePath
+#else
 import struct TSCBasic.AbsolutePath
+#endif
 
 /// The set of known SourceKitD instances, uniqued by path.
 ///

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Csourcekitd
+#else
 import Csourcekitd
+#endif
 
 package struct sourcekitd_api_keys {
   /// `key.version_major`

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+import SKLogging
+import SKSupport
+#else
 import LanguageServerProtocol
 import SKLogging
 import SKSupport
+#endif
 
 /// A class which tracks the client's capabilities as well as our dynamic
 /// capability registrations in order to avoid registering conflicting

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -10,12 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Dispatch
+package import LanguageServerProtocol
+import SKLogging
+package import SKSupport
+import SemanticIndex
+package import SwiftSyntax
+#else
 import Dispatch
 import LanguageServerProtocol
 import SKLogging
 import SKSupport
 import SemanticIndex
 import SwiftSyntax
+#endif
 
 /// An immutable snapshot of a document at a given time.
 ///

--- a/Sources/SourceKitLSP/DocumentSnapshot+FromFileContents.swift
+++ b/Sources/SourceKitLSP/DocumentSnapshot+FromFileContents.swift
@@ -10,8 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+package import LanguageServerProtocol
+import SKSupport
+#else
+import Foundation
 import LanguageServerProtocol
 import SKSupport
+#endif
 
 package extension DocumentSnapshot {
   /// Creates a `DocumentSnapshot` with the file contents from disk.

--- a/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
+++ b/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import BuildSystemIntegration
+import Foundation
+package import LanguageServerProtocol
+import SKLogging
+import SemanticIndex
+#else
 import BuildSystemIntegration
 import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SemanticIndex
+#endif
 
 extension UncheckedIndex {
   package func mainFilesContainingFile(_ uri: DocumentURI) -> Set<DocumentURI> {

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+package import LanguageServerProtocol
+package import SKOptions
+package import SwiftSyntax
+package import ToolchainRegistry
+#else
 import Foundation
 import LanguageServerProtocol
 import SKOptions
 import SwiftSyntax
 import ToolchainRegistry
+#endif
 
 /// The state of a `ToolchainLanguageServer`
 package enum LanguageServerState {

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -10,6 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import IndexStoreDB
+package import LanguageServerProtocol
+import SKLogging
+import SKSupport
+import SemanticIndex
+import SourceKitD
+import SwiftSyntax
+#else
 import IndexStoreDB
 import LanguageServerProtocol
 import SKLogging
@@ -17,6 +26,7 @@ import SKSupport
 import SemanticIndex
 import SourceKitD
 import SwiftSyntax
+#endif
 
 // MARK: - Helper types
 

--- a/Sources/SourceKitLSP/SemanticTokensLegend+SourceKitLSPLegend.swift
+++ b/Sources/SourceKitLSP/SemanticTokensLegend+SourceKitLSPLegend.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 extension SemanticTokenTypes {
   // LSP doesn’t know about actors. Display actors as classes.

--- a/Sources/SourceKitLSP/SourceKitLSPCommandMetadata.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPCommandMetadata.swift
@@ -10,10 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+package import LanguageServerProtocol
+import SKLogging
+import SKSupport
+#else
 import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SKSupport
+#endif
 
 /// Represents metadata that SourceKit-LSP injects at every command returned by code actions.
 /// The ExecuteCommand is not a TextDocumentRequest, so metadata is injected to allow SourceKit-LSP

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -10,6 +10,28 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import BuildServerProtocol
+import BuildSystemIntegration
+import Dispatch
+import Foundation
+import IndexStoreDB
+package import LanguageServerProtocol
+import LanguageServerProtocolJSONRPC
+import PackageLoading
+import SKLogging
+package import SKOptions
+import SKSupport
+import SemanticIndex
+import SourceKitD
+import SwiftExtensions
+package import ToolchainRegistry
+
+import struct PackageModel.BuildFlags
+import struct TSCBasic.AbsolutePath
+import protocol TSCBasic.FileSystem
+import var TSCBasic.localFileSystem
+#else
 import BuildServerProtocol
 import BuildSystemIntegration
 import Dispatch
@@ -30,8 +52,7 @@ import struct PackageModel.BuildFlags
 import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.FileSystem
 import var TSCBasic.localFileSystem
-
-package typealias URL = Foundation.URL
+#endif
 
 /// Disambiguate LanguageServerProtocol.Language and IndexstoreDB.Language
 package typealias Language = LanguageServerProtocol.Language

--- a/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
@@ -10,10 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import SwiftBasicFormat
+import SwiftParser
+import SwiftRefactor
+package import SwiftSyntax
+#else
 import SwiftBasicFormat
 import SwiftParser
 import SwiftRefactor
 import SwiftSyntax
+#endif
 
 /// Insert a documentation template associated with a function or macro.
 ///

--- a/Sources/SourceKitLSP/Swift/CodeActions/ConvertJSONToCodableStruct.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/ConvertJSONToCodableStruct.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+import LanguageServerProtocol
+import SwiftBasicFormat
+import SwiftRefactor
+package import SwiftSyntax
+#else
 import Foundation
 import LanguageServerProtocol
 import SwiftBasicFormat
 import SwiftRefactor
 import SwiftSyntax
+#endif
 
 /// Convert JSON literals into corresponding Swift structs that conform to the
 /// `Codable` protocol.

--- a/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import LanguageServerProtocol
 import PackageModel
 import PackageModelSyntax

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+package import LanguageServerProtocol
+import SKLogging
+import SourceKitD
+import SwiftBasicFormat
+#else
 import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SourceKitD
 import SwiftBasicFormat
+#endif
 
 extension SwiftLanguageService {
   package func completion(_ req: CompletionRequest) async throws -> CompletionList {

--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SKSupport
@@ -17,7 +18,6 @@ import SourceKitD
 import SwiftDiagnostics
 
 extension CodeAction {
-
   /// Creates a CodeAction from a list for sourcekit fixits.
   ///
   /// If this is from a note, the note's description should be passed as `fromNote`.

--- a/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
@@ -10,6 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+package import LanguageServerProtocol
+import SKLogging
+import SwiftParser
+import SwiftSyntax
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+import func TSCBasic.withTemporaryFile
+#else
 import Foundation
 import LanguageServerProtocol
 import SKLogging
@@ -19,6 +30,7 @@ import SwiftSyntax
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import func TSCBasic.withTemporaryFile
+#endif
 
 fileprivate extension String {
   init?(bytes: [UInt8], encoding: Encoding) {

--- a/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
@@ -10,10 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+package import LanguageServerProtocol
+import SKLogging
+import SwiftSyntax
+#else
 import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SwiftSyntax
+#endif
 
 extension SwiftLanguageService {
   package func documentSymbol(_ req: DocumentSymbolRequest) async throws -> DocumentSymbolResponse? {

--- a/Sources/SourceKitLSP/Swift/ExpandMacroCommand.swift
+++ b/Sources/SourceKitLSP/Swift/ExpandMacroCommand.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+import SourceKitD
+#else
 import LanguageServerProtocol
 import SourceKitD
+#endif
 
 package struct ExpandMacroCommand: SwiftCommand {
   package static let identifier: String = "expand.macro.command"

--- a/Sources/SourceKitLSP/Swift/FoldingRange.swift
+++ b/Sources/SourceKitLSP/Swift/FoldingRange.swift
@@ -10,10 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+import SKLogging
+import SKSupport
+import SwiftSyntax
+#else
 import LanguageServerProtocol
 import SKLogging
 import SKSupport
 import SwiftSyntax
+#endif
 
 fileprivate final class FoldingRangeFinder: SyntaxAnyVisitor {
   private let snapshot: DocumentSnapshot

--- a/Sources/SourceKitLSP/Swift/MacroExpansionReferenceDocumentURLData.swift
+++ b/Sources/SourceKitLSP/Swift/MacroExpansionReferenceDocumentURLData.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+package import LanguageServerProtocol
+import RegexBuilder
+#else
 import Foundation
 import LanguageServerProtocol
 import RegexBuilder
+#endif
 
 /// Represents url of macro expansion reference document as follows:
 /// `sourcekit-lsp://swift-macro-expansion/LaCb-LcCd.swift?fromLine=&fromColumn=&toLine=&toColumn=&bufferName=&parent=`

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+package import LanguageServerProtocol
+import SKLogging
+import SKSupport
+import SourceKitD
+#else
 import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SKSupport
 import SourceKitD
+#endif
 
 struct GeneratedInterfaceInfo {
   var contents: String

--- a/Sources/SourceKitLSP/Swift/RefactoringEdit.swift
+++ b/Sources/SourceKitLSP/Swift/RefactoringEdit.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+import SourceKitD
+#else
 import LanguageServerProtocol
 import SourceKitD
+#endif
 
 /// Represents an edit from semantic refactor response. Notionally, a subclass of `TextEdit`
 package struct RefactoringEdit: Hashable, Sendable, Codable {

--- a/Sources/SourceKitLSP/Swift/SemanticRefactorCommand.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactorCommand.swift
@@ -10,8 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+import SourceKitD
+#else
 import LanguageServerProtocol
 import SourceKitD
+#endif
 
 package struct SemanticRefactorCommand: SwiftCommand {
   typealias Response = SemanticRefactoring

--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -10,12 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+import SKLogging
+import SourceKitD
+import SwiftIDEUtils
+import SwiftParser
+import SwiftSyntax
+#else
 import LanguageServerProtocol
 import SKLogging
 import SourceKitD
 import SwiftIDEUtils
 import SwiftParser
 import SwiftSyntax
+#endif
 
 extension SwiftLanguageService {
   /// Requests the semantic highlighting tokens for the given snapshot from sourcekitd.

--- a/Sources/SourceKitLSP/Swift/SwiftCommand.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftCommand.swift
@@ -9,7 +9,12 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+
+#if compiler(>=6)
+package import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 /// The set of known Swift commands.
 ///

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -10,6 +10,25 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildSystemIntegration
+import Dispatch
+import Foundation
+import IndexStoreDB
+package import LanguageServerProtocol
+import SKLogging
+package import SKOptions
+import SKSupport
+import SemanticIndex
+package import SourceKitD
+import SwiftExtensions
+import SwiftParser
+import SwiftParserDiagnostics
+package import SwiftSyntax
+package import ToolchainRegistry
+
+import struct TSCBasic.AbsolutePath
+#else
 import BuildSystemIntegration
 import Dispatch
 import Foundation
@@ -27,6 +46,7 @@ import SwiftSyntax
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
+#endif
 
 #if os(Windows)
 import WinSDK

--- a/Sources/SourceKitLSP/Swift/SymbolInfo.swift
+++ b/Sources/SourceKitLSP/Swift/SymbolInfo.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+#else
 import LanguageServerProtocol
+#endif
 
 extension SwiftLanguageService {
   package func symbolInfo(_ req: SymbolInfoRequest) async throws -> [SymbolDetails] {

--- a/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
@@ -10,9 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+import SKLogging
+import SourceKitD
+#else
 import LanguageServerProtocol
 import SKLogging
 import SourceKitD
+#endif
 
 /// A ranged token in the document used for syntax highlighting.
 package struct SyntaxHighlightingToken: Hashable, Sendable {

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -10,11 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import IndexStoreDB
+package import LanguageServerProtocol
+import SKLogging
+import SemanticIndex
+import SwiftSyntax
+#else
 import IndexStoreDB
 import LanguageServerProtocol
 import SKLogging
 import SemanticIndex
 import SwiftSyntax
+#endif
 
 package enum TestStyle {
   package static let xcTest = "XCTest"

--- a/Sources/SourceKitLSP/TestHooks.swift
+++ b/Sources/SourceKitLSP/TestHooks.swift
@@ -10,6 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildSystemIntegration
+import Foundation
+package import LanguageServerProtocol
+import SKSupport
+package import SemanticIndex
+
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.RelativePath
+#else
 import BuildSystemIntegration
 import Foundation
 import LanguageServerProtocol
@@ -18,6 +28,7 @@ import SemanticIndex
 
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
+#endif
 
 /// Closures can be used to inspect or modify internal behavior in SourceKit-LSP.
 public struct TestHooks: Sendable {

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -10,6 +10,21 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import BuildServerProtocol
+package import BuildSystemIntegration
+import IndexStoreDB
+package import LanguageServerProtocol
+import SKLogging
+package import SKOptions
+import SKSupport
+package import SemanticIndex
+import SwiftExtensions
+import ToolchainRegistry
+
+import struct TSCBasic.AbsolutePath
+import struct TSCBasic.RelativePath
+#else
 import BuildServerProtocol
 import BuildSystemIntegration
 import IndexStoreDB
@@ -23,6 +38,7 @@ import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
+#endif
 
 /// Same as `??` but allows the right-hand side of the operator to 'await'.
 fileprivate func firstNonNil<T>(_ optional: T?, _ defaultValue: @autoclosure () async throws -> T) async rethrows -> T {

--- a/Sources/SwiftExtensions/PipeAsStringHandler.swift
+++ b/Sources/SwiftExtensions/PipeAsStringHandler.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import Foundation
+#else
 import Foundation
+#endif
 
 /// Gathers data from a stdout or stderr pipe. When it has accumulated a full line, calls the handler to handle the
 /// string.

--- a/Sources/ToolchainRegistry/Toolchain.swift
+++ b/Sources/ToolchainRegistry/Toolchain.swift
@@ -14,11 +14,19 @@ import RegexBuilder
 import SKLogging
 import SwiftExtensions
 
+#if compiler(>=6)
+import enum PackageLoading.Platform
+public import struct TSCBasic.AbsolutePath
+public import protocol TSCBasic.FileSystem
+public import class TSCBasic.Process
+public import var TSCBasic.localFileSystem
+#else
 import enum PackageLoading.Platform
 import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.FileSystem
 import class TSCBasic.Process
 import var TSCBasic.localFileSystem
+#endif
 
 /// A Swift version consisting of the major and minor component.
 package struct SwiftVersion: Sendable, Comparable, CustomStringConvertible {

--- a/Sources/ToolchainRegistry/ToolchainRegistry.swift
+++ b/Sources/ToolchainRegistry/ToolchainRegistry.swift
@@ -13,6 +13,15 @@
 import Dispatch
 import SKSupport
 
+#if compiler(>=6)
+public import struct TSCBasic.AbsolutePath
+public import protocol TSCBasic.FileSystem
+public import class TSCBasic.Process
+public import enum TSCBasic.ProcessEnv
+public import struct TSCBasic.ProcessEnvironmentKey
+public import func TSCBasic.getEnvSearchPaths
+public import var TSCBasic.localFileSystem
+#else
 import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.FileSystem
 import class TSCBasic.Process
@@ -20,6 +29,7 @@ import enum TSCBasic.ProcessEnv
 import struct TSCBasic.ProcessEnvironmentKey
 import func TSCBasic.getEnvSearchPaths
 import var TSCBasic.localFileSystem
+#endif
 
 /// Set of known toolchains.
 ///

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -10,6 +10,26 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+public import ArgumentParser
+import BuildSystemIntegration
+import Csourcekitd  // Not needed here, but fixes debugging...
+import Diagnose
+import Dispatch
+import Foundation
+import LanguageServerProtocol
+import LanguageServerProtocolJSONRPC
+import SKLogging
+import SKOptions
+import SKSupport
+import SourceKitLSP
+import SwiftExtensions
+import ToolchainRegistry
+
+public import struct TSCBasic.AbsolutePath
+public import struct TSCBasic.RelativePath
+public import var TSCBasic.localFileSystem
+#else
 import ArgumentParser
 import BuildSystemIntegration
 import Csourcekitd  // Not needed here, but fixes debugging...
@@ -28,6 +48,7 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
 import var TSCBasic.localFileSystem
+#endif
 
 extension AbsolutePath {
   public init?(argument: String) {


### PR DESCRIPTION
I didn’t actually audit whether the `public` and `package` imports are necessary. This is just mechanically adding the annotations.