### PR TITLE
Set `isExecuting` to `true` before yielding the execution task

### DIFF
--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -414,7 +414,12 @@ package final actor SemanticIndexManager {
       }
     }
     if let inProgressPrepareForEditorTask {
-      logger.debug("Cancelling preparation of \(inProgressPrepareForEditorTask.document) because \(uri) was opened")
+      // Cancel the in progress prepare for editor task to indicate that we are no longer interested in it.
+      // This will cancel the preparation of `inProgressPrepareForEditorTask`'s target if it hasn't started yet.
+      // (see comment at the end of `SemanticIndexManager.prepare`).
+      logger.debug(
+        "Marking preparation of \(inProgressPrepareForEditorTask.document) as no longer relevant because \(uri) was opened"
+      )
       inProgressPrepareForEditorTask.task.cancel()
     }
     inProgressPrepareForEditorTask = InProgressPrepareForEditorTask(

--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -244,9 +244,9 @@ package actor QueuedTask<TaskDescription: TaskDescriptionProtocol> {
       }
       return await self.finalizeExecution()
     }
+    _isExecuting.value = true
     executionTask = task
     executionTaskCreatedContinuation.yield(task)
-    _isExecuting.value = true
     await executionStateChangedCallback?(self, .executing)
     return await task.value
   }


### PR DESCRIPTION
There was a very brief time when a `QueuedTask` would start executing but `isExecuting` was still sent to `false`. This caused the `preparationTask.isExecuting` check in `SemanticIndexManager.prepare` to fail after we did start preparation, causing the preparation of `LibB` in `testDontStackTargetPreparationForEditorFunctionality` to be cancelled, which wasn’t intended. Thus, the expected preparation tracker got out of sync and the test would fail.

rdar://136570212