### PR TITLE
Specify explicit `self` in `ExternalBuildSystemAdapter`

### DIFF
--- a/Sources/BuildSystemIntegration/ExternalBuildSystemAdapter.swift
+++ b/Sources/BuildSystemIntegration/ExternalBuildSystemAdapter.swift
@@ -170,7 +170,7 @@ actor ExternalBuildSystemAdapter {
         if terminationStatus != 0 {
           Task {
             await orLog("Restarting BSP server") {
-              try await handleBspServerCrash()
+              try await self.handleBspServerCrash()
             }
           }
         }


### PR DESCRIPTION
I’m not entirely sure why but the file fails to compile with multiple arches without the `self`.