### PR TITLE
Explicitly shut down the build server when SourceKit-LSP is shut down

### DIFF
--- a/Sources/BuildSystemIntegration/ExternalBuildSystemAdapter.swift
+++ b/Sources/BuildSystemIntegration/ExternalBuildSystemAdapter.swift
@@ -118,7 +118,7 @@ actor ExternalBuildSystemAdapter {
   }
 
   /// Send a notification to the build server.
-  func send(_ notification: some NotificationType) async {
+  func send(_ notification: some NotificationType) {
     guard let connectionToBuildServer else {
       logger.error("Dropping notification because BSP server has crashed: \(notification.forLogging)")
       return

--- a/Sources/SKTestSupport/INPUTS/AbstractBuildServer.py
+++ b/Sources/SKTestSupport/INPUTS/AbstractBuildServer.py
@@ -38,7 +38,7 @@ class AbstractBuildServer:
 
             try:
                 result = self.handle_message(message)
-                if result:
+                if result is not None:
                     response_message: Dict[str, object] = {
                         "jsonrpc": "2.0",
                         "id": message["id"],
@@ -139,8 +139,8 @@ class AbstractBuildServer:
             code=-32601, message=f"'textDocument/sourceKitOptions' not implemented"
         )
 
-    def shutdown(self, notification: Dict[str, object]) -> None:
-        pass
+    def shutdown(self, request: Dict[str, object]) -> Dict[str, object]:
+        return {}
 
     def buildtarget_sources(self, request: Dict[str, object]) -> Dict[str, object]:
         raise RequestError(

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1241,6 +1241,16 @@ extension SourceKitLSPServer {
           await service.shutdown()
         }
       }
+      for workspace in workspaces {
+        taskGroup.addTask {
+          await orLog("Shutting down build server") {
+            // If the build server doesn't shut down in 1 second, don't delay SourceKit-LSP's shutdown because of it.
+            try await withTimeout(.seconds(2)) {
+              await workspace.buildSystemManager.shutdown()
+            }
+          }
+        }
+      }
     }
 
     // We have a semantic guarantee that no request or notification should be


### PR DESCRIPTION
The build server is automatically shut down using a background task when `BuildSystemManager` is deallocated.

This, however, leads to possible race conditions where the shutdown task might not finish before the test is done, which could result in the connection being reported as a leak. To avoid this problem, we want to explicitly shut, down the build server when the `SourceKitLSPServer` gets shut down.