### PR TITLE
In `withTaskPriorityChangedHandler` execute the task that watches for priority changes with high priority

### DIFF
--- a/Sources/SwiftExtensions/Task+WithPriorityChangedHandler.swift
+++ b/Sources/SwiftExtensions/Task+WithPriorityChangedHandler.swift
@@ -24,7 +24,10 @@ package func withTaskPriorityChangedHandler<T: Sendable>(
 ) async throws -> T {
   let lastPriority = ThreadSafeBox(initialValue: initialPriority)
   let result: T? = try await withThrowingTaskGroup(of: Optional<T>.self) { taskGroup in
-    taskGroup.addTask {
+    // Run the task priority watcher with high priority instead of inheriting the initial priority. Otherwise a
+    // `.background` task might not get its priority elevated because the priority watching task also runs at
+    // `.background` priority and might not actually get executed in time.
+    taskGroup.addTask(priority: .high) {
       while true {
         if Task.isCancelled {
           break

--- a/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
@@ -299,7 +299,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
     XCTAssertEqual(diagnosticsBeforeCrash.fullReport?.items, [])
     try FileManager.default.removeItem(at: project.scratchDirectory.appendingPathComponent("should_crash"))
 
-    try await repeatUntilExpectedResult(timeout: 20) {
+    try await repeatUntilExpectedResult(timeout: .seconds(20)) {
       let diagnostics = try await project.testClient.send(
         DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
       )

--- a/Tests/SKSupportTests/AsyncUtilsTests.swift
+++ b/Tests/SKSupportTests/AsyncUtilsTests.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SKLogging
 import SKSupport
 import SKTestSupport
 import SwiftExtensions
@@ -46,7 +47,8 @@ final class AsyncUtilsTests: XCTestCase {
       // We don't actually hit the timeout. It's just a large value.
       try await withTimeout(.seconds(defaultTimeout * 2)) {
         expectation.fulfill()
-        try await repeatUntilExpectedResult {
+        try await repeatUntilExpectedResult(sleepInterval: .seconds(0.1)) {
+          logger.debug("Current priority: \(Task.currentPriority.rawValue)")
           return Task.currentPriority > .background
         }
       }


### PR DESCRIPTION
I saw a nondeterministic test failure of `AsyncUtilsTests.testWithTimeoutEscalatesPriority` and I believe this was the cause.

Also refactor a few test helper functions on the way.