### PR TITLE
Yield `TimeoutError` before cancelling body task in `withTimeout`

### DIFF
--- a/Sources/SKTestSupport/RepeatUntilExpectedResult.swift
+++ b/Sources/SKTestSupport/RepeatUntilExpectedResult.swift
@@ -26,7 +26,6 @@ package func repeatUntilExpectedResult(
   file: StaticString = #filePath,
   line: UInt = #line
 ) async throws {
-  logger.info("x: \(Int(timeout.seconds / sleepInterval.seconds))")
   for _ in 0..<Int(timeout.seconds / sleepInterval.seconds) {
     if try await body() {
       return

--- a/Sources/SwiftExtensions/AsyncUtils.swift
+++ b/Sources/SwiftExtensions/AsyncUtils.swift
@@ -189,8 +189,8 @@ package func withTimeout<T: Sendable>(
 
     let timeoutTask = Task {
       try await Task.sleep(for: duration)
-      bodyTask.cancel()
       continuation.yield(with: .failure(TimeoutError()))
+      bodyTask.cancel()
     }
     mutableTasks = [bodyTask, timeoutTask]
   }


### PR DESCRIPTION
Otherwise, the body task might finish before we yield the `TimeoutError` and thus `withTimeout` would not actually throw a `TimeoutError`.

rdar://137171114