### PR TITLE
Use the test’s default timeout duration for sourcekitd timeouts

### DIFF
--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -130,6 +130,9 @@ package final class TestSourceKitLSPClient: MessageHandler, Sendable {
         (options.swiftPMOrDefault.swiftCompilerFlags ?? []) + ["-module-cache-path", globalModuleCache.path]
     }
     options.backgroundIndexing = enableBackgroundIndexing
+    if options.sourcekitdRequestTimeout == nil {
+      options.sourcekitdRequestTimeout = defaultTimeout
+    }
 
     var notificationYielder: AsyncStream<any NotificationType>.Continuation!
     self.notifications = AsyncStream { continuation in


### PR DESCRIPTION
Otherwise, we are stuck with the timeout default of 120s and the test runner can’t increase it.