### PR TITLE
Allow running tests on Windows by using `SWIFTSYNTAX_BUILD_DYNAMIC_LIBRARY`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,16 +38,20 @@ $ swift build -Xcxx -I/usr/lib/swift -Xcxx -I/usr/lib/swift/Block
 
 ### Windows
 
-You must provide the following dependencies for SourceKit-LSP:
-- SQLite3 ninja
+To build SourceKit-LSP on Windows, the swift-syntax libraries need to be built as dynamic libraries so we do not exceed the maximum symbol limit in a single binary. Additionally, the equivalent search paths to the linux build need to be passed. Run the following in Command Prompt.
 
 ```cmd
-> swift build -Xcc -I<absolute path to SQLite header search path> -Xlinker -L<absolute path to SQLite library search path> -Xcc -I%SDKROOT%\usr\include -Xcc -I%SDKROOT%\usr\include\Block
+> set SWIFTSYNTAX_BUILD_DYNAMIC_LIBRARY=1
+> swift build -Xcc -I%SDKROOT%\usr\include -Xcc -I%SDKROOT%\usr\include\Block
 ```
 
-The header and library search paths must be passed to the build by absolute path. This allows the clang importer and linker to find the dependencies.
+To work on SourceKit-LSP in VS Code, add the following to your `settings.json`, for other editors ensure that the `SWIFTSYNTAX_BUILD_DYNAMIC_LIBRARY` environment variable is set when launching `sourcekit-lsp`.
 
-Additionally, as SourceKit-LSP depends on libdispatch and the Blocks runtime, which are part of the SDK, but not in the default search path, need to be explicitly added.
+```json
+"swift.swiftEnvironmentVariables": {
+  "SWIFTSYNTAX_BUILD_DYNAMIC_LIBRARY": "1"
+},
+```
 
 ### Devcontainer
 

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -17,6 +17,10 @@ import SourceKitLSP
 import SwiftExtensions
 import XCTest
 
+#if os(Windows)
+import WinSDK
+#endif
+
 final class PullDiagnosticsTests: XCTestCase {
   func testUnknownIdentifierDiagnostic() async throws {
     let testClient = try await TestSourceKitLSPClient()
@@ -309,7 +313,11 @@ final class PullDiagnosticsTests: XCTestCase {
         if Task.isCancelled {
           break
         }
-        usleep(10_000)
+        #if os(Windows)
+        Sleep(10 /*ms*/)
+        #else
+        usleep(10_000 /*µs*/)
+        #endif
       }
     }
     let project = try await SwiftPMTestProject(

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -34,7 +34,7 @@ final class SwiftInterfaceTests: XCTestCase {
       )
     )
     let location = try XCTUnwrap(resp?.locations?.only)
-    XCTAssertTrue(location.uri.pseudoPath.hasSuffix("/Foundation.swiftinterface"))
+    XCTAssertTrue(location.uri.pseudoPath.hasSuffix("Foundation.swiftinterface"))
     let fileContents = try XCTUnwrap(location.uri.fileURL.flatMap({ try String(contentsOf: $0, encoding: .utf8) }))
     // Sanity-check that the generated Swift Interface contains Swift code
     XCTAssert(


### PR DESCRIPTION
Also, fix two minor Windows test failures.