### PR TITLE
Reduce the debounce duration to publish diagnostics to 1s

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -47,4 +47,4 @@ The structure of the file is currently not guaranteed to be stable. Options may 
 - `backgroundPreparationMode: "build"|"noLazy"|"enabled"`: Determines how background indexing should prepare a target. Possible values are: `build`: Build a target to prepare it, `noLazy`: Prepare a target without generating object files but do not do lazy type checking and function body skipping, `enabled`: Prepare a target without generating object files and the like
 - `cancelTextDocumentRequestsOnEditAndClose: bool`: Whether sending a `textDocument/didChange` or `textDocument/didClose` notification for a document should cancel all pending requests for that document.
 - `experimentalFeatures: string[]`: Experimental features to enable
-- `swiftPublishDiagnosticsDebounce`: The time that `SwiftLanguageService` should wait after an edit before starting to compute diagnostics and sending a `PublishDiagnosticsNotification`.
+- `swiftPublishDiagnosticsDebounce: double`: The time that `SwiftLanguageService` should wait after an edit before starting to compute diagnostics and sending a `PublishDiagnosticsNotification`.

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -297,16 +297,13 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
 
   /// The time that `SwiftLanguageService` should wait after an edit before starting to compute diagnostics and
   /// sending a `PublishDiagnosticsNotification`.
-  ///
-  /// This is mostly intended for testing purposes so we don't need to wait the debouncing time to get a diagnostics
-  /// notification when running unit tests.
   public var swiftPublishDiagnosticsDebounceDuration: Double? = nil
 
   public var swiftPublishDiagnosticsDebounceDurationOrDefault: Duration {
     if let swiftPublishDiagnosticsDebounceDuration {
       return .seconds(swiftPublishDiagnosticsDebounceDuration)
     }
-    return .seconds(2)
+    return .seconds(1)
   }
 
   /// When a task is started that should be displayed to the client as a work done progress, how many milliseconds to


### PR DESCRIPTION
We received two feedbacks that the 2s timeout is too long. 2s was a somewhat arbitrary choice, let’s reduce it to 1s.

Fixes #1753