### PR TITLE
Disable flaky tests on Windows

### DIFF
--- a/Sources/SKTestSupport/FindTool.swift
+++ b/Sources/SKTestSupport/FindTool.swift
@@ -31,7 +31,7 @@ package func findTool(name: String) async -> URL? {
   #elseif os(Windows)
   var buf = [WCHAR](repeating: 0, count: Int(MAX_PATH))
   GetWindowsDirectoryW(&buf, DWORD(MAX_PATH))
-  var wherePath = String(decodingCString: &buf, as: UTF16.self)
+  let wherePath = String(decodingCString: &buf, as: UTF16.self)
     .appendingPathComponent("system32")
     .appendingPathComponent("where.exe")
   let cmd = [wherePath, name]

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -17,6 +17,7 @@ package import SKOptions
 package import SourceKitLSP
 import TSCBasic
 import ToolchainRegistry
+import XCTest
 #else
 import Foundation
 import LanguageServerProtocol
@@ -24,6 +25,7 @@ import SKOptions
 import SourceKitLSP
 import TSCBasic
 import ToolchainRegistry
+import XCTest
 #endif
 
 private struct SwiftSyntaxCShimsModulemapNotFoundError: Error {}
@@ -171,6 +173,13 @@ package class SwiftPMTestProject: MultiFileTestProject {
     cleanUp: (@Sendable () -> Void)? = nil,
     testName: String = #function
   ) async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
     var filesByPath: [RelativeFileLocation: String] = [:]
     for (fileLocation, contents) in files {
       let directories =

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -535,6 +535,14 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testPrepareTargetAfterEditToDependency() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
+
     var testHooks = TestHooks()
     let expectedPreparationTracker = ExpectedIndexTaskTracker(expectedPreparations: [
       [
@@ -634,6 +642,14 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testDontStackTargetPreparationForEditorFunctionality() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
+
     let allDocumentsOpened = WrappedSemaphore(name: "All documents opened")
     let libBStartedPreparation = WrappedSemaphore(name: "LibB started preparing")
     let libDPreparedForEditing = WrappedSemaphore(name: "LibD prepared for editing")
@@ -765,6 +781,14 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testIndexingHappensInParallel() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
+
     let fileAIndexingStarted = WrappedSemaphore(name: "FileA indexing started")
     let fileBIndexingStarted = WrappedSemaphore(name: "FileB indexing started")
 

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -300,6 +300,14 @@ final class PullDiagnosticsTests: XCTestCase {
   }
 
   func testDontReturnEmptyDiagnosticsIfDiagnosticRequestIsCancelled() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
+
     let diagnosticRequestCancelled = self.expectation(description: "diagnostic request cancelled")
     let packageLoadingDidFinish = self.expectation(description: "Package loading did finish")
     var testHooks = TestHooks()

--- a/Tests/SourceKitLSPTests/ReferencesTests.swift
+++ b/Tests/SourceKitLSPTests/ReferencesTests.swift
@@ -17,6 +17,10 @@ import XCTest
 /// Tests that test the overall state of the SourceKit-LSP server, that's not really specific to any language
 final class ReferencesTests: XCTestCase {
   func testReferencesInMacro() async throws {
+    #if os(Windows)
+    // FIXME: https://github.com/swiftlang/sourcekit-lsp/issues/1758
+    try XCTSkipIf(true, "Disabled until https://github.com/swiftlang/sourcekit-lsp/issues/1758 is fixed")
+    #endif
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       import Observation

--- a/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
@@ -185,6 +185,13 @@ final class SwiftPMIntegrationTests: XCTestCase {
   }
 
   func testNestedPackage() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
     let project = try await MultiFileTestProject(files: [
       "pkg/Sources/lib/lib.swift": "",
       "pkg/Package.swift": """

--- a/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
@@ -16,6 +16,13 @@ import XCTest
 
 class WorkspaceSymbolsTests: XCTestCase {
   func testWorkspaceSymbolsAcrossPackages() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
     let project = try await MultiFileTestProject(
       files: [
         "packageA/Sources/PackageALib/PackageALib.swift": """

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -23,6 +23,13 @@ import XCTest
 final class WorkspaceTests: XCTestCase {
 
   func testMultipleSwiftPMWorkspaces() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
     // The package manifest is the same for both packages we open.
     let packageManifest = """
       // swift-tools-version: 5.7
@@ -159,6 +166,13 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testOpenPackageManifestInMultiSwiftPMWorkspaceSetup() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
     let project = try await MultiFileTestProject(
       files: [
         // PackageA
@@ -235,6 +249,13 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testSwiftPMPackageInSubfolder() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
     let packageManifest = """
       // swift-tools-version: 5.7
 
@@ -314,6 +335,13 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testNestedSwiftPMWorkspacesWithoutDedicatedWorkspaceFolder() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
     // The package manifest is the same for both packages we open.
     let packageManifest = """
       // swift-tools-version: 5.7
@@ -496,6 +524,13 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testRecomputeFileWorkspaceMembershipOnPackageSwiftChange() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
     let project = try await MultiFileTestProject(
       files: [
         "PackageA/Sources/MyLibrary/libA.swift": "",
@@ -625,6 +660,13 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testChangeWorkspaceFolders() async throws {
+    #if os(Windows)
+    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
+    try XCTSkipIf(
+      true,
+      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
+    )
+    #endif
     let project = try await MultiFileTestProject(
       files: [
         "subdir/Sources/otherPackage/otherPackage.swift": """


### PR DESCRIPTION
The goal for now is to get to a state where Windows tests are passing. Once we have that, we can start enabling tests again as we fix their underlying issues.