### PR TITLE
Make `logHandler` print to stdout instead of stderr

### DIFF
--- a/Sources/SKLogging/NonDarwinLogging.swift
+++ b/Sources/SKLogging/NonDarwinLogging.swift
@@ -281,7 +281,12 @@ actor LogHandlerActor {
 
 /// The handler that is called to log a message from `NonDarwinLogger` unless `overrideLogHandler` is set on the logger.
 @LogHandlerActor
-var logHandler: @Sendable (String) async -> Void = { fputs($0 + "\n", stderr) }
+var logHandler: @Sendable (String) async -> Void = { message in
+  // Print to stdout. When using the sourcekit-lsp binary, we will have stdout redirected to stderr, so it ends up
+  // logging to stderr. During test execution, we log to stdout, which is generally better handled than logging to
+  // stderr by XCTest (for some reason logging to stderr will hang test execution when running tests in parallel).
+  print(message + "\n")
+}
 
 /// The queue on which we log messages.
 ///


### PR DESCRIPTION
For some reason, logging to `stderr` makes test execution hang on Windows when running tests in parallel – it appears that stdout and stderr are handled the same way but there must be some difference, I wasn’t able to reduce the issue.

When running the sourcekit-lsp binary, stdout gets redirected to stderr, so logging printing to stdout ends up with the same result as `fputs` to `stderr`.