### PR TITLE
Use fallback build settings if build system doesn’t provide build settings within a timeout

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -31,6 +31,7 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `cxxCompilerFlags: string[]`: Extra arguments passed to the compiler for C++ files
   - `swiftCompilerFlags: string[]`: Extra arguments passed to the compiler for Swift files
   - `sdk: string`: The SDK to use for fallback arguments. Default is to infer the SDK using `xcrun`.
+- `buildSettingsTimeout: int`: Number of milliseconds to wait for build settings from the build system before using fallback build settings.
 - `clangdOptions: string[]`: Extra command line arguments passed to `clangd` when launching it
 - `index`: Dictionary with the following keys, defining options related to indexing
     - `indexStorePath: string`: Directory in which a separate compilation stores the index store. By default, inferred from the build system.

--- a/Sources/BuildSystemIntegration/BuildSystemTestHooks.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemTestHooks.swift
@@ -10,10 +10,25 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+package import LanguageServerProtocol
+#else
+import LanguageServerProtocol
+#endif
+
 package struct BuildSystemTestHooks: Sendable {
   package var swiftPMTestHooks: SwiftPMTestHooks
 
-  package init(swiftPMTestHooks: SwiftPMTestHooks = SwiftPMTestHooks()) {
+  /// A hook that will be executed before a request is handled by a `BuiltInBuildSystem`.
+  ///
+  /// This allows requests to be artificially delayed.
+  package var handleRequest: (@Sendable (any RequestType) async -> Void)?
+
+  package init(
+    swiftPMTestHooks: SwiftPMTestHooks = SwiftPMTestHooks(),
+    handleRequest: (@Sendable (any RequestType) async -> Void)? = nil
+  ) {
     self.swiftPMTestHooks = swiftPMTestHooks
+    self.handleRequest = handleRequest
   }
 }

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
@@ -59,6 +59,8 @@ actor BuiltInBuildSystemAdapter: QueueBasedMessageHandler {
   /// The connection with which messages are sent to `BuildSystemManager`.
   private let connectionToSourceKitLSP: LocalConnection
 
+  private let buildSystemTestHooks: BuildSystemTestHooks
+
   /// If the underlying build system is a `TestBuildSystem`, return it. Otherwise, `nil`
   ///
   /// - Important: For testing purposes only.
@@ -70,10 +72,12 @@ actor BuiltInBuildSystemAdapter: QueueBasedMessageHandler {
   /// from the build system to SourceKit-LSP.
   init(
     underlyingBuildSystem: BuiltInBuildSystem,
-    connectionToSourceKitLSP: LocalConnection
+    connectionToSourceKitLSP: LocalConnection,
+    buildSystemTestHooks: BuildSystemTestHooks
   ) {
     self.underlyingBuildSystem = underlyingBuildSystem
     self.connectionToSourceKitLSP = connectionToSourceKitLSP
+    self.buildSystemTestHooks = buildSystemTestHooks
   }
 
   deinit {
@@ -116,6 +120,7 @@ actor BuiltInBuildSystemAdapter: QueueBasedMessageHandler {
     reply: @Sendable @escaping (LSPResult<Request.Response>) -> Void
   ) async {
     let request = RequestAndReply(request, reply: reply)
+    await buildSystemTestHooks.handleRequest?(request.params)
     switch request {
     case let request as RequestAndReply<BuildShutdownRequest>:
       await request.reply { VoidResponse() }

--- a/Sources/BuildSystemIntegration/CMakeLists.txt
+++ b/Sources/BuildSystemIntegration/CMakeLists.txt
@@ -14,7 +14,6 @@ add_library(BuildSystemIntegration STATIC
   ExternalBuildSystemAdapter.swift
   FallbackBuildSettings.swift
   FileBuildSettings.swift
-  Language+InferredFromFileExtension.swift
   LegacyBuildServerBuildSystem.swift
   MainFilesProvider.swift
   PathPrefixMapping.swift

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -250,6 +250,13 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     set { fallbackBuildSystem = newValue }
   }
 
+  /// Number of milliseconds to wait for build settings from the build system before using fallback build settings.
+  public var buildSettingsTimeout: Int?
+  public var buildSettingsTimeoutOrDefault: Duration {
+    // The default timeout of 500ms was chosen arbitrarily without any measurements.
+    get { .milliseconds(buildSettingsTimeout ?? 500) }
+  }
+
   public var clangdOptions: [String]?
 
   private var index: IndexOptions?

--- a/Sources/SKSupport/CMakeLists.txt
+++ b/Sources/SKSupport/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(SKSupport STATIC
   DocumentURI+CustomLogStringConvertible.swift
   DocumentURI+symlinkTarget.swift
   FileSystem.swift
+  Language+InferredFromFileExtension.swift
   LineTable.swift
   LocalConnection.swift
   Process+Run.swift

--- a/Sources/SKSupport/Language+InferredFromFileExtension.swift
+++ b/Sources/SKSupport/Language+InferredFromFileExtension.swift
@@ -10,11 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
+import Foundation
+package import LanguageServerProtocol
+#else
 import Foundation
 import LanguageServerProtocol
+#endif
 
 extension Language {
-  init?(inferredFromFileExtension uri: DocumentURI) {
+  package init?(inferredFromFileExtension uri: DocumentURI) {
     // URL.pathExtension is only set for file URLs but we want to also infer a file extension for non-file URLs like
     // untitled:file.cpp
     let pathExtension = uri.fileURL?.pathExtension ?? (uri.pseudoPath as NSString).pathExtension

--- a/Sources/SKTestSupport/WrappedSemaphore.swift
+++ b/Sources/SKTestSupport/WrappedSemaphore.swift
@@ -56,12 +56,16 @@ package struct WrappedSemaphore: Sendable {
   }
 
   /// Wait for a signal and emit an XCTFail if the semaphore is not signaled within `timeout`.
-  package func waitOrXCTFail(timeout: DispatchTime = DispatchTime.now() + .seconds(Int(defaultTimeout))) {
+  package func waitOrXCTFail(
+    timeout: DispatchTime = DispatchTime.now() + .seconds(Int(defaultTimeout)),
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) {
     switch self.wait(timeout: timeout) {
     case .success:
       break
     case .timedOut:
-      XCTFail("\(name) timed out")
+      XCTFail("\(name) timed out", file: file, line: line)
     }
   }
 }

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -254,7 +254,12 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       logger.error("Not indexing \(file.forLogging) because its language could not be determined")
       return
     }
-    let buildSettings = await buildSystemManager.buildSettings(for: file.mainFile, in: target, language: language)
+    let buildSettings = await buildSystemManager.buildSettings(
+      for: file.mainFile,
+      in: target,
+      language: language,
+      fallbackAfterTimeout: false
+    )
     guard let buildSettings else {
       logger.error("Not indexing \(file.forLogging) because it has no compiler arguments")
       return

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -364,7 +364,8 @@ extension SwiftLanguageService {
     let req = sourcekitd.dictionary([
       keys.request: sourcekitd.requests.nameTranslation,
       keys.sourceFile: snapshot.uri.pseudoPath,
-      keys.compilerArgs: await self.buildSettings(for: snapshot.uri)?.compilerArgs as [SKDRequestValue]?,
+      keys.compilerArgs: await self.buildSettings(for: snapshot.uri, fallbackAfterTimeout: false)?.compilerArgs
+        as [SKDRequestValue]?,
       keys.offset: snapshot.utf8Offset(of: snapshot.position(of: symbolLocation)),
       keys.nameKind: sourcekitd.values.nameSwift,
       keys.baseName: name.baseName,
@@ -415,7 +416,8 @@ extension SwiftLanguageService {
     let req = sourcekitd.dictionary([
       keys.request: sourcekitd.requests.nameTranslation,
       keys.sourceFile: snapshot.uri.pseudoPath,
-      keys.compilerArgs: await self.buildSettings(for: snapshot.uri)?.compilerArgs as [SKDRequestValue]?,
+      keys.compilerArgs: await self.buildSettings(for: snapshot.uri, fallbackAfterTimeout: false)?.compilerArgs
+        as [SKDRequestValue]?,
       keys.offset: snapshot.utf8Offset(of: snapshot.position(of: symbolLocation)),
       keys.nameKind: sourcekitd.values.nameObjc,
     ])

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -34,7 +34,7 @@ extension SwiftLanguageService {
 
     let clientSupportsSnippets =
       capabilityRegistry.clientCapabilities.textDocument?.completion?.completionItem?.snippetSupport ?? false
-    let buildSettings = await buildSettings(for: snapshot.uri)
+    let buildSettings = await buildSettings(for: snapshot.uri, fallbackAfterTimeout: false)
 
     let inferredIndentationWidth = BasicFormat.inferIndentation(of: await syntaxTreeManager.syntaxTree(for: snapshot))
 

--- a/Sources/SourceKitLSP/Swift/CursorInfo.swift
+++ b/Sources/SourceKitLSP/Swift/CursorInfo.swift
@@ -141,10 +141,12 @@ extension SwiftLanguageService {
   /// - Parameters:
   ///   - url: Document URI in which to perform the request. Must be an open document.
   ///   - range: The position range within the document to lookup the symbol at.
-  ///   - completion: Completion block to asynchronously receive the CursorInfo, or error.
+  ///   - fallbackSettingsAfterTimeout: Whether fallback build settings should be used for the cursor info request if no
+  ///     build settings can be retrieved within a timeout.
   func cursorInfo(
     _ uri: DocumentURI,
     _ range: Range<Position>,
+    fallbackSettingsAfterTimeout: Bool,
     additionalParameters appendAdditionalParameters: ((SKDRequestDictionary) -> Void)? = nil
   ) async throws -> (cursorInfo: [CursorInfo], refactorActions: [SemanticRefactorCommand]) {
     let documentManager = try self.documentManager
@@ -161,7 +163,8 @@ extension SwiftLanguageService {
       keys.length: offsetRange.upperBound != offsetRange.lowerBound ? offsetRange.count : nil,
       keys.sourceFile: snapshot.uri.sourcekitdSourceFile,
       keys.primaryFile: snapshot.uri.primaryFile?.pseudoPath,
-      keys.compilerArgs: await self.buildSettings(for: uri)?.compilerArgs as [SKDRequestValue]?,
+      keys.compilerArgs: await self.buildSettings(for: uri, fallbackAfterTimeout: fallbackSettingsAfterTimeout)?
+        .compilerArgs as [SKDRequestValue]?,
     ])
 
     appendAdditionalParameters?(skreq)

--- a/Sources/SourceKitLSP/Swift/MacroExpansion.swift
+++ b/Sources/SourceKitLSP/Swift/MacroExpansion.swift
@@ -86,7 +86,7 @@ actor MacroExpansionManager {
     }
 
     let snapshot = try await swiftLanguageService.latestSnapshot(for: uri)
-    let buildSettings = await swiftLanguageService.buildSettings(for: uri)
+    let buildSettings = await swiftLanguageService.buildSettings(for: uri, fallbackAfterTimeout: false)
 
     if let cacheEntry = cache.first(where: {
       $0.snapshotID == snapshot.id && $0.range == range && $0.buildSettings == buildSettings

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -100,7 +100,8 @@ extension SwiftLanguageService {
       keys.groupName: groupName,
       keys.name: interfaceURI.pseudoPath,
       keys.synthesizedExtension: 1,
-      keys.compilerArgs: await self.buildSettings(for: document)?.compilerArgs as [SKDRequestValue]?,
+      keys.compilerArgs: await self.buildSettings(for: document, fallbackAfterTimeout: false)?.compilerArgs
+        as [SKDRequestValue]?,
     ])
 
     let dict = try await sendSourcekitdRequest(skreq, fileContents: nil)

--- a/Sources/SourceKitLSP/Swift/RefactoringResponse.swift
+++ b/Sources/SourceKitLSP/Swift/RefactoringResponse.swift
@@ -126,7 +126,8 @@ extension SwiftLanguageService {
       keys.column: utf8Column + 1,
       keys.length: snapshot.utf8OffsetRange(of: refactorCommand.positionRange).count,
       keys.actionUID: self.sourcekitd.api.uid_get_from_cstr(refactorCommand.actionString)!,
-      keys.compilerArgs: await self.buildSettings(for: snapshot.uri)?.compilerArgs as [SKDRequestValue]?,
+      keys.compilerArgs: await self.buildSettings(for: snapshot.uri, fallbackAfterTimeout: true)?.compilerArgs
+        as [SKDRequestValue]?,
     ])
 
     let dict = try await sendSourcekitdRequest(skreq, fileContents: snapshot.text)

--- a/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
+++ b/Sources/SourceKitLSP/Swift/RelatedIdentifiers.swift
@@ -73,7 +73,8 @@ extension SwiftLanguageService {
       keys.sourceFile: snapshot.uri.sourcekitdSourceFile,
       keys.primaryFile: snapshot.uri.primaryFile?.pseudoPath,
       keys.includeNonEditableBaseNames: includeNonEditableBaseNames ? 1 : 0,
-      keys.compilerArgs: await self.buildSettings(for: snapshot.uri)?.compilerArgs as [SKDRequestValue]?,
+      keys.compilerArgs: await self.buildSettings(for: snapshot.uri, fallbackAfterTimeout: true)?.compilerArgs
+        as [SKDRequestValue]?,
     ])
 
     let dict = try await sendSourcekitdRequest(skreq, fileContents: snapshot.text)

--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -29,7 +29,9 @@ import SwiftSyntax
 extension SwiftLanguageService {
   /// Requests the semantic highlighting tokens for the given snapshot from sourcekitd.
   private func semanticHighlightingTokens(for snapshot: DocumentSnapshot) async throws -> SyntaxHighlightingTokens? {
-    guard let buildSettings = await self.buildSettings(for: snapshot.uri), !buildSettings.isFallback else {
+    guard let buildSettings = await self.buildSettings(for: snapshot.uri, fallbackAfterTimeout: false),
+      !buildSettings.isFallback
+    else {
       return nil
     }
 

--- a/Sources/SourceKitLSP/Swift/SymbolInfo.swift
+++ b/Sources/SourceKitLSP/Swift/SymbolInfo.swift
@@ -21,6 +21,7 @@ extension SwiftLanguageService {
     let uri = req.textDocument.uri
     let snapshot = try documentManager.latestSnapshot(uri)
     let position = await self.adjustPositionToStartOfIdentifier(req.position, in: snapshot)
-    return try await cursorInfo(uri, position..<position).cursorInfo.map { $0.symbolInfo }
+    return try await cursorInfo(uri, position..<position, fallbackSettingsAfterTimeout: false)
+      .cursorInfo.map { $0.symbolInfo }
   }
 }

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -89,7 +89,8 @@ extension SwiftLanguageService {
       keys.request: requests.collectVariableType,
       keys.sourceFile: snapshot.uri.sourcekitdSourceFile,
       keys.primaryFile: snapshot.uri.primaryFile?.pseudoPath,
-      keys.compilerArgs: await self.buildSettings(for: uri)?.compilerArgs as [SKDRequestValue]?,
+      keys.compilerArgs: await self.buildSettings(for: uri, fallbackAfterTimeout: false)?.compilerArgs
+        as [SKDRequestValue]?,
     ])
 
     if let range = range {

--- a/Tests/BuildSystemIntegrationTests/FallbackBuildSettingsTests.swift
+++ b/Tests/BuildSystemIntegrationTests/FallbackBuildSettingsTests.swift
@@ -10,10 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BuildServerProtocol
 @_spi(Testing) import BuildSystemIntegration
 import LanguageServerProtocol
 import SKOptions
 import SKTestSupport
+import SourceKitLSP
 import TSCBasic
 import XCTest
 
@@ -159,5 +161,43 @@ final class FallbackBuildSystemTests: XCTestCase {
     let source = DocumentURI(filePath: "/my/source.mm", isDirectory: false)
 
     XCTAssertNil(fallbackBuildSettings(for: source, language: Language(rawValue: "unknown"), options: .init()))
+  }
+
+  func testFallbackBuildSettingsWhileBuildSystemIsComputingBuildSettings() async throws {
+    let fallbackResultsReceived = WrappedSemaphore(name: "Fallback results received")
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Test.swift": """
+        let x: 1️⃣String2️⃣ = 1
+        """
+      ],
+      testHooks: TestHooks(
+        buildSystemTestHooks: BuildSystemTestHooks(
+          handleRequest: { request in
+            if request is TextDocumentSourceKitOptionsRequest {
+              fallbackResultsReceived.waitOrXCTFail()
+            }
+          }
+        )
+      )
+    )
+
+    let (uri, positions) = try project.openDocument("Test.swift")
+
+    let documentHighlight = try await project.testClient.send(
+      DocumentHighlightRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    XCTAssertEqual(documentHighlight, [DocumentHighlight(range: positions["1️⃣"]..<positions["2️⃣"], kind: .read)])
+
+    fallbackResultsReceived.signal()
+
+    try await repeatUntilExpectedResult {
+      let diagsAfterBuildSettings = try await project.testClient.send(
+        DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
+      )
+      return diagsAfterBuildSettings.fullReport?.items.map(\.message) == [
+        "Cannot convert value of type 'Int' to specified type 'String'"
+      ]
+    }
   }
 }

--- a/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
@@ -121,7 +121,11 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       assertNotNil(await buildSystemManager.initializationData?.indexDatabasePath)
       assertNotNil(await buildSystemManager.initializationData?.indexStorePath)
       let arguments = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: aswift.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: aswift.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
 
       assertArgumentsContain("-module-name", "lib", arguments: arguments)
@@ -191,7 +195,8 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let arguments = try await unwrap(
         buildSystemManager.buildSettingsInferredFromMainFile(
           for: DocumentURI(urlWithPlusEscaped),
-          language: .swift
+          language: .swift,
+          fallbackAfterTimeout: false
         )
       )
       .compilerArguments
@@ -246,7 +251,11 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
 
       let arguments = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: aswift.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: aswift.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
 
       assertArgumentsContain("-typecheck", arguments: arguments)
@@ -322,7 +331,11 @@ final class SwiftPMBuildSystemTests: XCTestCase {
 
       let source = try resolveSymlinks(packageRoot.appending(component: "Package.swift"))
       let arguments = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: source.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: source.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
 
       assertArgumentsContain("-swift-version", "4.2", arguments: arguments)
@@ -360,12 +373,20 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let bswift = packageRoot.appending(components: "Sources", "lib", "b.swift")
 
       let argumentsA = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: aswift.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: aswift.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
       assertArgumentsContain(aswift.pathString, arguments: argumentsA)
       assertArgumentsContain(bswift.pathString, arguments: argumentsA)
       let argumentsB = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: aswift.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: aswift.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
       assertArgumentsContain(aswift.pathString, arguments: argumentsB)
       assertArgumentsContain(bswift.pathString, arguments: argumentsB)
@@ -408,7 +429,11 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
       let arguments = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: aswift.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: aswift.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
       assertArgumentsContain(aswift.pathString, arguments: arguments)
       assertArgumentsDoNotContain(bswift.pathString, arguments: arguments)
@@ -421,7 +446,11 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       )
 
       let argumentsB = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: bswift.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: bswift.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
       assertArgumentsContain(bswift.pathString, arguments: argumentsB)
       assertArgumentsDoNotContain(aswift.pathString, arguments: argumentsB)
@@ -462,15 +491,26 @@ final class SwiftPMBuildSystemTests: XCTestCase {
 
       let aswift = packageRoot.appending(components: "Sources", "libA", "a.swift")
       let bswift = packageRoot.appending(components: "Sources", "libB", "b.swift")
-      assertNotNil(await buildSystemManager.buildSettingsInferredFromMainFile(for: aswift.asURI, language: .swift))
+      assertNotNil(
+        await buildSystemManager.buildSettingsInferredFromMainFile(
+          for: aswift.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
+      )
       assertEqual(
-        await buildSystemManager.buildSettingsInferredFromMainFile(for: bswift.asURI, language: .swift)?.isFallback,
+        await buildSystemManager.buildSettingsInferredFromMainFile(
+          for: bswift.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )?.isFallback,
         true
       )
       assertEqual(
         await buildSystemManager.buildSettingsInferredFromMainFile(
           for: DocumentURI(URL(string: "https://www.apple.com")!),
-          language: .swift
+          language: .swift,
+          fallbackAfterTimeout: false
         )?.isFallback,
         true
       )
@@ -515,7 +555,11 @@ final class SwiftPMBuildSystemTests: XCTestCase {
 
       for file in [acxx, header] {
         let args = try await unwrap(
-          buildSystemManager.buildSettingsInferredFromMainFile(for: file.asURI, language: .cpp)
+          buildSystemManager.buildSettingsInferredFromMainFile(
+            for: file.asURI,
+            language: .cpp,
+            fallbackAfterTimeout: false
+          )
         ).compilerArguments
 
         assertArgumentsContain("-std=c++14", arguments: args)
@@ -588,7 +632,11 @@ final class SwiftPMBuildSystemTests: XCTestCase {
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
       let arguments = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: aswift.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: aswift.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
       assertArgumentsContain("-target", arguments: arguments)  // Only one!
 
@@ -642,10 +690,18 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       let manifest = packageRoot.appending(components: "Package.swift")
 
       let argumentsFromSymlink = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: aswiftSymlink.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: aswiftSymlink.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
       let argumentsFromReal = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: aswiftReal.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: aswiftReal.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
 
       // The arguments retrieved from the symlink and the real document should be the same, except that both should
@@ -663,7 +719,11 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       assertArgumentsDoNotContain(aswiftSymlink.pathString, arguments: argumentsFromReal)
 
       let argsManifest = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: manifest.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: manifest.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
       XCTAssertNotNil(argsManifest)
 
@@ -717,7 +777,8 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         let args = try unwrap(
           await buildSystemManager.buildSettingsInferredFromMainFile(
             for: symlinkRoot.appending(components: file).asURI,
-            language: .cpp
+            language: .cpp,
+            fallbackAfterTimeout: false
           )?
           .compilerArguments
         )
@@ -756,7 +817,11 @@ final class SwiftPMBuildSystemTests: XCTestCase {
 
       let aswift = packageRoot.appending(components: "Sources", "lib", "a.swift")
       let arguments = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: aswift.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: aswift.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       )
       .compilerArguments
       assertArgumentsContain(aswift.pathString, arguments: arguments)
@@ -830,7 +895,11 @@ final class SwiftPMBuildSystemTests: XCTestCase {
 
       assertNotNil(await buildSystemManager.initializationData?.indexStorePath)
       let arguments = try await unwrap(
-        buildSystemManager.buildSettingsInferredFromMainFile(for: aswift.asURI, language: .swift)
+        buildSystemManager.buildSettingsInferredFromMainFile(
+          for: aswift.asURI,
+          language: .swift,
+          fallbackAfterTimeout: false
+        )
       ).compilerArguments
 
       // Plugins get compiled with the same compiler arguments as the package manifest


### PR DESCRIPTION
When we receive build settings after hitting the timeout, we call `fileBuildSettingsChanged` on the delegate, which should cause the document to get re-opened in sourcekitd and diagnostics to get refreshed.

rdar://136332685
Fixes #1693