### PR TITLE
Support `workspace/diagnostic/refresh` request from `TestSourceKitLSPClient`

### DIFF
--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -354,6 +354,12 @@ package final class TestSourceKitLSPClient: MessageHandler, Sendable {
         return (handler, index, handlerAndIsOneShot.isOneShot)
       }.first
       guard let (requestHandler, index, isOneShot) = requestHandlerIndexAndIsOneShot else {
+        if Request.self == DiagnosticsRefreshRequest.self {
+          // Ignore diagnostic refresh requests. This keeps the log a little cleaner than if we return
+          // methodNotFound.
+          reply(.success(VoidResponse() as! Request.Response))
+          return
+        }
         reply(.failure(.methodNotFound(Request.method)))
         return
       }


### PR DESCRIPTION
Currently, we return a `methodNotFound` error when we get a diagnostic refresh request from SourceKit-LSP. This doesn’t do any harm but draws the attention when reading test logs, despite being the expected result. Clean up that output by returning a proper response.