### PR TITLE
Make `DocumentManager.documents` private

### DIFF
--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -104,7 +104,7 @@ package final class DocumentManager: InMemoryDocumentManager, Sendable {
   private let queue: DispatchQueue = DispatchQueue(label: "document-manager-queue")
 
   // `nonisolated(unsafe)` is fine because `documents` is guarded by queue.
-  nonisolated(unsafe) var documents: [DocumentURI: Document] = [:]
+  private nonisolated(unsafe) var documents: [DocumentURI: Document] = [:]
 
   package init() {}
 

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -205,7 +205,7 @@ extension SourceKitLSPServer {
       return documentManager.fileHasInMemoryModifications(uri)
     }
 
-    let filesWithInMemoryState = documentManager.documents.keys.filter { uri in
+    let filesWithInMemoryState = documentManager.openDocuments.filter { uri in
       // Use the index to check for in-memory modifications so we can re-use its cache. If no index exits, ask the
       // document manager directly.
       if let index {


### PR DESCRIPTION
`documents` needs to be guarded by `queue` and thus shouldn’t be accessible from outside the type. Also uncovered on incorrect use of it.