### PR TITLE
Support building only tests using SwiftPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,423 +8,443 @@ let globalSwiftSettings: [SwiftSetting] = [
   .enableUpcomingFeature("InternalImportsByDefault")
 ]
 
+var products: [Product] = [
+  .executable(name: "sourcekit-lsp", targets: ["sourcekit-lsp"]),
+  .library(name: "_SourceKitLSP", targets: ["SourceKitLSP"]),
+  .library(name: "LSPBindings", targets: ["LanguageServerProtocol", "LanguageServerProtocolJSONRPC"]),
+]
+
+var targets: [Target] = [
+  // Formatting style:
+  //  - One section for each target and its test target
+  //  - Sections are sorted alphabetically
+  //  - Dependencies are listed on separate lines
+  //  - All array elements are sorted alphabetically
+
+  // MARK: sourcekit-lsp
+
+  .executableTarget(
+    name: "sourcekit-lsp",
+    dependencies: [
+      "BuildSystemIntegration",
+      "Diagnose",
+      "LanguageServerProtocol",
+      "LanguageServerProtocolJSONRPC",
+      "SKOptions",
+      "SKSupport",
+      "SourceKitLSP",
+      "ToolchainRegistry",
+      .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+    ],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings,
+    linkerSettings: sourcekitLSPLinkSettings
+  ),
+
+  // MARK: BuildServerProtocol
+
+  .target(
+    name: "BuildServerProtocol",
+    dependencies: [
+      "LanguageServerProtocol"
+    ],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: BuildSystemIntegration
+
+  .target(
+    name: "BuildSystemIntegration",
+    dependencies: [
+      "BuildServerProtocol",
+      "LanguageServerProtocol",
+      "LanguageServerProtocolJSONRPC",
+      "SKLogging",
+      "SKOptions",
+      "SKSupport",
+      "SourceKitD",
+      "SwiftExtensions",
+      "ToolchainRegistry",
+      .product(name: "SwiftPM-auto", package: "swift-package-manager"),
+      .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+    ],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  .testTarget(
+    name: "BuildSystemIntegrationTests",
+    dependencies: [
+      "BuildSystemIntegration",
+      "LanguageServerProtocol",
+      "SKOptions",
+      "SKTestSupport",
+      "SourceKitLSP",
+      "ToolchainRegistry",
+    ],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: CAtomics
+
+  .target(
+    name: "CAtomics",
+    dependencies: []
+  ),
+
+  // MARK: CSKTestSupport
+
+  .target(
+    name: "CSKTestSupport",
+    dependencies: []
+  ),
+
+  // MARK: Csourcekitd
+
+  .target(
+    name: "Csourcekitd",
+    dependencies: [],
+    exclude: ["CMakeLists.txt"]
+  ),
+
+  // MARK: Diagnose
+
+  .target(
+    name: "Diagnose",
+    dependencies: [
+      "BuildSystemIntegration",
+      "InProcessClient",
+      "SKLogging",
+      "SKOptions",
+      "SKSupport",
+      "SourceKitD",
+      "SourceKitLSP",
+      "SwiftExtensions",
+      "ToolchainRegistry",
+      .product(name: "ArgumentParser", package: "swift-argument-parser"),
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+    ] + swiftSyntaxDependencies(["SwiftIDEUtils", "SwiftSyntax", "SwiftParser"]),
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  .testTarget(
+    name: "DiagnoseTests",
+    dependencies: [
+      "BuildSystemIntegration",
+      "Diagnose",
+      "SKLogging",
+      "SKTestSupport",
+      "SourceKitD",
+      "ToolchainRegistry",
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+    ],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: InProcessClient
+
+  .target(
+    name: "InProcessClient",
+    dependencies: [
+      "BuildSystemIntegration",
+      "LanguageServerProtocol",
+      "SKLogging",
+      "SKOptions",
+      "SourceKitLSP",
+      "ToolchainRegistry",
+    ],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: LanguageServerProtocol
+
+  .target(
+    name: "LanguageServerProtocol",
+    dependencies: [],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  .testTarget(
+    name: "LanguageServerProtocolTests",
+    dependencies: [
+      "LanguageServerProtocol",
+      "SKTestSupport",
+    ],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: LanguageServerProtocolJSONRPC
+
+  .target(
+    name: "LanguageServerProtocolJSONRPC",
+    dependencies: [
+      "LanguageServerProtocol",
+      "SKLogging",
+      "SwiftExtensions",
+    ],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  .testTarget(
+    name: "LanguageServerProtocolJSONRPCTests",
+    dependencies: [
+      "LanguageServerProtocolJSONRPC",
+      "SKTestSupport",
+    ],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: SemanticIndex
+
+  .target(
+    name: "SemanticIndex",
+    dependencies: [
+      "BuildSystemIntegration",
+      "LanguageServerProtocol",
+      "SKLogging",
+      "SwiftExtensions",
+      "ToolchainRegistry",
+      .product(name: "IndexStoreDB", package: "indexstore-db"),
+    ],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  .testTarget(
+    name: "SemanticIndexTests",
+    dependencies: [
+      "SemanticIndex",
+      "SKLogging",
+      "SKTestSupport",
+    ],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: SKLogging
+
+  .target(
+    name: "SKLogging",
+    dependencies: [
+      "SwiftExtensions",
+      .product(name: "Crypto", package: "swift-crypto"),
+    ],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings + lspLoggingSwiftSettings
+  ),
+
+  .testTarget(
+    name: "SKLoggingTests",
+    dependencies: [
+      "SKLogging",
+      "SKTestSupport",
+    ],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: SKOptions
+
+  .target(
+    name: "SKOptions",
+    dependencies: [
+      "LanguageServerProtocol",
+      "SKLogging",
+      "SKSupport",
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+    ],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: SKSupport
+
+  .target(
+    name: "SKSupport",
+    dependencies: [
+      "LanguageServerProtocol",
+      "LanguageServerProtocolJSONRPC",
+      "SKLogging",
+      "SourceKitD",
+      "SwiftExtensions",
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+    ],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  .testTarget(
+    name: "SKSupportTests",
+    dependencies: [
+      "SKSupport",
+      "SKTestSupport",
+      "SwiftExtensions",
+    ],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: SKTestSupport
+
+  .target(
+    name: "SKTestSupport",
+    dependencies: [
+      "BuildSystemIntegration",
+      "CSKTestSupport",
+      "InProcessClient",
+      "LanguageServerProtocol",
+      "LanguageServerProtocolJSONRPC",
+      "SKLogging",
+      "SKOptions",
+      "SKSupport",
+      "SourceKitLSP",
+      "SwiftExtensions",
+      "ToolchainRegistry",
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+    ],
+    resources: [.copy("INPUTS")],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: SourceKitD
+
+  .target(
+    name: "SourceKitD",
+    dependencies: [
+      "Csourcekitd",
+      "SKLogging",
+      "SwiftExtensions",
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+    ],
+    exclude: ["CMakeLists.txt", "sourcekitd_uids.swift.gyb"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  .testTarget(
+    name: "SourceKitDTests",
+    dependencies: [
+      "BuildSystemIntegration",
+      "SourceKitD",
+      "SKTestSupport",
+      "SwiftExtensions",
+      "ToolchainRegistry",
+    ],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: SourceKitLSP
+
+  .target(
+    name: "SourceKitLSP",
+    dependencies: [
+      "BuildServerProtocol",
+      "BuildSystemIntegration",
+      "LanguageServerProtocol",
+      "LanguageServerProtocolJSONRPC",
+      "SemanticIndex",
+      "SKLogging",
+      "SKOptions",
+      "SKSupport",
+      "SourceKitD",
+      "SwiftExtensions",
+      "ToolchainRegistry",
+      .product(name: "IndexStoreDB", package: "indexstore-db"),
+      .product(name: "Crypto", package: "swift-crypto"),
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+      .product(name: "SwiftPM-auto", package: "swift-package-manager"),
+    ]
+      + swiftSyntaxDependencies([
+        "SwiftBasicFormat", "SwiftDiagnostics", "SwiftIDEUtils", "SwiftParser", "SwiftParserDiagnostics",
+        "SwiftRefactor", "SwiftSyntax",
+      ]),
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  .testTarget(
+    name: "SourceKitLSPTests",
+    dependencies: [
+      "BuildServerProtocol",
+      "BuildSystemIntegration",
+      "LanguageServerProtocol",
+      "SemanticIndex",
+      "SKLogging",
+      "SKOptions",
+      "SKSupport",
+      "SKTestSupport",
+      "SourceKitD",
+      "SourceKitLSP",
+      "ToolchainRegistry",
+      .product(name: "IndexStoreDB", package: "indexstore-db"),
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+      // Depend on `SwiftCompilerPlugin` and `SwiftSyntaxMacros` so the modules are built before running tests and can
+      // be used by test cases that test macros (see `SwiftPMTestProject.macroPackageManifest`)
+    ] + swiftSyntaxDependencies(["SwiftParser", "SwiftSyntax", "SwiftCompilerPlugin", "SwiftSyntaxMacros"]),
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: SwiftExtensions
+
+  .target(
+    name: "SwiftExtensions",
+    dependencies: ["CAtomics"],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  // MARK: ToolchainRegistry
+
+  .target(
+    name: "ToolchainRegistry",
+    dependencies: [
+      "SKLogging",
+      "SKSupport",
+      "SwiftExtensions",
+      .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+    ],
+    exclude: ["CMakeLists.txt"],
+    swiftSettings: globalSwiftSettings
+  ),
+
+  .testTarget(
+    name: "ToolchainRegistryTests",
+    dependencies: [
+      "SKTestSupport",
+      "ToolchainRegistry",
+      .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
+      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+    ],
+    swiftSettings: globalSwiftSettings
+  ),
+]
+
+if buildOnlyTests {
+  products = []
+  targets = targets.compactMap { target in
+    guard target.isTest || target.name == "SKTestSupport" else {
+      return nil
+    }
+    target.dependencies = target.dependencies.filter { dependency in
+      if case .byNameItem(name: "SKTestSupport", _) = dependency {
+        return true
+      }
+      return false
+    }
+    return target
+  }
+}
+
 let package = Package(
   name: "SourceKitLSP",
   platforms: [.macOS(.v13)],
-  products: [
-    .executable(name: "sourcekit-lsp", targets: ["sourcekit-lsp"]),
-    .library(name: "_SourceKitLSP", targets: ["SourceKitLSP"]),
-    .library(name: "LSPBindings", targets: ["LanguageServerProtocol", "LanguageServerProtocolJSONRPC"]),
-  ],
+  products: products,
   dependencies: dependencies,
-  targets: [
-    // Formatting style:
-    //  - One section for each target and its test target
-    //  - Sections are sorted alphabetically
-    //  - Dependencies are listed on separate lines
-    //  - All array elements are sorted alphabetically
-
-    // MARK: sourcekit-lsp
-
-    .executableTarget(
-      name: "sourcekit-lsp",
-      dependencies: [
-        "BuildSystemIntegration",
-        "Diagnose",
-        "LanguageServerProtocol",
-        "LanguageServerProtocolJSONRPC",
-        "SKOptions",
-        "SKSupport",
-        "SourceKitLSP",
-        "ToolchainRegistry",
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings,
-      linkerSettings: sourcekitLSPLinkSettings
-    ),
-
-    // MARK: BuildServerProtocol
-
-    .target(
-      name: "BuildServerProtocol",
-      dependencies: [
-        "LanguageServerProtocol"
-      ],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: BuildSystemIntegration
-
-    .target(
-      name: "BuildSystemIntegration",
-      dependencies: [
-        "BuildServerProtocol",
-        "LanguageServerProtocol",
-        "LanguageServerProtocolJSONRPC",
-        "SKLogging",
-        "SKOptions",
-        "SKSupport",
-        "SourceKitD",
-        "SwiftExtensions",
-        "ToolchainRegistry",
-        .product(name: "SwiftPM-auto", package: "swift-package-manager"),
-        .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    .testTarget(
-      name: "BuildSystemIntegrationTests",
-      dependencies: [
-        "BuildSystemIntegration",
-        "LanguageServerProtocol",
-        "SKOptions",
-        "SKTestSupport",
-        "SourceKitLSP",
-        "ToolchainRegistry",
-      ],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: CAtomics
-
-    .target(
-      name: "CAtomics",
-      dependencies: []
-    ),
-
-    // MARK: CSKTestSupport
-
-    .target(
-      name: "CSKTestSupport",
-      dependencies: []
-    ),
-
-    // MARK: Csourcekitd
-
-    .target(
-      name: "Csourcekitd",
-      dependencies: [],
-      exclude: ["CMakeLists.txt"]
-    ),
-
-    // MARK: Diagnose
-
-    .target(
-      name: "Diagnose",
-      dependencies: [
-        "BuildSystemIntegration",
-        "InProcessClient",
-        "SKLogging",
-        "SKOptions",
-        "SKSupport",
-        "SourceKitD",
-        "SourceKitLSP",
-        "SwiftExtensions",
-        "ToolchainRegistry",
-        .product(name: "ArgumentParser", package: "swift-argument-parser"),
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ] + swiftSyntaxDependencies(["SwiftIDEUtils", "SwiftSyntax", "SwiftParser"]),
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    .testTarget(
-      name: "DiagnoseTests",
-      dependencies: [
-        "BuildSystemIntegration",
-        "Diagnose",
-        "SKLogging",
-        "SKTestSupport",
-        "SourceKitD",
-        "ToolchainRegistry",
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: InProcessClient
-
-    .target(
-      name: "InProcessClient",
-      dependencies: [
-        "BuildSystemIntegration",
-        "LanguageServerProtocol",
-        "SKLogging",
-        "SKOptions",
-        "SourceKitLSP",
-        "ToolchainRegistry",
-      ],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: LanguageServerProtocol
-
-    .target(
-      name: "LanguageServerProtocol",
-      dependencies: [],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    .testTarget(
-      name: "LanguageServerProtocolTests",
-      dependencies: [
-        "LanguageServerProtocol",
-        "SKTestSupport",
-      ],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: LanguageServerProtocolJSONRPC
-
-    .target(
-      name: "LanguageServerProtocolJSONRPC",
-      dependencies: [
-        "LanguageServerProtocol",
-        "SKLogging",
-        "SwiftExtensions",
-      ],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    .testTarget(
-      name: "LanguageServerProtocolJSONRPCTests",
-      dependencies: [
-        "LanguageServerProtocolJSONRPC",
-        "SKTestSupport",
-      ],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: SemanticIndex
-
-    .target(
-      name: "SemanticIndex",
-      dependencies: [
-        "BuildSystemIntegration",
-        "LanguageServerProtocol",
-        "SKLogging",
-        "SwiftExtensions",
-        "ToolchainRegistry",
-        .product(name: "IndexStoreDB", package: "indexstore-db"),
-      ],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    .testTarget(
-      name: "SemanticIndexTests",
-      dependencies: [
-        "SemanticIndex",
-        "SKLogging",
-        "SKTestSupport",
-      ],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: SKLogging
-
-    .target(
-      name: "SKLogging",
-      dependencies: [
-        "SwiftExtensions",
-        .product(name: "Crypto", package: "swift-crypto"),
-      ],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings + lspLoggingSwiftSettings
-    ),
-
-    .testTarget(
-      name: "SKLoggingTests",
-      dependencies: [
-        "SKLogging",
-        "SKTestSupport",
-      ],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: SKOptions
-
-    .target(
-      name: "SKOptions",
-      dependencies: [
-        "LanguageServerProtocol",
-        "SKLogging",
-        "SKSupport",
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: SKSupport
-
-    .target(
-      name: "SKSupport",
-      dependencies: [
-        "LanguageServerProtocol",
-        "LanguageServerProtocolJSONRPC",
-        "SKLogging",
-        "SourceKitD",
-        "SwiftExtensions",
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    .testTarget(
-      name: "SKSupportTests",
-      dependencies: [
-        "SKSupport",
-        "SKTestSupport",
-        "SwiftExtensions",
-      ],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: SKTestSupport
-
-    .target(
-      name: "SKTestSupport",
-      dependencies: [
-        "BuildSystemIntegration",
-        "CSKTestSupport",
-        "InProcessClient",
-        "LanguageServerProtocol",
-        "LanguageServerProtocolJSONRPC",
-        "SKLogging",
-        "SKOptions",
-        "SKSupport",
-        "SourceKitLSP",
-        "SwiftExtensions",
-        "ToolchainRegistry",
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ],
-      resources: [.copy("INPUTS")],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: SourceKitD
-
-    .target(
-      name: "SourceKitD",
-      dependencies: [
-        "Csourcekitd",
-        "SKLogging",
-        "SwiftExtensions",
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ],
-      exclude: ["CMakeLists.txt", "sourcekitd_uids.swift.gyb"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    .testTarget(
-      name: "SourceKitDTests",
-      dependencies: [
-        "BuildSystemIntegration",
-        "SourceKitD",
-        "SKTestSupport",
-        "SwiftExtensions",
-        "ToolchainRegistry",
-      ],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: SourceKitLSP
-
-    .target(
-      name: "SourceKitLSP",
-      dependencies: [
-        "BuildServerProtocol",
-        "BuildSystemIntegration",
-        "LanguageServerProtocol",
-        "LanguageServerProtocolJSONRPC",
-        "SemanticIndex",
-        "SKLogging",
-        "SKOptions",
-        "SKSupport",
-        "SourceKitD",
-        "SwiftExtensions",
-        "ToolchainRegistry",
-        .product(name: "IndexStoreDB", package: "indexstore-db"),
-        .product(name: "Crypto", package: "swift-crypto"),
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-        .product(name: "SwiftPM-auto", package: "swift-package-manager"),
-      ]
-        + swiftSyntaxDependencies([
-          "SwiftBasicFormat", "SwiftDiagnostics", "SwiftIDEUtils", "SwiftParser", "SwiftParserDiagnostics",
-          "SwiftRefactor", "SwiftSyntax",
-        ]),
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    .testTarget(
-      name: "SourceKitLSPTests",
-      dependencies: [
-        "BuildServerProtocol",
-        "BuildSystemIntegration",
-        "LanguageServerProtocol",
-        "SemanticIndex",
-        "SKLogging",
-        "SKOptions",
-        "SKSupport",
-        "SKTestSupport",
-        "SourceKitD",
-        "SourceKitLSP",
-        "ToolchainRegistry",
-        .product(name: "IndexStoreDB", package: "indexstore-db"),
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-        // Depend on `SwiftCompilerPlugin` and `SwiftSyntaxMacros` so the modules are built before running tests and can
-        // be used by test cases that test macros (see `SwiftPMTestProject.macroPackageManifest`)
-      ] + swiftSyntaxDependencies(["SwiftParser", "SwiftSyntax", "SwiftCompilerPlugin", "SwiftSyntaxMacros"]),
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: SwiftExtensions
-
-    .target(
-      name: "SwiftExtensions",
-      dependencies: ["CAtomics"],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    // MARK: ToolchainRegistry
-
-    .target(
-      name: "ToolchainRegistry",
-      dependencies: [
-        "SKLogging",
-        "SKSupport",
-        "SwiftExtensions",
-        .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ],
-      exclude: ["CMakeLists.txt"],
-      swiftSettings: globalSwiftSettings
-    ),
-
-    .testTarget(
-      name: "ToolchainRegistryTests",
-      dependencies: [
-        "SKTestSupport",
-        "ToolchainRegistry",
-        .product(name: "SwiftPMDataModel-auto", package: "swift-package-manager"),
-        .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
-      ],
-      swiftSettings: globalSwiftSettings
-    ),
-  ],
+  targets: targets,
   swiftLanguageVersions: [.v5, .version("6")]
 )
 
@@ -463,6 +483,13 @@ var useLocalDependencies: Bool { hasEnvironmentVariable("SWIFTCI_USE_LOCAL_DEPS"
 /// and run its tests.
 var buildDynamicSwiftSyntaxLibrary: Bool { hasEnvironmentVariable("SWIFTSYNTAX_BUILD_DYNAMIC_LIBRARY") }
 
+/// Build only tests targets and test support modules.
+///
+/// This is used to test swift-format on Windows, where the modules required for the `swift-format` executable are
+/// built using CMake. When using this setting, the caller is responsible for passing the required search paths to
+/// the `swift test` invocation so that all pre-built modules can be found.
+var buildOnlyTests: Bool { hasEnvironmentVariable("SOURCEKIT_LSP_BUILD_ONLY_TESTS") }
+
 // MARK: - Dependencies
 
 // When building with the swift build-script, use local dependencies whose contents are controlled
@@ -470,7 +497,9 @@ var buildDynamicSwiftSyntaxLibrary: Bool { hasEnvironmentVariable("SWIFTSYNTAX_B
 // for building the swift toolchain, such as `update-checkout`, or cross-repo PR tests.
 
 var dependencies: [Package.Dependency] {
-  if useLocalDependencies {
+  if buildOnlyTests {
+    return []
+  } else if useLocalDependencies {
     return [
       .package(path: "../indexstore-db"),
       .package(name: "swift-package-manager", path: "../swiftpm"),

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-package-name SourceKitLSP>")
+add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-package-name sourcekit_lsp>")
 add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-DRESILIENT_LIBRARIES>")
 add_compile_options("$<$<COMPILE_LANGUAGE:Swift>:SHELL:-swift-version 6>")
 add_subdirectory(BuildServerProtocol)


### PR DESCRIPTION
This allows us to build everything required for the executable using CMake and only the test targets using SwiftPM, enabling us to run tests on Windows from build.ps1 with minimal overhead.

Analogous to https://github.com/swiftlang/swift-format/pull/851