### PR TITLE
Re-enable SemanticTokenTests and SwiftInterfaceTests on Windows

### DIFF
--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -330,11 +330,6 @@ final class SemanticTokensTests: XCTestCase {
   func testSemanticTokensForFunctionSignatures() async throws {
     try await SkipUnless.sourcekitdHasSemanticTokensRequest()
 
-    #if os(Windows)
-    // FIXME: Run when https://github.com/swiftlang/sourcekit-lsp/issues/1770 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1770")
-    #endif
-
     try await assertSemanticTokens(
       markedContents: "1️⃣func 2️⃣f(3️⃣x: 4️⃣Int, _ 5️⃣y: 6️⃣String) {}",
       expected: [
@@ -408,11 +403,6 @@ final class SemanticTokensTests: XCTestCase {
 
   func testSemanticTokensForEnumMembers() async throws {
     try await SkipUnless.sourcekitdHasSemanticTokensRequest()
-
-    #if os(Windows)
-    // FIXME: Run when https://github.com/swiftlang/sourcekit-lsp/issues/1770 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1770")
-    #endif
 
     try await assertSemanticTokens(
       markedContents: """
@@ -500,11 +490,6 @@ final class SemanticTokensTests: XCTestCase {
   func testEmptyEdit() async throws {
     try await SkipUnless.sourcekitdHasSemanticTokensRequest()
 
-    #if os(Windows)
-    // FIXME: Run when https://github.com/swiftlang/sourcekit-lsp/issues/1770 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1770")
-    #endif
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -588,11 +573,6 @@ final class SemanticTokensTests: XCTestCase {
   func testReplaceUntilEndOfToken() async throws {
     try await SkipUnless.sourcekitdHasSemanticTokensRequest()
 
-    #if os(Windows)
-    // FIXME: Run when https://github.com/swiftlang/sourcekit-lsp/issues/1770 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1770")
-    #endif
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -645,11 +625,6 @@ final class SemanticTokensTests: XCTestCase {
 
   func testInsertSpaceBeforeToken() async throws {
     try await SkipUnless.sourcekitdHasSemanticTokensRequest()
-
-    #if os(Windows)
-    // FIXME: Run when https://github.com/swiftlang/sourcekit-lsp/issues/1770 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1770")
-    #endif
 
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
@@ -717,11 +692,6 @@ final class SemanticTokensTests: XCTestCase {
 
   func testInsertNewline() async throws {
     try await SkipUnless.sourcekitdHasSemanticTokensRequest()
-
-    #if os(Windows)
-    // FIXME: Run when https://github.com/swiftlang/sourcekit-lsp/issues/1770 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1770")
-    #endif
 
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
@@ -795,11 +765,6 @@ final class SemanticTokensTests: XCTestCase {
 
   func testInsertTokens() async throws {
     try await SkipUnless.sourcekitdHasSemanticTokensRequest()
-
-    #if os(Windows)
-    // FIXME: Run when https://github.com/swiftlang/sourcekit-lsp/issues/1770 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1770")
-    #endif
 
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
@@ -932,11 +897,6 @@ final class SemanticTokensTests: XCTestCase {
   func testArgumentLabels() async throws {
     try await SkipUnless.sourcekitdHasSemanticTokensRequest()
 
-    #if os(Windows)
-    // FIXME: Run when https://github.com/swiftlang/sourcekit-lsp/issues/1770 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1770")
-    #endif
-
     try await assertSemanticTokens(
       markedContents: """
         1️⃣func 2️⃣foo(3️⃣arg: 4️⃣Int) {}
@@ -956,11 +916,6 @@ final class SemanticTokensTests: XCTestCase {
 
   func testFunctionDeclarationWithFirstAndSecondName() async throws {
     try await SkipUnless.sourcekitdHasSemanticTokensRequest()
-
-    #if os(Windows)
-    // FIXME: Run when https://github.com/swiftlang/sourcekit-lsp/issues/1770 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1770")
-    #endif
 
     try await assertSemanticTokens(
       markedContents: """

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -43,11 +43,6 @@ final class SwiftInterfaceTests: XCTestCase {
   }
 
   func testDefinitionInSystemModuleInterface() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/sourcekit-lsp/issues/1771 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1771")
-    #endif
-
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public func libFunc() async {
@@ -140,11 +135,6 @@ final class SwiftInterfaceTests: XCTestCase {
   }
 
   func testJumpToSynthesizedExtensionMethodInSystemModuleWithoutIndex() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/sourcekit-lsp/issues/1771 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1771")
-    #endif
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -167,11 +157,6 @@ final class SwiftInterfaceTests: XCTestCase {
   }
 
   func testJumpToSynthesizedExtensionMethodInSystemModuleWithIndex() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/sourcekit-lsp/issues/1771 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1771")
-    #endif
-
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       func test(x: [String]) {


### PR DESCRIPTION
Depends on https://github.com/swiftlang/swift/pull/77120

---

The underlying issue was fixed by https://github.com/swiftlang/swift/pull/77120

Fixes #1770
Fixes #1771
rdar://138210224
rdar://138210215