### PR TITLE
Lower `swift-tools-version` to 5.9 in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 5.9
 
 import Foundation
 import PackageDescription


### PR DESCRIPTION
This would unblock https://github.com/swiftlang/swift-tools-support-core/pull/488