### PR TITLE
Guard access-level import by `compiler(>=6)`

### DIFF
--- a/Sources/SwiftExtensions/FileManagerExtensions.swift
+++ b/Sources/SwiftExtensions/FileManagerExtensions.swift
@@ -10,7 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if compiler(>=6)
 package import Foundation
+#else
+import Foundation
+#endif
 
 extension FileManager {
   /// Same as `fileExists(atPath:)` but takes a `URL` instead of a `String`.


### PR DESCRIPTION
This allows us to build SourceKit-LSP using Swift 5.10 again.