### PR TITLE
Enable `testReferencesInMacro`

### DIFF
--- a/Tests/SourceKitLSPTests/ReferencesTests.swift
+++ b/Tests/SourceKitLSPTests/ReferencesTests.swift
@@ -17,10 +17,6 @@ import XCTest
 /// Tests that test the overall state of the SourceKit-LSP server, that's not really specific to any language
 final class ReferencesTests: XCTestCase {
   func testReferencesInMacro() async throws {
-    #if os(Windows)
-    // FIXME: https://github.com/swiftlang/sourcekit-lsp/issues/1758
-    try XCTSkipIf(true, "Disabled until https://github.com/swiftlang/sourcekit-lsp/issues/1758 is fixed")
-    #endif
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       import Observation


### PR DESCRIPTION
I’m no longer seeing the issue that caused me to disable the test. Let’s re-enable it.

Fixes #1758
rdar://137922381