### PR TITLE
Don’t rely on timers for BSP target / settings change tests

### DIFF
--- a/Sources/SKTestSupport/INPUTS/AbstractBuildServer.py
+++ b/Sources/SKTestSupport/INPUTS/AbstractBuildServer.py
@@ -76,6 +76,8 @@ class AbstractBuildServer:
             return self.register_for_changes(params)
         elif method == "textDocument/sourceKitOptions":
             return self.textdocument_sourcekitoptions(params)
+        elif method == "workspace/didChangeWatchedFiles":
+            return self.workspace_did_change_watched_files(params)
         elif method == "workspace/buildTargets":
             return self.workspace_build_targets(params)
 
@@ -146,6 +148,9 @@ class AbstractBuildServer:
         raise RequestError(
             code=-32601, message=f"'buildTarget/sources' not implemented"
         )
+
+    def workspace_did_change_watched_files(self, notification: Dict[str, object]) -> None:
+        pass
 
     def workspace_build_targets(self, request: Dict[str, object]) -> Dict[str, object]:
         raise RequestError(


### PR DESCRIPTION
The timers were racy and on Windows we would get the updated build targets / build settings before we expect them. Change the tests to explicitly tell the build server when to change the targets / settings it reports by sending it a `workspace/didChangeWatchedFiles` notification.

This should also speed up the tests because we don’t have a 1s timer anymore.