### PR TITLE
Fix nondeterministic test failure for tests that await next diagnostic notification

### DIFF
--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -120,7 +120,9 @@ final class BuildSystemTests: XCTestCase {
     await buildSystem.setBuildSettings(for: doc, to: newSettings)
 
     try await repeatUntilExpectedResult {
-      let refreshedDiags = try await testClient.nextDiagnosticsNotification(timeout: .seconds(1))
+      guard let refreshedDiags = try? await testClient.nextDiagnosticsNotification(timeout: .seconds(1)) else {
+        return false
+      }
       return try text == documentManager.latestSnapshot(doc).text && refreshedDiags.diagnostics.count == 0
     }
   }

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -195,14 +195,14 @@ final class MainFilesProviderTests: XCTestCase {
       DidChangeWatchedFilesNotification(changes: [FileEvent(uri: fancyLibraryUri, type: .changed)])
     )
 
-    // 'MyFancyLibrary.c' now also includes 'shared.h'. Since it lexicographically preceeds MyLibrary, we should use its
+    // 'MyFancyLibrary.c' now also includes 'shared.h'. Since it lexicographically precedes MyLibrary, we should use its
     // build settings.
     // `clangd` may return diagnostics from the old build settings sometimes (I believe when it's still building the
     // preamble for shared.h when the new build settings come in). Check that it eventually returns the correct
     // diagnostics.
     try await repeatUntilExpectedResult {
-      let refreshedDiags = try await project.testClient.nextDiagnosticsNotification(timeout: .seconds(1))
-      guard let diagnostic = refreshedDiags.diagnostics.only else {
+      let refreshedDiags = try? await project.testClient.nextDiagnosticsNotification(timeout: .seconds(1))
+      guard let diagnostic = refreshedDiags?.diagnostics.only else {
         return false
       }
       return diagnostic.message == "Unused variable 'fromMyFancyLibrary'"


### PR DESCRIPTION
These tests were designed to poll for the next diagnostic notification and if that notification didn’t contain the expected result, try again.

But if we didn’t get any diagnostic notification in 1s, we would unconditionally fail instead of trying again, which was not intended.