### PR TITLE
Increase timeout duration in `testSourcekitdTimeout`

### DIFF
--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -1426,9 +1426,13 @@ final class LocalSwiftTests: XCTestCase {
   }
 
   func testSourceKitdTimeout() async throws {
-    var options = SourceKitLSPOptions.testDefault()
-    options.sourcekitdRequestTimeout = 1 /* second */
+    try SkipUnless.longTestsEnabled()
 
+    var options = SourceKitLSPOptions.testDefault()
+    // This is how long we wait until implicitly cancelling the first diagnostics request.
+    // It needs to be long enough so we can compute diagnostics for the second requests.
+    // 1s is not sufficient on Windows for that.
+    options.sourcekitdRequestTimeout = 3 /* seconds */
     let testClient = try await TestSourceKitLSPClient(options: options)
     let uri = DocumentURI(for: .swift)
 


### PR DESCRIPTION
The 1s we allowed for the second (fast) diagnostics request was not sufficient on Windows in some runs. Increase the timeout to 3s.