### PR TITLE
Add config option for trailing closure rewriting

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -39,6 +39,8 @@ The structure of the file is currently not guaranteed to be stable. Options may 
     - `indexPrefixMap: [string: string]`: Path remappings for remapping index data for local use.
     - `maxCoresPercentageToUseForBackgroundIndexing: double`: A hint indicating how many cores background indexing should use at most (value between 0 and 1). Background indexing is not required to honor this setting
     - `updateIndexStoreTimeout: int`: Number of seconds to wait for an update index store task to finish before killing it.
+- `codeCompletion`: Dictionary with the following keys, defining options related to code completion actions
+    - `rewriteTrailingClosures: "full"|"never"`: Whether to pre-expand trailing closures when completing a function call expression
 - `logging`: Dictionary with the following keys, changing SourceKit-LSP’s logging behavior on non-Apple platforms. On Apple platforms, logging is done through the [system log](Diagnose%20Bundle.md#Enable%20Extended%20Logging). These options can only be set globally and not per workspace.
   - `logLevel: "debug"|"info"|"default"|"error"|"fault"`: The level from which one onwards log messages should be written.
   - `privacyLevel: "public"|"private"|"sensitive"`: Whether potentially sensitive information should be redacted. Default is `public`, which redacts potentially sensitive information.

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -46,6 +46,16 @@ extension SourceKitLSPOptions {
   }
 }
 
+extension SourceKitLSPOptions.CodeCompletionOptions {
+  package static func testDefault(
+    rewriteTrailingClosures: RewriteLevel = .full
+  ) -> SourceKitLSPOptions.CodeCompletionOptions {
+    return SourceKitLSPOptions.CodeCompletionOptions(
+      rewriteTrailingClosures: rewriteTrailingClosures
+    )
+  }
+}
+
 fileprivate struct NotificationTimeoutError: Error, CustomStringConvertible {
   var description: String = "Failed to receive next notification within timeout"
 }

--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -363,8 +363,13 @@ class CodeCompletionSession {
       let docBrief: String? = value[sourcekitd.keys.docBrief]
       let utf8CodeUnitsToErase: Int = value[sourcekitd.keys.numBytesToErase] ?? 0
 
-      if let closureExpanded = expandClosurePlaceholders(insertText: insertText) {
-        insertText = closureExpanded
+      switch options.codeCompletionOrDefault.rewriteTrailingClosures {
+      case .full:
+        if let closureExpanded = expandClosurePlaceholders(insertText: insertText) {
+          insertText = closureExpanded
+        }
+      case .never:
+        break
       }
 
       let text = rewriteSourceKitPlaceholders(in: insertText, clientSupportsSnippets: clientSupportsSnippets)


### PR DESCRIPTION
This would resolve <https://github.com/swiftlang/sourcekit-lsp/issues/1787>

The default remains the automatic expansion introduced in <https://github.com/swiftlang/sourcekit-lsp/pull/1072>, but the new option allows the user to disable it via a configuration file.

This is expressed as an enumeration rather than a boolean flag because there is room for [other levels of rewriting][0]. E.g. for trailing closures, a "basic" level might be implemented as rewriting to a pair of brackets on the same line, with a single placeholder, rather than the "full" multi-line behavior.

A [configuration file][1] like the following will disable the expansion feature:

``` json
{
  "codeCompletion" : {
    "rewriteTrailingClosures" : "never"
  }
}
```

[0]: https://github.com/swiftlang/sourcekit-lsp/issues/1788
[1]: https://github.com/swiftlang/sourcekit-lsp/blob/f25055094789a27af9ecd3b965717bcf5008faa6/Documentation/Configuration%20File.md
