### PR TITLE
Fix race condition that caused `testMainFileChangesIfIncludeIsAdded` to fail

### DIFF
--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import LanguageServerProtocol
+import SKLogging
 import SKTestSupport
 import SourceKitLSP
 import SwiftExtensions
@@ -202,10 +203,11 @@ final class MainFilesProviderTests: XCTestCase {
     // diagnostics.
     try await repeatUntilExpectedResult {
       let refreshedDiags = try? await project.testClient.nextDiagnosticsNotification(timeout: .seconds(1))
-      guard let diagnostic = refreshedDiags?.diagnostics.only else {
+      guard refreshedDiags?.diagnostics.only?.message == "Unused variable 'fromMyFancyLibrary'" else {
+        logger.debug("Received unexpected diagnostics: \(refreshedDiags?.forLogging)")
         return false
       }
-      return diagnostic.message == "Unused variable 'fromMyFancyLibrary'"
+      return true
     }
   }
 }


### PR DESCRIPTION
In some situations, we could return the timeout error from the timeout task, but receive a notification from the `self.notifications` `AsyncStream`. That notification would then be dropped and never get delivered to the test case, which can cause test cases to fail.