### PR TITLE
XCTests in extensions produced by symbols have no parent ID

### DIFF
--- a/Sources/SemanticIndex/CheckedIndex.swift
+++ b/Sources/SemanticIndex/CheckedIndex.swift
@@ -161,6 +161,28 @@ package final class CheckedIndex {
   package func fileHasInMemoryModifications(_ uri: DocumentURI) -> Bool {
     return checker.fileHasInMemoryModifications(uri)
   }
+
+  /// If there are any definition occurrences of the given USR, return these.
+  /// Otherwise return declaration occurrences.
+  package func definitionOrDeclarationOccurrences(ofUSR usr: String) -> [SymbolOccurrence] {
+    let definitions = occurrences(ofUSR: usr, roles: [.definition])
+    if !definitions.isEmpty {
+      return definitions
+    }
+    return occurrences(ofUSR: usr, roles: [.declaration])
+  }
+
+  /// Find a `SymbolOccurrence` that is considered the primary definition of the symbol with the given USR.
+  ///
+  /// If the USR has an ambiguous definition, the most important role of this function is to deterministically return
+  /// the same result every time.
+  package func primaryDefinitionOrDeclarationOccurrence(ofUSR usr: String) -> SymbolOccurrence? {
+    let result = definitionOrDeclarationOccurrences(ofUSR: usr).sorted().first
+    if result == nil {
+      logger.error("Failed to find definition of \(usr) in index")
+    }
+    return result
+  }
 }
 
 /// A wrapper around `IndexStoreDB` that allows the retrieval of a `CheckedIndex` with a specified check level or the

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2402,28 +2402,6 @@ private let maxWorkspaceSymbolResults = 4096
 package typealias Diagnostic = LanguageServerProtocol.Diagnostic
 
 fileprivate extension CheckedIndex {
-  /// If there are any definition occurrences of the given USR, return these.
-  /// Otherwise return declaration occurrences.
-  func definitionOrDeclarationOccurrences(ofUSR usr: String) -> [SymbolOccurrence] {
-    let definitions = occurrences(ofUSR: usr, roles: [.definition])
-    if !definitions.isEmpty {
-      return definitions
-    }
-    return occurrences(ofUSR: usr, roles: [.declaration])
-  }
-
-  /// Find a `SymbolOccurrence` that is considered the primary definition of the symbol with the given USR.
-  ///
-  /// If the USR has an ambiguous definition, the most important role of this function is to deterministically return
-  /// the same result every time.
-  func primaryDefinitionOrDeclarationOccurrence(ofUSR usr: String) -> SymbolOccurrence? {
-    let result = definitionOrDeclarationOccurrences(ofUSR: usr).sorted().first
-    if result == nil {
-      logger.error("Failed to find definition of \(usr) in index")
-    }
-    return result
-  }
-
   /// Get the name of the symbol that is a parent of this symbol, if one exists
   func containerName(of symbol: SymbolOccurrence) -> String? {
     // The container name of accessors is the container of the surrounding variable.


### PR DESCRIPTION
If the workspace has been indexed then TestItems are pulled from indexed symbols. In this code path XCTests defined in extensions don't have their parent class name appended to their ID.

As a result, when the user freshly opened a test file that contained XCTests defined in extensions then their IDs would be incorrect. However as soon as they made a change to the file then the method to produce the document tests would switch over to getting the tests from `languageService.syntatciDocumentTests(for:in:)` which does handle tests in extensions correctly, and the issue would dissapear.

When constructing TestItems from symbols check if the symbol is in an extension and if so, add the context to the generated ID.