### PR TITLE
Fix incorrect log message in `JSONRPCConnection`

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -219,7 +219,7 @@ public final class JSONRPCConnection: Connection {
     }
     let process = Foundation.Process()
     logger.log(
-      "Launching build server at \(executable.description) with options [\(arguments.joined(separator: " "))]"
+      "Launching JSON-RPC connection to \(executable.description) with options [\(arguments.joined(separator: " "))]"
     )
     process.executableURL = executable
     process.arguments = arguments


### PR DESCRIPTION
Not all JSON-RPC connections are to build servers. They can also be to clangd.