### PR TITLE
Fix a crash when trying to apply in edit that has out of line positions

### DIFF
--- a/Sources/SourceKitLSP/Swift/FoldingRange.swift
+++ b/Sources/SourceKitLSP/Swift/FoldingRange.swift
@@ -287,11 +287,12 @@ extension SwiftLanguageService {
 
 fileprivate extension LineTable {
   func isAtEndOfLine(_ position: Position) -> Bool {
-    guard position.line >= 0, position.line < self.count else {
+    guard let line = self.line(at: position.line) else {
       return false
     }
-    let line = self[position.line]
-    let suffixAfterPositionColumn = line[line.utf16.index(line.startIndex, offsetBy: position.utf16index)...]
-    return suffixAfterPositionColumn.allSatisfy(\.isNewline)
+    guard let index = line.utf16.index(line.startIndex, offsetBy: position.utf16index, limitedBy: line.endIndex) else {
+      return false
+    }
+    return line[index...].allSatisfy(\.isNewline)
   }
 }

--- a/Tests/SKSupportTests/LineTablePerfTests.swift
+++ b/Tests/SKSupportTests/LineTablePerfTests.swift
@@ -87,9 +87,9 @@ final class LineTablePerfTests: PerfTestCase {
       self.startMeasuring()
 
       for _ in 1...iterations {
-        let line = (0..<(t.count - 1)).randomElement(using: &lcg) ?? 0
-        let col = (0..<t[line].utf16.count).randomElement(using: &lcg) ?? 0
-        let len = t[line].isEmpty ? 0 : Bool.random() ? 1 : 0
+        let line = (0..<(t.lineCount - 1)).randomElement(using: &lcg) ?? 0
+        let col = (0..<t.line(at: line)!.utf16.count).randomElement(using: &lcg) ?? 0
+        let len = t.line(at: line)!.isEmpty ? 0 : Bool.random() ? 1 : 0
         var newText = String(characters.randomElement(using: &lcg)!)
         if len == 1 && Bool.random(using: &lcg) {
           newText = ""  // deletion

--- a/Tests/SKSupportTests/SupportTests.swift
+++ b/Tests/SKSupportTests/SupportTests.swift
@@ -14,17 +14,22 @@ import SKSupport
 import TSCBasic
 import XCTest
 
-final class SupportTests: XCTestCase {
+fileprivate extension LineTable {
+  var lines: [Substring] {
+    (0..<lineCount).map { line(at: $0)! }
+  }
+}
 
+final class SupportTests: XCTestCase {
   func checkLines(_ string: String, _ expected: [String], file: StaticString = #filePath, line: UInt = #line) {
     let table = LineTable(string)
-    XCTAssertEqual(table.map { String($0) }, expected, file: file, line: line)
+    XCTAssertEqual(table.lines.map(String.init), expected, file: file, line: line)
   }
 
   func checkOffsets(_ string: String, _ expected: [Int], file: StaticString = #filePath, line: UInt = #line) {
     let table = LineTable(string)
     XCTAssertEqual(
-      table.map { string.utf8.distance(from: string.startIndex, to: $0.startIndex) },
+      table.lines.map { string.utf8.distance(from: string.startIndex, to: $0.startIndex) },
       expected,
       file: file,
       line: line
@@ -69,8 +74,8 @@ final class SupportTests: XCTestCase {
     checkOffsets("\n\u{10000}b", [0, 1])
     checkOffsets("\n\u{10000}b\nc", [0, 1, 7])
 
-    XCTAssertEqual(LineTable("")[0], "")
-    XCTAssertEqual(LineTable("\n")[1], "")
+    XCTAssertEqual(LineTable("").line(at: 0), "")
+    XCTAssertEqual(LineTable("\n").line(at: 1), "")
   }
 
   func checkLineAndColumns(

--- a/Tests/SourceKitLSPTests/LifecycleTests.swift
+++ b/Tests/SourceKitLSPTests/LifecycleTests.swift
@@ -135,4 +135,31 @@ final class LifecycleTests: XCTestCase {
     )
     XCTAssertGreaterThan(symbolInfo.count, 0)
   }
+
+  func testEditWithOutOfRangeLine() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    testClient.openDocument("", uri: uri)
+
+    // Check that we don't crash.
+    testClient.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(uri, version: 2),
+        contentChanges: [TextDocumentContentChangeEvent(range: Range(Position(line: 2, utf16index: 0)), text: "new")]
+      )
+    )
+  }
+
+  func testEditWithOutOfRangeColumn() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    testClient.openDocument("", uri: uri)
+
+    testClient.send(
+      DidChangeTextDocumentNotification(
+        textDocument: VersionedTextDocumentIdentifier(uri, version: 2),
+        contentChanges: [TextDocumentContentChangeEvent(range: Range(Position(line: 0, utf16index: 4)), text: "new")]
+      )
+    )
+  }
 }

--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -200,6 +200,7 @@ private func assertSystemSwiftInterface(
   // load contents of swiftinterface
   let contents = try XCTUnwrap(location.uri.fileURL.flatMap({ try String(contentsOf: $0, encoding: .utf8) }))
   let lineTable = LineTable(contents)
-  let destinationLine = lineTable[location.range.lowerBound.line].trimmingCharacters(in: .whitespaces)
+  let destinationLine = try XCTUnwrap(lineTable.line(at: location.range.lowerBound.line))
+    .trimmingCharacters(in: .whitespaces)
   XCTAssert(destinationLine.hasPrefix(linePrefix), "Full line was: '\(destinationLine)'", line: line)
 }


### PR DESCRIPTION
`LineTable.replace` did not actually validate that the edit is in range. This could cause crashes of SourceKit-LSP if the editor is sending us bogus edits. Validate the position, like we do in all the other position conversions and log a fault if the edit is out-of-range.

While fixing this, I found a couple more places where line table accesses were not properly guarded. I migrated them to safe alternatives as well.

rdar://138962353