### PR TITLE
Add a logging option to record all notifications received by SoruceKit-LSP

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -42,6 +42,7 @@ The structure of the file is currently not guaranteed to be stable. Options may 
 - `logging`: Dictionary with the following keys, changing SourceKit-LSP’s logging behavior on non-Apple platforms. On Apple platforms, logging is done through the [system log](Diagnose%20Bundle.md#Enable%20Extended%20Logging). These options can only be set globally and not per workspace.
   - `logLevel: "debug"|"info"|"default"|"error"|"fault"`: The level from which one onwards log messages should be written.
   - `privacyLevel: "public"|"private"|"sensitive"`: Whether potentially sensitive information should be redacted. Default is `public`, which redacts potentially sensitive information.
+  - `inputMirrorDirectory: string`: Write all input received by SourceKit-LSP on stdin to a file in this directory. Useful to record and replay an entire SourceKit-LSP session.
 - `defaultWorkspaceType: "buildserver"|"compdb"|"swiftpm"`: Overrides workspace type selection logic.
 - `generatedFilesPath: string`: Directory in which generated interfaces and macro expansions should be stored.
 - `backgroundIndexing: bool`: Explicitly enable or disable background indexing.

--- a/Package.swift
+++ b/Package.swift
@@ -281,6 +281,7 @@ var targets: [Target] = [
   .testTarget(
     name: "SKSupportTests",
     dependencies: [
+      "SKLogging",
       "SKSupport",
       "SKTestSupport",
       "SwiftExtensions",

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -200,21 +200,30 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
   public struct LoggingOptions: Sendable, Codable, Equatable {
     /// The level from which one onwards log messages should be written.
     public var level: String?
+
     /// Whether potentially sensitive information should be redacted.
     public var privacyLevel: String?
 
+    /// Write all input received by SourceKit-LSP on stdin to a file in this directory.
+    ///
+    /// Useful to record and replay an entire SourceKit-LSP session.
+    public var inputMirrorDirectory: String?
+
     public init(
       level: String? = nil,
-      privacyLevel: String? = nil
+      privacyLevel: String? = nil,
+      inputMirrorDirectory: String? = nil
     ) {
       self.level = level
       self.privacyLevel = privacyLevel
+      self.inputMirrorDirectory = inputMirrorDirectory
     }
 
     static func merging(base: LoggingOptions, override: LoggingOptions?) -> LoggingOptions {
       return LoggingOptions(
         level: override?.level ?? base.level,
-        privacyLevel: override?.privacyLevel ?? base.privacyLevel
+        privacyLevel: override?.privacyLevel ?? base.privacyLevel,
+        inputMirrorDirectory: override?.inputMirrorDirectory ?? base.inputMirrorDirectory
       )
     }
   }


### PR DESCRIPTION
This allows us to record the communication between SourceKit-LSP and the editor on a very low level to inspect any transfer issues. It also allows us to record an entire SourceKit-LSP session and replay it using

```
cat /path/to/mirror.log - | path/to/sourcekit-lsp
```