### PR TITLE
Import new Android overlay in more places

### DIFF
--- a/Sources/SKSupport/Process+Run.swift
+++ b/Sources/SKSupport/Process+Run.swift
@@ -30,6 +30,8 @@ import struct TSCBasic.ProcessResult
 
 #if os(Windows)
 import WinSDK
+#elseif canImport(Android)
+import Android
 #endif
 
 extension Process {

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -26,6 +26,10 @@ import SourceKitLSP
 import SwiftExtensions
 import ToolchainRegistry
 
+#if canImport(Android)
+import Android
+#endif
+
 public import struct TSCBasic.AbsolutePath
 public import struct TSCBasic.RelativePath
 public import var TSCBasic.localFileSystem

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -19,6 +19,8 @@ import class Foundation.Pipe
 
 #if os(Windows)
 import WinSDK
+#elseif canImport(Android)
+import Android
 #endif
 
 class ConnectionTests: XCTestCase {

--- a/Tests/SKSupportTests/AsyncUtilsTests.swift
+++ b/Tests/SKSupportTests/AsyncUtilsTests.swift
@@ -18,6 +18,8 @@ import XCTest
 
 #if os(Windows)
 import WinSDK
+#elseif canImport(Android)
+import Android
 #endif
 
 final class AsyncUtilsTests: XCTestCase {

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -20,6 +20,8 @@ import XCTest
 
 #if os(Windows)
 import WinSDK
+#elseif canImport(Android)
+import Android
 #endif
 
 final class PullDiagnosticsTests: XCTestCase {

--- a/Tests/ToolchainRegistryTests/ToolchainRegistryTests.swift
+++ b/Tests/ToolchainRegistryTests/ToolchainRegistryTests.swift
@@ -17,6 +17,10 @@ import XCTest
 
 import enum PackageLoading.Platform
 
+#if canImport(Android)
+import Android
+#endif
+
 final class ToolchainRegistryTests: XCTestCase {
   func testDefaultSingleToolchain() async throws {
     let tr = ToolchainRegistry(toolchains: [Toolchain(identifier: "a", displayName: "a", path: nil)])


### PR DESCRIPTION
I've been using [these](https://github.com/finagolfin/swift-android-sdk/blob/5f14c66ca8bf4c4af2a23cb816b35ec96e2b6b90/swift-android-ci.patch#L40) [patches](https://github.com/finagolfin/swift-android-sdk/blob/5f14c66ca8bf4c4af2a23cb816b35ec96e2b6b90/swift-android-ci-trunk.patch#L19) with Swift 6 on my Android CI and natively on Android for the last couple months.