### PR TITLE
Don’t log “Did not compute dependents for target”

### DIFF
--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -960,14 +960,11 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
           logger.fault("Did not compute depth for target \(buildTarget.id)")
           depth = 0
         }
-        let targetDependents: Set<BuildTargetIdentifier>
-        if let d = dependents[buildTarget.id] {
-          targetDependents = d
-        } else {
-          logger.fault("Did not compute dependents for target \(buildTarget.id)")
-          targetDependents = []
-        }
-        result[buildTarget.id] = BuildTargetInfo(target: buildTarget, depth: depth, dependents: targetDependents)
+        result[buildTarget.id] = BuildTargetInfo(
+          target: buildTarget,
+          depth: depth,
+          dependents: dependents[buildTarget.id] ?? []
+        )
       }
       return result
     }


### PR DESCRIPTION
Leaf targets don’t have dependents and that’s expected. We shouldn’t log a fault for them.