### PR TITLE
Verify that all imports are declared as dependencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,5 @@
     // Decrease timeout to 10s locally from the default 3min we allow by default. This is usually sufficient and makes test fail faster.
     "SOURCEKIT_LSP_TEST_TIMEOUT": "10"
   },
+  "swift.buildArguments": ["--explicit-target-dependency-import-check", "error"]
 }

--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -89,6 +89,7 @@ def get_swiftpm_options(swift_exec: str, args: argparse.Namespace, suppress_verb
         '--package-path', args.package_path,
         '--scratch-path', args.build_path,
         '--configuration', args.configuration,
+        '--explicit-target-dependency-import-check', 'error'
     ]
 
     if args.multiroot_data_file:


### PR DESCRIPTION
Pass `--explicit-target-dependency-import-check error` when building SourceKit-LSP in CI.