### PR TITLE
Mark `DummyBuildSystemManagerConnectionToClient.waitUntilInitialized` as `package`

### DIFF
--- a/Sources/SKTestSupport/DummyBuildSystemManagerConnectionToClient.swift
+++ b/Sources/SKTestSupport/DummyBuildSystemManagerConnectionToClient.swift
@@ -25,7 +25,7 @@ package struct DummyBuildSystemManagerConnectionToClient: BuildSystemManagerConn
 
   package init() {}
 
-  func waitUntilInitialized() async {}
+  package func waitUntilInitialized() async {}
 
   package func send(_ notification: some LanguageServerProtocol.NotificationType) {}
 


### PR DESCRIPTION
This restores the ability to build SourceKit-LSP using a Swift 5.10 compiler.