### PR TITLE
Handle on-type formatting requests

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -51,5 +51,5 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `noLazy`: Prepare a target without generating object files but do not do lazy type checking and function body skipping
   - `enabled`: Prepare a target without generating object files and the like
 - `cancelTextDocumentRequestsOnEditAndClose: bool`: Whether sending a `textDocument/didChange` or `textDocument/didClose` notification for a document should cancel all pending requests for that document.
-- `experimentalFeatures: string[]`: Experimental features to enable
+- `experimentalFeatures: string[]`: Experimental features to enable. Available features: on-type-formatting
 - `swiftPublishDiagnosticsDebounceDuration: double`: The time that `SwiftLanguageService` should wait after an edit before starting to compute diagnostics and sending a `PublishDiagnosticsNotification`.

--- a/Sources/SKOptions/ExperimentalFeatures.swift
+++ b/Sources/SKOptions/ExperimentalFeatures.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// An experimental feature that can be enabled by passing `--experimental-feature` to `sourcekit-lsp` on the command
-/// line. The raw value of this feature is how it is named on the command line.
+/// An experimental feature that can be enabled by passing `--experimental-feature`
+/// to `sourcekit-lsp` on the command line or through the configuration file.
+/// The raw value of this feature is how it is named on the command line and in the configuration file.
 public enum ExperimentalFeature: String, Codable, Sendable, CaseIterable {
-  /* This is here to silence the errors when the enum doesn't have any cases */
-  case exampleCase = "example-case"
+  case onTypeFormatting = "on-type-formatting"
 }

--- a/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
@@ -581,6 +581,10 @@ extension ClangLanguageService {
     return try await forwardRequestToClangd(req)
   }
 
+  func documentOnTypeFormatting(_ req: DocumentOnTypeFormattingRequest) async throws -> [TextEdit]? {
+    return try await forwardRequestToClangd(req)
+  }
+
   func codeAction(_ req: CodeActionRequest) async throws -> CodeActionRequestResponse? {
     return try await forwardRequestToClangd(req)
   }

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -210,6 +210,7 @@ package protocol LanguageService: AnyObject, Sendable {
   func documentDiagnostic(_ req: DocumentDiagnosticsRequest) async throws -> DocumentDiagnosticReport
   func documentFormatting(_ req: DocumentFormattingRequest) async throws -> [TextEdit]?
   func documentRangeFormatting(_ req: DocumentRangeFormattingRequest) async throws -> [TextEdit]?
+  func documentOnTypeFormatting(_ req: DocumentOnTypeFormattingRequest) async throws -> [TextEdit]?
 
   // MARK: - Rename
 

--- a/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
@@ -15,6 +15,7 @@ import Foundation
 package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
+import SKUtilities
 import SwiftExtensions
 import SwiftParser
 import SwiftSyntax
@@ -28,6 +29,7 @@ import Foundation
 import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
+import SKUtilities
 import SwiftExtensions
 import SwiftParser
 import SwiftSyntax
@@ -143,6 +145,7 @@ private func edits(from original: DocumentSnapshot, to edited: String) -> [TextE
 extension SwiftLanguageService {
   package func documentFormatting(_ req: DocumentFormattingRequest) async throws -> [TextEdit]? {
     return try await format(
+      snapshot: documentManager.latestSnapshot(req.textDocument.uri),
       textDocument: req.textDocument,
       options: req.options
     )
@@ -150,19 +153,36 @@ extension SwiftLanguageService {
 
   package func documentRangeFormatting(_ req: DocumentRangeFormattingRequest) async throws -> [TextEdit]? {
     return try await format(
+      snapshot: documentManager.latestSnapshot(req.textDocument.uri),
       textDocument: req.textDocument,
       options: req.options,
       range: req.range
     )
   }
 
+  package func documentOnTypeFormatting(_ req: DocumentOnTypeFormattingRequest) async throws -> [TextEdit]? {
+    let snapshot = try documentManager.latestSnapshot(req.textDocument.uri)
+    guard let line = snapshot.lineTable.line(at: req.position.line) else {
+      return nil
+    }
+
+    let lineStartPosition = snapshot.position(of: line.startIndex, fromLine: req.position.line)
+    let lineEndPosition = snapshot.position(of: line.endIndex, fromLine: req.position.line)
+
+    return try await format(
+      snapshot: snapshot,
+      textDocument: req.textDocument,
+      options: req.options,
+      range: lineStartPosition..<lineEndPosition
+    )
+  }
+
   private func format(
+    snapshot: DocumentSnapshot,
     textDocument: TextDocumentIdentifier,
     options: FormattingOptions,
     range: Range<Position>? = nil
   ) async throws -> [TextEdit]? {
-    let snapshot = try documentManager.latestSnapshot(textDocument.uri)
-
     guard let swiftFormat else {
       throw ResponseError.unknown(
         "Formatting not supported because the toolchain is missing the swift-format executable"
@@ -176,9 +196,13 @@ extension SwiftLanguageService {
       swiftFormatConfiguration(for: textDocument.uri, options: options),
     ]
     if let range {
+      let utf8Range = snapshot.utf8OffsetRange(of: range)
+      // swift-format takes an inclusive range, but Swift's `Range.upperBound` is exclusive.
+      // Also make sure `upperBound` does not go less than `lowerBound`.
+      let utf8UpperBound = max(utf8Range.lowerBound, utf8Range.upperBound - 1)
       args += [
         "--offsets",
-        "\(snapshot.utf8Offset(of: range.lowerBound)):\(snapshot.utf8Offset(of: range.upperBound))",
+        "\(utf8Range.lowerBound):\(utf8UpperBound)",
       ]
     }
     let process = TSCBasic.Process(arguments: args)

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -1226,6 +1226,12 @@ extension DocumentSnapshot {
     return Position(line: zeroBasedLine, utf16index: utf16Column)
   }
 
+  /// Converts the given `String.Index` to a UTF-16-based line:column position.
+  func position(of index: String.Index, fromLine: Int = 0) -> Position {
+    let (line, utf16Column) = lineTable.lineAndUTF16ColumnOf(index, fromLine: fromLine)
+    return Position(line: line, utf16index: utf16Column)
+  }
+
   // MARK: Position <-> AbsolutePosition
 
   /// Converts the given UTF-8-offset-based `AbsolutePosition` to a UTF-16-based line:column.

--- a/Tests/SourceKitLSPTests/OnTypeFormattingTests.swift
+++ b/Tests/SourceKitLSPTests/OnTypeFormattingTests.swift
@@ -1,0 +1,127 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+import SKLogging
+import SKTestSupport
+import SourceKitLSP
+import XCTest
+
+final class OnTypeFormattingTests: XCTestCase {
+  func testOnlyFormatsSpecifiedLine() async throws {
+    try await SkipUnless.toolchainContainsSwiftFormat()
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      func foo() {
+      if let SomeReallyLongVar = Some.More.Stuff(), let a = myfunc() {
+      1️⃣// do stuff
+      }
+      }
+      """,
+      uri: uri
+    )
+
+    let response = try await testClient.send(
+      DocumentOnTypeFormattingRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        position: positions["1️⃣"],
+        ch: "\n",
+        options: FormattingOptions(tabSize: 2, insertSpaces: true)
+      )
+    )
+
+    let edits = try XCTUnwrap(response)
+    XCTAssertEqual(
+      edits,
+      [
+        TextEdit(range: Range(positions["1️⃣"]), newText: "    ")
+      ]
+    )
+  }
+
+  func testFormatsFullLineAndDoesNotFormatNextLine() async throws {
+    try await SkipUnless.toolchainContainsSwiftFormat()
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      func foo() {
+      1️⃣if let SomeReallyLongVar = 2️⃣    3️⃣Some.More.Stuff(), let a = 4️⃣    5️⃣myfunc() 6️⃣{
+      }
+      }
+      """,
+      uri: uri
+    )
+
+    let response = try await testClient.send(
+      DocumentOnTypeFormattingRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        position: positions["6️⃣"],
+        ch: "{",
+        options: FormattingOptions(tabSize: 4, insertSpaces: true)
+      )
+    )
+
+    let edits = try XCTUnwrap(response)
+    XCTAssertEqual(
+      edits,
+      [
+        TextEdit(range: Range(positions["1️⃣"]), newText: "    "),
+        TextEdit(range: positions["2️⃣"]..<positions["3️⃣"], newText: ""),
+        TextEdit(range: positions["4️⃣"]..<positions["5️⃣"], newText: ""),
+      ]
+    )
+  }
+
+  /// Should not remove empty lines when formatting is triggered on a new empty line.
+  /// Otherwise could mess up writing code. You'd write {} and try to go into the braces to write more code,
+  /// only for on-type formatting to immediately close the braces again.
+  func testDoesNothingWhenInAnEmptyLine() async throws {
+    try await SkipUnless.toolchainContainsSwiftFormat()
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      func foo() {
+      if let SomeReallyLongVar =     Some.More.Stuff(), let a =     myfunc() {
+
+
+      1️⃣
+
+
+      }
+      }
+      """,
+      uri: uri
+    )
+
+    let response = try await testClient.send(
+      DocumentOnTypeFormattingRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        position: positions["1️⃣"],
+        ch: "\n",
+        options: FormattingOptions(tabSize: 2, insertSpaces: true)
+      )
+    )
+
+    let edits = try XCTUnwrap(response)
+    XCTAssertEqual(
+      edits,
+      []
+    )
+  }
+}


### PR DESCRIPTION
To fully resolve #1805

### TODO
* [x] Hide behind an experimental flag
* [x] Make sure the experimental flag is enable-able in VSCode?