### PR TITLE
Allow waiting for the next notification from SourceKit-LSP when the previous wait timed out

### DIFF
--- a/Sources/SKTestSupport/RepeatUntilExpectedResult.swift
+++ b/Sources/SKTestSupport/RepeatUntilExpectedResult.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import SKLogging
+import SwiftExtensions
 import XCTest
 
 /// Runs the body repeatedly once per second until it returns `true`, giving up after `timeout`.
@@ -33,10 +34,4 @@ package func repeatUntilExpectedResult(
     try await Task.sleep(for: sleepInterval)
   }
   XCTFail("Failed to get expected result", file: file, line: line)
-}
-
-fileprivate extension Duration {
-  var seconds: Double {
-    return Double(self.components.attoseconds) / 1_000_000_000_000_000_000 + Double(self.components.seconds)
-  }
 }

--- a/Sources/SwiftExtensions/CMakeLists.txt
+++ b/Sources/SwiftExtensions/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(SwiftExtensions STATIC
   CartesianProduct.swift
   Collection+Only.swift
   Collection+PartitionIntoBatches.swift
+  Duration+Seconds.swift
   FileManagerExtensions.swift
   NSLock+WithLock.swift
   PipeAsStringHandler.swift

--- a/Sources/SwiftExtensions/Duration+Seconds.swift
+++ b/Sources/SwiftExtensions/Duration+Seconds.swift
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+extension Duration {
+  package var seconds: Double {
+    return Double(self.components.attoseconds) / 1_000_000_000_000_000_000 + Double(self.components.seconds)
+  }
+}


### PR DESCRIPTION
When `TestSourceKitLSPClient.nextNotification` timed out, it would cancel `AsyncSequence.Iterator.next()` and thus also cancel the underlying `AsyncStream` (which I only now found out). This means that calling `nextNotification` again would never return any notification. Hence, if we didn’t receive a `PublishDiagnosticsNotification` within the first timeout, we would never get one.