### PR TITLE
Enable SwiftPM-baesd tests on Windows

### DIFF
--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -175,13 +175,6 @@ package class SwiftPMTestProject: MultiFileTestProject {
     cleanUp: (@Sendable () -> Void)? = nil,
     testName: String = #function
   ) async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
     var filesByPath: [RelativeFileLocation: String] = [:]
     for (fileLocation, contents) in files {
       let directories =

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -538,14 +538,6 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testPrepareTargetAfterEditToDependency() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
-
     var testHooks = TestHooks()
     let expectedPreparationTracker = ExpectedIndexTaskTracker(expectedPreparations: [
       [
@@ -645,14 +637,6 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testDontStackTargetPreparationForEditorFunctionality() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
-
     let allDocumentsOpened = WrappedSemaphore(name: "All documents opened")
     let libBStartedPreparation = WrappedSemaphore(name: "LibB started preparing")
     let libDPreparedForEditing = WrappedSemaphore(name: "LibD prepared for editing")
@@ -784,14 +768,6 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testIndexingHappensInParallel() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
-
     let fileAIndexingStarted = WrappedSemaphore(name: "FileA indexing started")
     let fileBIndexingStarted = WrappedSemaphore(name: "FileB indexing started")
 

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -312,14 +312,6 @@ final class PullDiagnosticsTests: XCTestCase {
   }
 
   func testDontReturnEmptyDiagnosticsIfDiagnosticRequestIsCancelled() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
-
     let diagnosticRequestCancelled = self.expectation(description: "diagnostic request cancelled")
     let packageLoadingDidFinish = self.expectation(description: "Package loading did finish")
     var testHooks = TestHooks()

--- a/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
@@ -185,13 +185,6 @@ final class SwiftPMIntegrationTests: XCTestCase {
   }
 
   func testNestedPackage() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
     let project = try await MultiFileTestProject(files: [
       "pkg/Sources/lib/lib.swift": "",
       "pkg/Package.swift": """

--- a/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
@@ -16,13 +16,6 @@ import XCTest
 
 class WorkspaceSymbolsTests: XCTestCase {
   func testWorkspaceSymbolsAcrossPackages() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
     let project = try await MultiFileTestProject(
       files: [
         "packageA/Sources/PackageALib/PackageALib.swift": """

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -24,13 +24,6 @@ import XCTest
 final class WorkspaceTests: XCTestCase {
 
   func testMultipleSwiftPMWorkspaces() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
     // The package manifest is the same for both packages we open.
     let packageManifest = """
       // swift-tools-version: 5.7
@@ -167,13 +160,6 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testOpenPackageManifestInMultiSwiftPMWorkspaceSetup() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
     let project = try await MultiFileTestProject(
       files: [
         // PackageA
@@ -250,13 +236,6 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testSwiftPMPackageInSubfolder() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
     let packageManifest = """
       // swift-tools-version: 5.7
 
@@ -336,13 +315,6 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testNestedSwiftPMWorkspacesWithoutDedicatedWorkspaceFolder() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
     // The package manifest is the same for both packages we open.
     let packageManifest = """
       // swift-tools-version: 5.7
@@ -525,13 +497,6 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testRecomputeFileWorkspaceMembershipOnPackageSwiftChange() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
     let project = try await MultiFileTestProject(
       files: [
         "PackageA/Sources/MyLibrary/libA.swift": "",
@@ -671,13 +636,6 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testChangeWorkspaceFolders() async throws {
-    #if os(Windows)
-    // FIXME: Enable when https://github.com/swiftlang/swift-package-manager/issues/8038 is fixed
-    try XCTSkipIf(
-      true,
-      "SwiftPM tests fail nondeterministically due to https://github.com/swiftlang/swift-package-manager/issues/8038"
-    )
-    #endif
     let project = try await MultiFileTestProject(
       files: [
         "subdir/Sources/otherPackage/otherPackage.swift": """


### PR DESCRIPTION
I ran Windows test 200 times locally without any failures, so I assume all the nondeterministic failures should be shaken out now.