### PR TITLE
Enable testPluginArgs on Windows

### DIFF
--- a/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
@@ -866,10 +866,6 @@ final class SwiftPMBuildSystemTests: XCTestCase {
   }
 
   func testPluginArgs() async throws {
-    #if os(Windows)
-    // TODO: Enable this test once https://github.com/swiftlang/sourcekit-lsp/issues/1775 is fixed
-    try XCTSkipIf(true, "https://github.com/swiftlang/sourcekit-lsp/issues/1775")
-    #endif
     try await withTestScratchDir { tempDir in
       try localFileSystem.createFiles(
         root: tempDir,


### PR DESCRIPTION
This should be fixed by https://github.com/swiftlang/swift-package-manager/pull/8118