### PR TITLE
Allow `scratchPath` to be a relative path

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -15,7 +15,7 @@ The structure of the file is currently not guaranteed to be stable. Options may 
 
 - `swiftPM`: Dictionary with the following keys, defining options for SwiftPM workspaces
   - `configuration: "debug"|"release"`: The configuration to build the project for during background indexing and the configuration whose build folder should be used for Swift modules if background indexing is disabled. Equivalent to SwiftPM's `--configuration` option.
-  - `scratchPath: string`: Build artifacts directory path. If nil, the build system may choose a default value. Equivalent to SwiftPM's `--scratch-path` option.
+  - `scratchPath: string`: Build artifacts directory path. If nil, the build system may choose a default value. This path can be specified as a relative path, which will be interpreted relative to the project root. Equivalent to SwiftPM's `--scratch-path` option.
   - `swiftSDKsDirectory: string`: Equivalent to SwiftPM's `--swift-sdks-path` option
   - `swiftSDK: string`: Equivalent to SwiftPM's `--swift-sdk` option
   - `triple: string`: Equivalent to SwiftPM's `--triple` option

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -324,7 +324,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
     if options.backgroundIndexingOrDefault {
       location.scratchDirectory = AbsolutePath(projectRoot.appending(components: ".build", "index-build"))
     } else if let scratchDirectory = options.swiftPMOrDefault.scratchPath,
-      let scratchDirectoryPath = try? AbsolutePath(validating: scratchDirectory)
+      let scratchDirectoryPath = try? AbsolutePath(validating: scratchDirectory, relativeTo: AbsolutePath(projectRoot))
     {
       location.scratchDirectory = scratchDirectoryPath
     }


### PR DESCRIPTION
Interpret it as relative to the project root directory if it's a relative path.