### PR TITLE
Add `Task{Start|Progress|Finish}Notification` to `BuildSystemMessageDependencyTracker`

### DIFF
--- a/Sources/BuildSystemIntegration/BuildSystemMessageDependencyTracker.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemMessageDependencyTracker.swift
@@ -65,6 +65,12 @@ package enum BuildSystemMessageDependencyTracker: QueueBasedMessageHandlerDepend
       self = .stateChange
     case is OnWatchedFilesDidChangeNotification:
       self = .stateChange
+    case is TaskFinishNotification:
+      self = .taskProgress
+    case is TaskProgressNotification:
+      self = .taskProgress
+    case is TaskStartNotification:
+      self = .taskProgress
     default:
       logger.error(
         """


### PR DESCRIPTION
Missed this when I created these notifications.