### PR TITLE
Restrict directories that we search for `MyDependency.swift` in tests

### DIFF
--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -245,7 +245,11 @@ final class BackgroundIndexingTests: XCTestCase {
     )
 
     let dependencyUrl = try XCTUnwrap(
-      FileManager.default.findFiles(named: "MyDependency.swift", in: project.scratchDirectory).only
+      FileManager.default.findFiles(
+        named: "MyDependency.swift",
+        in: project.scratchDirectory.appendingPathComponent(".build").appendingPathComponent("index-build")
+          .appendingPathComponent("checkouts")
+      ).only
     )
     let dependencyUri = DocumentURI(dependencyUrl)
     let testFileUri = try project.uri(for: "Test.swift")
@@ -1256,9 +1260,11 @@ final class BackgroundIndexingTests: XCTestCase {
     try await project.testClient.send(PollIndexRequest())
     project.testClient.send(
       DidChangeWatchedFilesNotification(
-        changes: FileManager.default.findFiles(named: "Dependency.swift", in: project.scratchDirectory).map {
-          FileEvent(uri: DocumentURI($0), type: .changed)
-        }
+        changes: FileManager.default.findFiles(
+          named: "Dependency.swift",
+          in: project.scratchDirectory.appendingPathComponent(".build").appendingPathComponent("index-build")
+            .appendingPathComponent("checkouts")
+        ).map { FileEvent(uri: DocumentURI($0), type: .changed) }
       )
     )
 


### PR DESCRIPTION
It appears that moving the index-build directory to be a subdirectory of `.build` caused some file in the index-build directory to exceed the `MAX_PATH` length on the SourceKit-LSP PR testing job (but not the swift PR job because that has a shorter job name). Because of https://github.com/swiftlang/swift-foundation/issues/1049, we would stop directory iteration at that file exceeding `MAX_PATH` and never find `MyDependency.swift`, causing these tests to fail. Only searching the `checkout` directory works around this issue because `FileManager.enumerator` never sees the file with the exceeding length that way.