### PR TITLE
Handle new swift-syntax closure expansion behavior

### DIFF
--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -26,6 +26,7 @@ target_sources(SourceKitLSP PRIVATE
 )
 target_sources(SourceKitLSP PRIVATE
   Swift/AdjustPositionToStartOfIdentifier.swift
+  Swift/ClosureCompletionFormat.swift
   Swift/CodeActions/AddDocumentation.swift
   Swift/CodeActions/ConvertIntegerLiteral.swift
   Swift/CodeActions/ConvertJSONToCodableStruct.swift

--- a/Sources/SourceKitLSP/Swift/ClosureCompletionFormat.swift
+++ b/Sources/SourceKitLSP/Swift/ClosureCompletionFormat.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6.0)
+public import SwiftBasicFormat
+public import SwiftSyntax
+#else
+import SwiftBasicFormat
+import SwiftSyntax
+#endif
+
+/// A specialization of `BasicFormat` for closure literals in a code completion
+/// context.
+///
+/// This is more conservative about newline insertion: unless the closure has
+/// multiple statements in its body it will not be reformatted to multiple
+/// lines.
+@_spi(Testing)
+public class ClosureCompletionFormat: BasicFormat {
+  @_spi(Testing)
+  public override func requiresNewline(
+    between first: TokenSyntax?,
+    and second: TokenSyntax?
+  ) -> Bool {
+    if let first, isEndOfSmallClosureSignature(first) {
+      return false
+    } else if let first, isSmallClosureDelimiter(first, kind: \.leftBrace) {
+      return false
+    } else if let second, isSmallClosureDelimiter(second, kind: \.rightBrace) {
+      return false
+    } else {
+      return super.requiresNewline(between: first, and: second)
+    }
+  }
+
+  /// Returns `true` if `token` is an opening or closing brace (according to
+  /// `kind`) of a closure, and that closure has no more than one statement in
+  /// its body.
+  private func isSmallClosureDelimiter(
+    _ token: TokenSyntax,
+    kind: KeyPath<ClosureExprSyntax, TokenSyntax>
+  ) -> Bool {
+    guard token.keyPathInParent == kind,
+      let closure = token.parent?.as(ClosureExprSyntax.self)
+    else {
+      return false
+    }
+
+    return closure.statements.count <= 1
+  }
+
+  /// Returns `true` if `token` is the last token in the signature of a closure,
+  /// and that closure has no more than one statement in its body.
+  private func isEndOfSmallClosureSignature(_ token: TokenSyntax) -> Bool {
+    guard
+      token.keyPathInParent == \ClosureSignatureSyntax.inKeyword,
+      let closure = token.ancestorOrSelf(mapping: { $0.as(ClosureExprSyntax.self) })
+    else {
+      return false
+    }
+
+    return closure.statements.count <= 1
+  }
+}

--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -323,9 +323,14 @@ class CodeCompletionSession {
     var parser = Parser(exprToExpand)
     let expr = ExprSyntax.parse(from: &parser)
     guard let call = OutermostFunctionCallFinder.findOutermostFunctionCall(in: expr),
-      let expandedCall = ExpandEditorPlaceholdersToTrailingClosures.refactor(
+      let expandedCall = ExpandEditorPlaceholdersToLiteralClosures.refactor(
         syntax: call,
-        in: ExpandEditorPlaceholdersToTrailingClosures.Context(indentationWidth: indentationWidth)
+        in: ExpandEditorPlaceholdersToLiteralClosures.Context(
+          format: .custom(
+            ClosureCompletionFormat(indentationWidth: indentationWidth),
+            allowNestedPlaceholders: true
+          )
+        )
       )
     else {
       return nil
@@ -334,7 +339,7 @@ class CodeCompletionSession {
     let bytesToExpand = Array(exprToExpand.utf8)
 
     var expandedBytes: [UInt8] = []
-    // Add the prefix that we stripped of to allow expression parsing
+    // Add the prefix that we stripped off to allow expression parsing
     expandedBytes += strippedPrefix.utf8
     // Add any part of the expression that didn't end up being part of the function call
     expandedBytes += bytesToExpand[0..<call.position.utf8Offset]

--- a/Sources/SourceKitLSP/Swift/RewriteSourceKitPlaceholders.swift
+++ b/Sources/SourceKitLSP/Swift/RewriteSourceKitPlaceholders.swift
@@ -14,34 +14,166 @@ import Foundation
 import SKLogging
 @_spi(RawSyntax) import SwiftSyntax
 
-func rewriteSourceKitPlaceholders(in string: String, clientSupportsSnippets: Bool) -> String {
-  var result = string
-  var index = 1
-  while let start = result.range(of: "<#") {
-    guard let end = result[start.upperBound...].range(of: "#>") else {
-      logger.fault("Invalid placeholder in \(string)")
-      return string
+/// Translate SourceKit placeholder syntax — `<#foo#>` — in `input` to LSP
+/// placeholder syntax: `${n:foo}`.
+///
+/// If `clientSupportsSnippets` is `false`, the placeholder is rendered as an
+/// empty string, to prevent the client from inserting special placeholder
+/// characters as if they were literal text.
+@_spi(Testing)
+public func rewriteSourceKitPlaceholders(in input: String, clientSupportsSnippets: Bool) -> String {
+  var result = ""
+  var nextPlaceholderNumber = 1
+  // Current stack of nested placeholders, most nested last. Each element needs
+  // to be rendered inside the element before it.
+  var placeholders: [(number: Int, contents: String)] = []
+  let tokens = tokenize(input)
+  for token in tokens {
+    switch token {
+    case let .text(text):
+      if placeholders.isEmpty {
+        result += text
+      } else {
+        placeholders.latest.contents += text
+      }
+
+    case let .curlyBrace(brace):
+      if placeholders.isEmpty {
+        result.append(brace)
+      } else {
+        // Braces are only escaped _inside_ a placeholder; otherwise the client
+        // would include the backslashes literally.
+        placeholders.latest.contents.append(contentsOf: ["\\", brace])
+      }
+
+    case .placeholderOpen:
+      placeholders.append((number: nextPlaceholderNumber, contents: ""))
+      nextPlaceholderNumber += 1
+
+    case .placeholderClose:
+      guard let (number, placeholderBody) = placeholders.popLast() else {
+        logger.fault("Invalid placeholder in \(input)")
+        return input
+      }
+      guard let displayName = nameForSnippet(placeholderBody) else {
+        logger.fault("Failed to decode placeholder \(placeholderBody) in \(input)")
+        return input
+      }
+      let placeholder =
+        clientSupportsSnippets
+        ? formatLSPPlaceholder(displayName, number: number)
+        : ""
+      if placeholders.isEmpty {
+        result += placeholder
+      } else {
+        placeholders.latest.contents += placeholder
+      }
     }
-    let rawPlaceholder = String(result[start.lowerBound..<end.upperBound])
-    guard let displayName = nameForSnippet(rawPlaceholder) else {
-      logger.fault("Failed to decode placeholder \(rawPlaceholder) in \(string)")
-      return string
-    }
-    let snippet = clientSupportsSnippets ? "${\(index):\(displayName)}" : ""
-    result.replaceSubrange(start.lowerBound..<end.upperBound, with: snippet)
-    index += 1
   }
+
   return result
 }
 
-/// Parse a SourceKit placeholder and extract the display name suitable for a
-/// LSP snippet.
-fileprivate func nameForSnippet(_ text: String) -> String? {
-  var text = text
+/// Scan `input` to identify special elements within: curly braces, which may
+/// need to be escaped; and SourceKit placeholder open/close delimiters.
+private func tokenize(_ input: String) -> [SnippetToken] {
+  var index = input.startIndex
+  var isAtEnd: Bool { index == input.endIndex }
+  func match(_ char: Character) -> Bool {
+    if isAtEnd || input[index] != char {
+      return false
+    } else {
+      input.formIndex(after: &index)
+      return true
+    }
+  }
+  func next() -> Character? {
+    guard !isAtEnd else { return nil }
+    defer { input.formIndex(after: &index) }
+    return input[index]
+  }
+
+  var tokens: [SnippetToken] = []
+  var text = ""
+  while let char = next() {
+    switch char {
+    case "<":
+      if match("#") {
+        tokens.append(.text(text))
+        text.removeAll()
+        tokens.append(.placeholderOpen)
+      } else {
+        text.append(char)
+      }
+
+    case "#":
+      if match(">") {
+        tokens.append(.text(text))
+        text.removeAll()
+        tokens.append(.placeholderClose)
+      } else {
+        text.append(char)
+      }
+
+    case "{", "}":
+      tokens.append(.text(text))
+      text.removeAll()
+      tokens.append(.curlyBrace(char))
+
+    case let c:
+      text.append(c)
+    }
+  }
+
+  tokens.append(.text(text))
+
+  return tokens
+}
+
+/// A syntactical element inside a SourceKit snippet.
+private enum SnippetToken {
+  /// A placeholder delimiter.
+  case placeholderOpen, placeholderClose
+  /// One of '{' or '}', which may need to be escaped in the output.
+  case curlyBrace(Character)
+  /// Any other consecutive run of characters from the input, which needs no
+  /// special treatment.
+  case text(String)
+}
+
+/// Given the interior text of a SourceKit placeholder, extract a display name
+/// suitable for a LSP snippet.
+private func nameForSnippet(_ body: String) -> String? {
+  var text = rewrappedAsPlaceholder(body)
   return text.withSyntaxText {
     guard let data = RawEditorPlaceholderData(syntaxText: $0) else {
       return nil
     }
     return String(syntaxText: data.typeForExpansionText ?? data.displayText)
+  }
+}
+
+private let placeholderStart = "<#"
+private let placeholderEnd = "#>"
+private func rewrappedAsPlaceholder(_ body: String) -> String {
+  return placeholderStart + body + placeholderEnd
+}
+
+/// Wrap `body` in LSP snippet placeholder syntax, using `number` as the
+/// placeholder's index in the snippet.
+private func formatLSPPlaceholder(_ body: String, number: Int) -> String {
+  "${\(number):\(body)}"
+}
+
+private extension Array {
+  /// Mutable access to the final element of an array.
+  ///
+  /// - precondition: The array must not be empty.
+  var latest: Element {
+    get { self.last! }
+    _modify {
+      let index = self.index(before: self.endIndex)
+      yield &self[index]
+    }
   }
 }

--- a/Tests/SourceKitLSPTests/ClosureCompletionFormatTests.swift
+++ b/Tests/SourceKitLSPTests/ClosureCompletionFormatTests.swift
@@ -1,0 +1,130 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Testing) import SourceKitLSP
+import Swift
+import SwiftBasicFormat
+import SwiftParser
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import XCTest
+
+fileprivate func assertFormatted<T: SyntaxProtocol>(
+  tree: T,
+  expected: String,
+  using format: ClosureCompletionFormat = ClosureCompletionFormat(indentationWidth: .spaces(4)),
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  XCTAssertEqual(tree.formatted(using: format).description, expected, file: file, line: line)
+}
+
+fileprivate func assertFormatted(
+  source: String,
+  expected: String,
+  using format: ClosureCompletionFormat = ClosureCompletionFormat(indentationWidth: .spaces(4)),
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  assertFormatted(
+    tree: Parser.parse(source: source),
+    expected: expected,
+    using: format,
+    file: file,
+    line: line
+  )
+}
+
+final class ClosureCompletionFormatTests: XCTestCase {
+  func testSingleStatementClosureArg() {
+    assertFormatted(
+      source: """
+        foo(bar: { baz in baz.quux })
+        """,
+      expected: """
+        foo(bar: { baz in baz.quux })
+        """
+    )
+  }
+
+  func testSingleStatementClosureArgAlreadyMultiLine() {
+    assertFormatted(
+      source: """
+        foo(
+          bar: { baz in
+            baz.quux
+          }
+        )
+        """,
+      expected: """
+        foo(
+          bar: { baz in
+            baz.quux
+          }
+        )
+        """
+    )
+  }
+
+  func testMultiStatmentClosureArg() {
+    assertFormatted(
+      source: """
+        foo(
+            bar: { baz in print(baz); return baz.quux }
+        )
+        """,
+      expected: """
+        foo(
+            bar: { baz in
+                print(baz);
+                return baz.quux
+            }
+        )
+        """
+    )
+  }
+
+  func testMultiStatementClosureArgAlreadyMultiLine() {
+    assertFormatted(
+      source: """
+        foo(
+            bar: { baz in
+                print(baz)
+                return baz.quux
+            }
+        )
+        """,
+      expected: """
+        foo(
+            bar: { baz in
+                print(baz)
+                return baz.quux
+            }
+        )
+        """
+    )
+  }
+
+  func testFormatClosureWithInitialIndentation() throws {
+    assertFormatted(
+      tree: ClosureExprSyntax(
+        statements: CodeBlockItemListSyntax([
+          CodeBlockItemSyntax(item: CodeBlockItemSyntax.Item(IntegerLiteralExprSyntax(integerLiteral: 2)))
+        ])
+      ),
+      expected: """
+            { 2 }
+        """,
+      using: ClosureCompletionFormat(initialIndentation: .spaces(4))
+    )
+  }
+}

--- a/Tests/SourceKitLSPTests/RewriteSourceKitPlaceholdersTests.swift
+++ b/Tests/SourceKitLSPTests/RewriteSourceKitPlaceholdersTests.swift
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SKTestSupport
+@_spi(Testing) import SourceKitLSP
+import XCTest
+
+final class RewriteSourceKitPlaceholdersTests: XCTestCase {
+  func testClientDoesNotSupportSnippets() {
+    let input = "foo(bar: <#T##Int##Int#>)"
+    let rewritten = rewriteSourceKitPlaceholders(in: input, clientSupportsSnippets: false)
+
+    XCTAssertEqual(rewritten, "foo(bar: )")
+  }
+
+  func testInputWithoutPlaceholders() {
+    let input = "foo()"
+    let rewritten = rewriteSourceKitPlaceholders(in: input, clientSupportsSnippets: true)
+
+    XCTAssertEqual(rewritten, "foo()")
+  }
+
+  func testPlaceholderWithType() {
+    let input = "foo(bar: <#T##bar##Int#>)"
+    let rewritten = rewriteSourceKitPlaceholders(in: input, clientSupportsSnippets: true)
+
+    XCTAssertEqual(rewritten, "foo(bar: ${1:Int})")
+  }
+
+  func testMultiplePlaceholders() {
+    let input = "foo(bar: <#T##Int##Int#>, baz: <#T##String##String#>, quux: <#T##String##String#>)"
+    let rewritten = rewriteSourceKitPlaceholders(in: input, clientSupportsSnippets: true)
+
+    XCTAssertEqual(rewritten, "foo(bar: ${1:Int}, baz: ${2:String}, quux: ${3:String})")
+  }
+
+  func testClosurePlaceholderReturnType() {
+    let input = "foo(bar: <#{ <#T##Int##Int#> }#>)"
+    let rewritten = rewriteSourceKitPlaceholders(in: input, clientSupportsSnippets: true)
+
+    XCTAssertEqual(rewritten, #"foo(bar: ${1:\{ ${2:Int} \}})"#)
+  }
+
+  func testClosurePlaceholderArgumentType() {
+    let input = "foo(bar: <#{ <#T##Int##Int#> in <#T##Void##Void#> }#>)"
+    let rewritten = rewriteSourceKitPlaceholders(in: input, clientSupportsSnippets: true)
+
+    XCTAssertEqual(rewritten, #"foo(bar: ${1:\{ ${2:Int} in ${3:Void} \}})"#)
+  }
+
+  func testMultipleClosurePlaceholders() {
+    let input = "foo(<#{ <#T##Int##Int#> }#>, baz: <#{ <#Int#> in <#T##Bool##Bool#> }#>)"
+    let rewritten = rewriteSourceKitPlaceholders(in: input, clientSupportsSnippets: true)
+
+    XCTAssertEqual(rewritten, #"foo(${1:\{ ${2:Int} \}}, baz: ${3:\{ ${4:Int} in ${5:Bool} \}})"#)
+  }
+}

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -863,20 +863,16 @@ final class SwiftCompletionTests: XCTestCase {
           deprecated: false,
           sortText: nil,
           filterText: "myMap(:)",
-          insertText: """
-            myMap { ${1:Int} in
-                ${2:Bool}
-            }
-            """,
+          insertText: #"""
+            myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+            """#,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
             TextEdit(
               range: Range(positions["1️⃣"]),
-              newText: """
-                myMap { ${1:Int} in
-                    ${2:Bool}
-                }
-                """
+              newText: #"""
+                myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+                """#
             )
           )
         )
@@ -911,20 +907,16 @@ final class SwiftCompletionTests: XCTestCase {
           deprecated: false,
           sortText: nil,
           filterText: ".myMap(:)",
-          insertText: """
-            ?.myMap { ${1:Int} in
-                ${2:Bool}
-            }
-            """,
+          insertText: #"""
+            ?.myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+            """#,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
             TextEdit(
               range: positions["1️⃣"]..<positions["2️⃣"],
-              newText: """
-                ?.myMap { ${1:Int} in
-                    ${2:Bool}
-                }
-                """
+              newText: #"""
+                ?.myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+                """#
             )
           )
         )
@@ -959,24 +951,16 @@ final class SwiftCompletionTests: XCTestCase {
           deprecated: false,
           sortText: nil,
           filterText: "myMap(::)",
-          insertText: """
-            myMap { ${1:Int} in
-                ${2:Bool}
-            } _: { ${3:Int} in
-                ${4:String}
-            }
-            """,
+          insertText: #"""
+            myMap(${1:\{ ${2:Int} in ${3:Bool} \}}, ${4:\{ ${5:Int} in ${6:String} \}})
+            """#,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
             TextEdit(
               range: Range(positions["1️⃣"]),
-              newText: """
-                myMap { ${1:Int} in
-                    ${2:Bool}
-                } _: { ${3:Int} in
-                    ${4:String}
-                }
-                """
+              newText: #"""
+                myMap(${1:\{ ${2:Int} in ${3:Bool} \}}, ${4:\{ ${5:Int} in ${6:String} \}})
+                """#
             )
           )
         )
@@ -1011,24 +995,16 @@ final class SwiftCompletionTests: XCTestCase {
           deprecated: false,
           sortText: nil,
           filterText: "myMap(:second:)",
-          insertText: """
-            myMap { ${1:Int} in
-                ${2:Bool}
-            } second: { ${3:Int} in
-                ${4:String}
-            }
-            """,
+          insertText: #"""
+            myMap(${1:\{ ${2:Int} in ${3:Bool} \}}, second: ${4:\{ ${5:Int} in ${6:String} \}})
+            """#,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
             TextEdit(
               range: Range(positions["1️⃣"]),
-              newText: """
-                myMap { ${1:Int} in
-                    ${2:Bool}
-                } second: { ${3:Int} in
-                    ${4:String}
-                }
-                """
+              newText: #"""
+                myMap(${1:\{ ${2:Int} in ${3:Bool} \}}, second: ${4:\{ ${5:Int} in ${6:String} \}})
+                """#
             )
           )
         )
@@ -1065,20 +1041,16 @@ final class SwiftCompletionTests: XCTestCase {
           deprecated: false,
           sortText: nil,
           filterText: "myMap(:)",
-          insertText: """
-            myMap { ${1:Int} in
-              ${2:Bool}
-            }
-            """,
+          insertText: #"""
+            myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+            """#,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
             TextEdit(
               range: Range(positions["1️⃣"]),
-              newText: """
-                myMap { ${1:Int} in
-                  ${2:Bool}
-                }
-                """
+              newText: #"""
+                myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+                """#
             )
           )
         )


### PR DESCRIPTION
This resolves <https://github.com/swiftlang/sourcekit-lsp/issues/1788>, following the discussion of alternatives on <https://github.com/swiftlang/sourcekit-lsp/pulls/1789>. The bulk of the change updates the translation from SourceKit placeholders to LSP placeholders to handle nesting, which is implemented in https://github.com/swiftlang/swift-syntax/pull/2897

https://github.com/user-attachments/assets/0d5cca51-95f9-44e9-8a48-92a296e40678

