### PR TITLE
Use `URL` in many cases where we used `AbsolutePath`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -97,6 +97,7 @@ var targets: [Target] = [
       "SKTestSupport",
       "SourceKitLSP",
       "ToolchainRegistry",
+      "TSCExtensions",
     ],
     swiftSettings: globalSwiftSettings
   ),
@@ -348,7 +349,6 @@ var targets: [Target] = [
       "Csourcekitd",
       "SKLogging",
       "SwiftExtensions",
-      .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
     ],
     exclude: ["CMakeLists.txt", "sourcekitd_uids.swift.gyb"],
     swiftSettings: globalSwiftSettings

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
@@ -12,22 +12,18 @@
 
 #if compiler(>=6)
 package import BuildServerProtocol
+package import Foundation
 package import LanguageServerProtocol
 import SKLogging
 import SKOptions
 import ToolchainRegistry
-
-package import struct TSCBasic.AbsolutePath
-package import struct TSCBasic.RelativePath
 #else
 import BuildServerProtocol
+import Foundation
 import LanguageServerProtocol
 import SKLogging
 import SKOptions
 import ToolchainRegistry
-
-import struct TSCBasic.AbsolutePath
-import struct TSCBasic.RelativePath
 #endif
 
 /// An error build systems can throw from `prepare` if they don't support preparation of targets.
@@ -42,16 +38,16 @@ package protocol BuiltInBuildSystem: AnyObject, Sendable {
   /// The root of the project that this build system manages. For example, for SwiftPM packages, this is the folder
   /// containing Package.swift. For compilation databases it is the root folder based on which the compilation database
   /// was found.
-  var projectRoot: AbsolutePath { get async }
+  var projectRoot: URL { get async }
 
   /// The files to watch for changes.
   var fileWatchers: [FileSystemWatcher] { get async }
 
   /// The path to the raw index store data, if any.
-  var indexStorePath: AbsolutePath? { get async }
+  var indexStorePath: URL? { get async }
 
   /// The path to put the index database, if any.
-  var indexDatabasePath: AbsolutePath? { get async }
+  var indexDatabasePath: URL? { get async }
 
   /// Whether the build system is capable of preparing a target for indexing, ie. if the `prepare` methods has been
   /// implemented.

--- a/Sources/BuildSystemIntegration/DetermineBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/DetermineBuildSystem.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Foundation
+
 #if compiler(>=6)
 package import LanguageServerProtocol
 import SKLogging
@@ -43,25 +45,21 @@ package func determineBuildSystem(
     buildSystemPreference.removeAll(where: { $0 == defaultBuildSystem })
     buildSystemPreference.insert(defaultBuildSystem, at: 0)
   }
-  guard let workspaceFolderUrl = workspaceFolder.fileURL,
-    let workspaceFolderPath = try? AbsolutePath(validating: workspaceFolderUrl.filePath)
-  else {
+  guard let workspaceFolderUrl = workspaceFolder.fileURL else {
     return nil
   }
   for buildSystemType in buildSystemPreference {
     switch buildSystemType {
     case .buildServer:
-      if let projectRoot = ExternalBuildSystemAdapter.projectRoot(for: workspaceFolderPath, options: options) {
+      if let projectRoot = ExternalBuildSystemAdapter.projectRoot(for: workspaceFolderUrl, options: options) {
         return BuildSystemSpec(kind: .buildServer, projectRoot: projectRoot)
       }
     case .compilationDatabase:
-      if let projectRoot = CompilationDatabaseBuildSystem.projectRoot(for: workspaceFolderPath, options: options) {
+      if let projectRoot = CompilationDatabaseBuildSystem.projectRoot(for: workspaceFolderUrl, options: options) {
         return BuildSystemSpec(kind: .compilationDatabase, projectRoot: projectRoot)
       }
     case .swiftPM:
-      if let projectRootURL = SwiftPMBuildSystem.projectRoot(for: workspaceFolderUrl, options: options),
-        let projectRoot = try? AbsolutePath(validating: projectRootURL.filePath)
-      {
+      if let projectRoot = SwiftPMBuildSystem.projectRoot(for: workspaceFolderUrl, options: options) {
         return BuildSystemSpec(kind: .swiftPM, projectRoot: projectRoot)
       }
     }

--- a/Sources/BuildSystemIntegration/LegacyBuildServerBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/LegacyBuildServerBuildSystem.swift
@@ -20,13 +20,6 @@ import SKOptions
 import SwiftExtensions
 import ToolchainRegistry
 
-import struct TSCBasic.AbsolutePath
-import protocol TSCBasic.FileSystem
-import struct TSCBasic.FileSystemError
-import func TSCBasic.getEnvSearchPaths
-import var TSCBasic.localFileSystem
-import func TSCBasic.lookupExecutablePath
-
 #if compiler(>=6.3)
 #warning("We have had a one year transition period to the pull based build server. Consider removing this build server")
 #endif
@@ -53,12 +46,12 @@ actor LegacyBuildServerBuildSystem: MessageHandler, BuiltInBuildSystem {
   /// execution of tasks.
   private let bspMessageHandlingQueue = AsyncQueue<Serial>()
 
-  package let projectRoot: AbsolutePath
+  package let projectRoot: URL
 
   var fileWatchers: [FileSystemWatcher] = []
 
-  let indexDatabasePath: AbsolutePath?
-  let indexStorePath: AbsolutePath?
+  let indexDatabasePath: URL?
+  let indexStorePath: URL?
 
   package let connectionToSourceKitLSP: LocalConnection
 
@@ -69,7 +62,7 @@ actor LegacyBuildServerBuildSystem: MessageHandler, BuiltInBuildSystem {
   private var urisRegisteredForChanges: Set<URI> = []
 
   init(
-    projectRoot: AbsolutePath,
+    projectRoot: URL,
     initializationData: InitializeBuildResponse,
     _ externalBuildSystemAdapter: ExternalBuildSystemAdapter
   ) async {
@@ -163,7 +156,7 @@ actor LegacyBuildServerBuildSystem: MessageHandler, BuiltInBuildSystem {
     return BuildTargetSourcesResponse(items: [
       SourcesItem(
         target: .dummy,
-        sources: [SourceItem(uri: DocumentURI(self.projectRoot.asURL), kind: .directory, generated: false)]
+        sources: [SourceItem(uri: DocumentURI(self.projectRoot), kind: .directory, generated: false)]
       )
     ])
   }

--- a/Sources/BuildSystemIntegration/TestBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/TestBuildSystem.swift
@@ -12,29 +12,27 @@
 
 #if compiler(>=6)
 package import BuildServerProtocol
+package import Foundation
 package import LanguageServerProtocol
 import SKOptions
 import ToolchainRegistry
-
-package import struct TSCBasic.AbsolutePath
 #else
 import BuildServerProtocol
+import Foundation
 import LanguageServerProtocol
 import SKOptions
 import ToolchainRegistry
-
-import struct TSCBasic.AbsolutePath
 #endif
 
 /// Build system to be used for testing BuildSystem and BuildSystemDelegate functionality with SourceKitLSPServer
 /// and other components.
 package actor TestBuildSystem: BuiltInBuildSystem {
-  package let projectRoot: AbsolutePath
+  package let projectRoot: URL
 
   package let fileWatchers: [FileSystemWatcher] = []
 
-  package let indexStorePath: AbsolutePath? = nil
-  package let indexDatabasePath: AbsolutePath? = nil
+  package let indexStorePath: URL? = nil
+  package let indexDatabasePath: URL? = nil
 
   private let connectionToSourceKitLSP: any Connection
 
@@ -49,7 +47,7 @@ package actor TestBuildSystem: BuiltInBuildSystem {
   package nonisolated var supportsPreparation: Bool { false }
 
   package init(
-    projectRoot: AbsolutePath,
+    projectRoot: URL,
     connectionToSourceKitLSP: any Connection
   ) {
     self.projectRoot = projectRoot

--- a/Sources/Diagnose/DiagnoseCommand.swift
+++ b/Sources/Diagnose/DiagnoseCommand.swift
@@ -97,7 +97,7 @@ package struct DiagnoseCommand: AsyncParsableCommand {
 
   var toolchainRegistry: ToolchainRegistry {
     get throws {
-      let installPath = try AbsolutePath(validating: Bundle.main.bundlePath)
+      let installPath = Bundle.main.bundleURL
       return ToolchainRegistry(installPath: installPath)
     }
   }
@@ -106,7 +106,7 @@ package struct DiagnoseCommand: AsyncParsableCommand {
   var toolchain: Toolchain? {
     get async throws {
       if let toolchainOverride {
-        return Toolchain(try AbsolutePath(validating: toolchainOverride))
+        return Toolchain(URL(fileURLWithPath: toolchainOverride))
       }
       return try await toolchainRegistry.default
     }
@@ -178,14 +178,14 @@ package struct DiagnoseCommand: AsyncParsableCommand {
         .deletingLastPathComponent()
         .deletingLastPathComponent()
 
-      guard let toolchain = try Toolchain(AbsolutePath(validating: toolchainPath.filePath)),
+      guard let toolchain = Toolchain(toolchainPath),
         let sourcekitd = toolchain.sourcekitd
       else {
         continue
       }
 
       let executor = OutOfProcessSourceKitRequestExecutor(
-        sourcekitd: sourcekitd.asURL,
+        sourcekitd: sourcekitd,
         swiftFrontend: crashInfo.swiftFrontend,
         reproducerPredicate: nil
       )
@@ -335,7 +335,7 @@ package struct DiagnoseCommand: AsyncParsableCommand {
         message: "Determining Swift version of \(toolchain.identifier)"
       )
 
-      guard let swiftUrl = toolchain.swift?.asURL else {
+      guard let swiftUrl = toolchain.swift else {
         continue
       }
 
@@ -461,7 +461,7 @@ package struct DiagnoseCommand: AsyncParsableCommand {
 
     let requestInfo = requestInfo
     let executor = OutOfProcessSourceKitRequestExecutor(
-      sourcekitd: sourcekitd.asURL,
+      sourcekitd: sourcekitd,
       swiftFrontend: swiftFrontend,
       reproducerPredicate: nil
     )

--- a/Sources/Diagnose/IndexCommand.swift
+++ b/Sources/Diagnose/IndexCommand.swift
@@ -105,15 +105,15 @@ package struct IndexCommand: AsyncParsableCommand {
     )
 
     let installPath =
-      if let toolchainOverride, let toolchain = Toolchain(try AbsolutePath(validating: toolchainOverride)) {
+      if let toolchainOverride, let toolchain = Toolchain(URL(fileURLWithPath: toolchainOverride)) {
         toolchain.path
       } else {
-        try AbsolutePath(validating: Bundle.main.bundlePath)
+        Bundle.main.bundleURL
       }
 
     let messageHandler = IndexLogMessageHandler()
     let inProcessClient = try await InProcessSourceKitLSPClient(
-      toolchainPath: installPath?.asURL,
+      toolchainPath: installPath,
       options: options,
       workspaceFolders: [WorkspaceFolder(uri: DocumentURI(URL(fileURLWithPath: project)))],
       messageHandler: messageHandler

--- a/Sources/Diagnose/ReduceCommand.swift
+++ b/Sources/Diagnose/ReduceCommand.swift
@@ -68,10 +68,9 @@ package struct ReduceCommand: AsyncParsableCommand {
   var toolchain: Toolchain? {
     get async throws {
       if let toolchainOverride {
-        return Toolchain(try AbsolutePath(validating: toolchainOverride))
+        return Toolchain(URL(fileURLWithPath: toolchainOverride))
       }
-      let installPath = try AbsolutePath(validating: Bundle.main.bundlePath)
-      return await ToolchainRegistry(installPath: installPath).default
+      return await ToolchainRegistry(installPath: Bundle.main.bundleURL).default
     }
   }
 
@@ -92,7 +91,7 @@ package struct ReduceCommand: AsyncParsableCommand {
     let requestInfo = try RequestInfo(request: request)
 
     let executor = OutOfProcessSourceKitRequestExecutor(
-      sourcekitd: sourcekitd.asURL,
+      sourcekitd: sourcekitd,
       swiftFrontend: swiftFrontend,
       reproducerPredicate: nsPredicate
     )

--- a/Sources/Diagnose/ReduceFrontendCommand.swift
+++ b/Sources/Diagnose/ReduceFrontendCommand.swift
@@ -76,10 +76,9 @@ package struct ReduceFrontendCommand: AsyncParsableCommand {
   var toolchain: Toolchain? {
     get async throws {
       if let toolchainOverride {
-        return Toolchain(try AbsolutePath(validating: toolchainOverride))
+        return Toolchain(URL(fileURLWithPath: toolchainOverride))
       }
-      let installPath = try AbsolutePath(validating: Bundle.main.bundlePath)
-      return await ToolchainRegistry(installPath: installPath).default
+      return await ToolchainRegistry(installPath: Bundle.main.bundleURL).default
     }
   }
 
@@ -100,7 +99,7 @@ package struct ReduceFrontendCommand: AsyncParsableCommand {
     )
 
     let executor = OutOfProcessSourceKitRequestExecutor(
-      sourcekitd: sourcekitd.asURL,
+      sourcekitd: sourcekitd,
       swiftFrontend: swiftFrontend,
       reproducerPredicate: nsPredicate
     )

--- a/Sources/Diagnose/ReproducerBundle.swift
+++ b/Sources/Diagnose/ReproducerBundle.swift
@@ -29,7 +29,7 @@ func makeReproducerBundle(for requestInfo: RequestInfo, toolchain: Toolchain, bu
     encoding: .utf8
   )
   if let toolchainPath = toolchain.path {
-    try toolchainPath.asURL.realpath.filePath
+    try toolchainPath.realpath.filePath
       .write(
         to: bundlePath.appendingPathComponent("toolchain.txt"),
         atomically: true,

--- a/Sources/Diagnose/RunSourcekitdRequestCommand.swift
+++ b/Sources/Diagnose/RunSourcekitdRequestCommand.swift
@@ -15,6 +15,7 @@ package import ArgumentParser
 import Csourcekitd
 import Foundation
 import SKUtilities
+import SwiftExtensions
 import SourceKitD
 import ToolchainRegistry
 
@@ -25,6 +26,7 @@ import Csourcekitd
 import Foundation
 import SKUtilities
 import SourceKitD
+import SwiftExtensions
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
@@ -55,18 +57,17 @@ package struct RunSourceKitdRequestCommand: AsyncParsableCommand {
   package init() {}
 
   package func run() async throws {
-    let installPath = try AbsolutePath(validating: Bundle.main.bundlePath)
     let sourcekitdPath =
       if let sourcekitdPath {
-        sourcekitdPath
-      } else if let path = await ToolchainRegistry(installPath: installPath).default?.sourcekitd?.pathString {
+        URL(fileURLWithPath: sourcekitdPath)
+      } else if let path = await ToolchainRegistry(installPath: Bundle.main.bundleURL).default?.sourcekitd {
         path
       } else {
         print("Did not find sourcekitd in the toolchain. Specify path to sourcekitd manually by passing --sourcekitd")
         throw ExitCode(1)
       }
     let sourcekitd = try await DynamicallyLoadedSourceKitD.getOrCreate(
-      dylibPath: try! AbsolutePath(validating: sourcekitdPath)
+      dylibPath: sourcekitdPath
     )
 
     var lastResponse: SKDResponse?

--- a/Sources/InProcessClient/InProcessSourceKitLSPClient.swift
+++ b/Sources/InProcessClient/InProcessSourceKitLSPClient.swift
@@ -70,7 +70,7 @@ public final class InProcessSourceKitLSPClient: Sendable {
     let serverToClientConnection = LocalConnection(receiverName: "client")
     self.server = SourceKitLSPServer(
       client: serverToClientConnection,
-      toolchainRegistry: ToolchainRegistry(installPath: AbsolutePath(validatingOrNil: try? toolchainPath?.filePath)),
+      toolchainRegistry: ToolchainRegistry(installPath: toolchainPath),
       options: options,
       testHooks: TestHooks(),
       onExit: {

--- a/Sources/SKTestSupport/FileManager+createFiles.swift
+++ b/Sources/SKTestSupport/FileManager+createFiles.swift
@@ -11,27 +11,22 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6)
-package import struct TSCBasic.AbsolutePath
-package import struct TSCBasic.ByteString
-package import protocol TSCBasic.FileSystem
+package import Foundation
 #else
-import struct TSCBasic.AbsolutePath
-import struct TSCBasic.ByteString
-import protocol TSCBasic.FileSystem
+import Foundation
 #endif
 
-extension FileSystem {
-
+extension FileManager {
   /// Creates files from a dictionary of path to contents.
   ///
   /// - parameters:
   ///   - root: The root directory that the paths are relative to.
   ///   - files: Dictionary from path (relative to root) to contents.
-  package func createFiles(root: AbsolutePath = .root, files: [String: ByteString]) throws {
+  package func createFiles(root: URL, files: [String: String]) throws {
     for (path, contents) in files {
-      let path = try AbsolutePath(validating: path, relativeTo: root)
-      try createDirectory(path.parentDirectory, recursive: true)
-      try writeFileContents(path, bytes: contents)
+      let path = URL(fileURLWithPath: path, relativeTo: root)
+      try createDirectory(at: path.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try contents.write(to: path, atomically: true, encoding: .utf8)
     }
   }
 }

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -62,7 +62,7 @@ package struct IndexedSingleSwiftFileTestProject {
     let testFileURL = testWorkspaceDirectory.appendingPathComponent("test.swift")
     let indexURL = testWorkspaceDirectory.appendingPathComponent("index")
     self.indexDBURL = testWorkspaceDirectory.appendingPathComponent("index-db")
-    guard let swiftc = await ToolchainRegistry.forTesting.default?.swiftc?.asURL else {
+    guard let swiftc = await ToolchainRegistry.forTesting.default?.swiftc else {
       throw Error.swiftcNotFound
     }
 

--- a/Sources/SKTestSupport/MultiFileTestProject.swift
+++ b/Sources/SKTestSupport/MultiFileTestProject.swift
@@ -104,9 +104,15 @@ package class MultiFileTestProject {
 
     var fileData: [String: FileData] = [:]
     for (fileLocation, markedText) in files {
+      // Drop trailing slashes from the test dir URL, so tests can write `$TEST_DIR_URL/someFile.swift` without ending
+      // up with double slashes.
+      var testDirUrl = scratchDirectory.absoluteString
+      while testDirUrl.hasSuffix("/") {
+        testDirUrl = String(testDirUrl.dropLast())
+      }
       let markedText =
         markedText
-        .replacingOccurrences(of: "$TEST_DIR_URL", with: scratchDirectory.absoluteString)
+        .replacingOccurrences(of: "$TEST_DIR_URL", with: testDirUrl)
         .replacingOccurrences(of: "$TEST_DIR", with: try scratchDirectory.filePath)
       let fileURL = fileLocation.url(relativeTo: scratchDirectory)
       try FileManager.default.createDirectory(

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -224,7 +224,7 @@ package class SwiftPMTestProject: MultiFileTestProject {
 
   /// Build a SwiftPM package package manifest is located in the directory at `path`.
   package static func build(at path: URL, extraArguments: [String] = []) async throws {
-    guard let swift = await ToolchainRegistry.forTesting.default?.swift?.asURL else {
+    guard let swift = await ToolchainRegistry.forTesting.default?.swift else {
       throw Error.swiftNotFound
     }
     var arguments =
@@ -246,7 +246,7 @@ package class SwiftPMTestProject: MultiFileTestProject {
 
   /// Resolve package dependencies for the package at `path`.
   package static func resolvePackageDependencies(at path: URL) async throws {
-    guard let swift = await ToolchainRegistry.forTesting.default?.swift?.asURL else {
+    guard let swift = await ToolchainRegistry.forTesting.default?.swift else {
       throw Error.swiftNotFound
     }
     let arguments = [

--- a/Sources/SKTestSupport/Utils.swift
+++ b/Sources/SKTestSupport/Utils.swift
@@ -14,7 +14,7 @@
 package import Foundation
 package import LanguageServerProtocol
 import SwiftExtensions
-package import struct TSCBasic.AbsolutePath
+import struct TSCBasic.AbsolutePath
 #else
 import Foundation
 import LanguageServerProtocol
@@ -73,11 +73,11 @@ package func testScratchDir(testName: String = #function) throws -> URL {
   #if os(Windows)
   let url = try FileManager.default.temporaryDirectory.realpath
     .appendingPathComponent("lsp-test")
-    .appendingPathComponent("\(uuid)")
+    .appendingPathComponent("\(uuid)", isDirectory: true)
   #else
   let url = try FileManager.default.temporaryDirectory.realpath
     .appendingPathComponent("sourcekit-lsp-test-scratch")
-    .appendingPathComponent("\(testBaseName)-\(uuid)")
+    .appendingPathComponent("\(testBaseName)-\(uuid)", isDirectory: true)
   #endif
   try? FileManager.default.removeItem(at: url)
   try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
@@ -90,7 +90,7 @@ package func testScratchDir(testName: String = #function) throws -> URL {
 /// The temporary directory will be deleted at the end of `directory` unless the
 /// `SOURCEKIT_LSP_KEEP_TEST_SCRATCH_DIR` environment variable is set.
 package func withTestScratchDir<T>(
-  @_inheritActorContext _ body: @Sendable (AbsolutePath) async throws -> T,
+  @_inheritActorContext _ body: @Sendable (URL) async throws -> T,
   testName: String = #function
 ) async throws -> T {
   let scratchDirectory = try testScratchDir(testName: testName)
@@ -100,7 +100,7 @@ package func withTestScratchDir<T>(
       try? FileManager.default.removeItem(at: scratchDirectory)
     }
   }
-  return try await body(try AbsolutePath(validating: scratchDirectory.filePath))
+  return try await body(scratchDirectory)
 }
 
 var globalModuleCache: URL? {

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -335,7 +335,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
     try await runIndexingProcess(
       indexFile: uri,
       buildSettings: buildSettings,
-      processArguments: [swiftc.pathString] + indexingArguments,
+      processArguments: [swiftc.filePath] + indexingArguments,
       workingDirectory: buildSettings.workingDirectory.map(AbsolutePath.init(validating:))
     )
   }
@@ -360,7 +360,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
     try await runIndexingProcess(
       indexFile: uri,
       buildSettings: buildSettings,
-      processArguments: [clang.pathString] + indexingArguments,
+      processArguments: [clang.filePath] + indexingArguments,
       workingDirectory: buildSettings.workingDirectory.map(AbsolutePath.init(validating:))
     )
   }

--- a/Sources/SourceKitD/SourceKitDRegistry.swift
+++ b/Sources/SourceKitD/SourceKitDRegistry.swift
@@ -10,12 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-
 #if compiler(>=6)
-package import struct TSCBasic.AbsolutePath
+package import Foundation
 #else
-import struct TSCBasic.AbsolutePath
+import Foundation
 #endif
 
 /// The set of known SourceKitD instances, uniqued by path.
@@ -30,10 +28,10 @@ import struct TSCBasic.AbsolutePath
 package actor SourceKitDRegistry {
 
   /// Mapping from path to active SourceKitD instance.
-  private var active: [AbsolutePath: SourceKitD] = [:]
+  private var active: [URL: SourceKitD] = [:]
 
   /// Instances that have been unregistered, but may be resurrected if accessed before destruction.
-  private var cemetary: [AbsolutePath: WeakSourceKitD] = [:]
+  private var cemetary: [URL: WeakSourceKitD] = [:]
 
   /// Initialize an empty registry.
   package init() {}
@@ -43,7 +41,7 @@ package actor SourceKitDRegistry {
 
   /// Returns the existing SourceKitD for the given path, or creates it and registers it.
   package func getOrAdd(
-    _ key: AbsolutePath,
+    _ key: URL,
     create: @Sendable () throws -> SourceKitD
   ) rethrows -> SourceKitD {
     if let existing = active[key] {
@@ -66,7 +64,7 @@ package actor SourceKitDRegistry {
   /// is converted to a weak reference until it is no longer referenced anywhere by the program. If
   /// the same path is looked up again before the original service is deinitialized, the original
   /// service is resurrected rather than creating a new instance.
-  package func remove(_ key: AbsolutePath) -> SourceKitD? {
+  package func remove(_ key: URL) -> SourceKitD? {
     let existing = active.removeValue(forKey: key)
     if let existing = existing {
       assert(self.cemetary[key]?.value == nil)

--- a/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
+++ b/Sources/SourceKitLSP/Clang/ClangLanguageService.swift
@@ -22,8 +22,6 @@ import SwiftSyntax
 import TSCExtensions
 import ToolchainRegistry
 
-import struct TSCBasic.AbsolutePath
-
 #if os(Windows)
 import WinSDK
 #endif
@@ -59,10 +57,10 @@ actor ClangLanguageService: LanguageService, MessageHandler {
   var capabilities: ServerCapabilities? = nil
 
   /// Path to the clang binary.
-  let clangPath: AbsolutePath?
+  let clangPath: URL?
 
   /// Path to the `clangd` binary.
-  let clangdPath: AbsolutePath
+  let clangdPath: URL
 
   let clangdOptions: [String]
 
@@ -178,7 +176,7 @@ actor ClangLanguageService: LanguageService, MessageHandler {
     openDocuments = [:]
 
     let (connectionToClangd, process) = try JSONRPCConnection.start(
-      executable: clangdPath.asURL,
+      executable: clangdPath,
       arguments: [
         "-compile_args_from=lsp",  // Provide compiler args programmatically.
         "-background-index=false",  // Disable clangd indexing, we use the build
@@ -459,9 +457,7 @@ extension ClangLanguageService {
     let clangBuildSettings = await self.buildSettings(for: uri, fallbackAfterTimeout: false)
 
     // The compile command changed, send over the new one.
-    if let compileCommand = clangBuildSettings?.compileCommand,
-      let pathString = AbsolutePath(validatingOrNil: try? url.filePath)?.pathString
-    {
+    if let compileCommand = clangBuildSettings?.compileCommand, let pathString = try? url.filePath {
       let notification = DidChangeConfigurationNotification(
         settings: .clangd(ClangWorkspaceSettings(compilationDatabaseChanges: [pathString: compileCommand]))
       )
@@ -644,8 +640,8 @@ private struct ClangBuildSettings: Equatable {
   /// fallback arguments and represent the file state differently.
   package let isFallback: Bool
 
-  package init(_ settings: FileBuildSettings, clangPath: AbsolutePath?) {
-    var arguments = [clangPath?.pathString ?? "clang"] + settings.compilerArguments
+  package init(_ settings: FileBuildSettings, clangPath: URL?) {
+    var arguments = [(try? clangPath?.filePath) ?? "clang"] + settings.compilerArguments
     if arguments.contains("-fmodules") {
       // Clangd is not built with support for the 'obj' format.
       arguments.append(contentsOf: [

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -30,7 +30,6 @@ package import ToolchainRegistry
 import struct PackageModel.BuildFlags
 import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.FileSystem
-import var TSCBasic.localFileSystem
 #else
 import BuildServerProtocol
 import BuildSystemIntegration
@@ -51,7 +50,6 @@ import ToolchainRegistry
 import struct PackageModel.BuildFlags
 import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.FileSystem
-import var TSCBasic.localFileSystem
 #endif
 
 /// Disambiguate LanguageServerProtocol.Language and IndexstoreDB.Language
@@ -540,7 +538,7 @@ package actor SourceKitLSPServer {
 
     logger.log(
       """
-      Using toolchain at \(toolchain.path?.pathString ?? "<nil>") (\(toolchain.identifier, privacy: .public)) \
+      Using toolchain at \(toolchain.path?.description ?? "<nil>") (\(toolchain.identifier, privacy: .public)) \
       for \(uri.forLogging)
       """
     )

--- a/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
@@ -15,6 +15,7 @@ import Foundation
 package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
+import SwiftExtensions
 import SwiftParser
 import SwiftSyntax
 import TSCExtensions
@@ -27,6 +28,7 @@ import Foundation
 import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
+import SwiftExtensions
 import SwiftParser
 import SwiftSyntax
 import TSCExtensions
@@ -168,7 +170,7 @@ extension SwiftLanguageService {
     }
 
     var args = try [
-      swiftFormat.pathString,
+      swiftFormat.filePath,
       "format",
       "--configuration",
       swiftFormatConfiguration(for: textDocument.uri, options: options),

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -28,8 +28,6 @@ import SwiftParser
 import SwiftParserDiagnostics
 package import SwiftSyntax
 package import ToolchainRegistry
-
-import struct TSCBasic.AbsolutePath
 #else
 import BuildSystemIntegration
 import Csourcekitd
@@ -48,8 +46,6 @@ import SwiftParser
 import SwiftParserDiagnostics
 import SwiftSyntax
 import ToolchainRegistry
-
-import struct TSCBasic.AbsolutePath
 #endif
 
 #if os(Windows)
@@ -125,7 +121,7 @@ package actor SwiftLanguageService: LanguageService, Sendable {
   let sourcekitd: SourceKitD
 
   /// Path to the swift-format executable if it exists in the toolchain.
-  let swiftFormat: AbsolutePath?
+  let swiftFormat: URL?
 
   /// Queue on which notifications from sourcekitd are handled to ensure we are
   /// handling them in-order.

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -232,7 +232,7 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
     )
 
     logger.log(
-      "Created workspace at \(rootUri.forLogging) with project root \(buildSystemSpec?.projectRoot.pathString ?? "<nil>")"
+      "Created workspace at \(rootUri.forLogging) with project root \(buildSystemSpec?.projectRoot.description ?? "<nil>")"
     )
 
     var index: IndexStoreDB? = nil
@@ -249,7 +249,7 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
     )
     if let indexStorePath, let indexDatabasePath, let libPath = await toolchainRegistry.default?.libIndexStore {
       do {
-        let lib = try IndexStoreLibrary(dylibPath: libPath.pathString)
+        let lib = try IndexStoreLibrary(dylibPath: libPath.filePath)
         indexDelegate = SourceKitIndexDelegate()
         let prefixMappings =
           indexOptions.indexPrefixMap?.map { PathPrefixMapping(original: $0.key, replacement: $0.value) } ?? []

--- a/Sources/SwiftExtensions/FileManagerExtensions.swift
+++ b/Sources/SwiftExtensions/FileManagerExtensions.swift
@@ -24,4 +24,17 @@ extension FileManager {
     }
     return self.fileExists(atPath: filePath)
   }
+
+  /// Returns `true` if an entry exists in the file system at the given URL and that entry is a directory.
+  package func isDirectory(at url: URL) -> Bool {
+    var isDirectory: ObjCBool = false
+    return self.fileExists(atPath: url.path, isDirectory: &isDirectory) && isDirectory.boolValue
+  }
+
+  /// Returns `true` if an entry exists in the file system at the given URL and that entry is a file, ie. not a
+  /// directory.
+  package func isFile(at url: URL) -> Bool {
+    var isDirectory: ObjCBool = false
+    return self.fileExists(atPath: url.path, isDirectory: &isDirectory) && !isDirectory.boolValue
+  }
 }

--- a/Sources/SwiftExtensions/URLExtensions.swift
+++ b/Sources/SwiftExtensions/URLExtensions.swift
@@ -76,9 +76,19 @@ extension URL {
     }
   }
 
-  /// Deprecate `path` to encourage using `filePath`, at least if `SwiftExtensions` is imported.
-  @available(*, deprecated, message: "Use filePath instead", renamed: "filePath")
-  package var path: String {
-    return try! filePath
+  package var isRoot: Bool {
+    #if os(Windows)
+    // FIXME: We should call into Windows' native check to check if this path is a root once https://github.com/swiftlang/swift-foundation/issues/976 is fixed.
+    return self.pathComponents.count <= 1
+    #else
+    // On Linux, we may end up with an string for the path due to https://github.com/swiftlang/swift-foundation/issues/980
+    // TODO: Remove the check for "" once https://github.com/swiftlang/swift-foundation/issues/980 is fixed.
+    return self.path == "/" || self.path == ""
+    #endif
+  }
+
+  /// Returns true if the path of `self` starts with the path in `other`.
+  package func isDescendant(of other: URL) -> Bool {
+    return self.pathComponents.dropLast().starts(with: other.pathComponents)
   }
 }

--- a/Sources/TSCExtensions/CMakeLists.txt
+++ b/Sources/TSCExtensions/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(TSCExtensions STATIC
   ByteString.swift
   Process+Run.swift
   SwitchableProcessResultExitStatus.swift
+  URL+appendingRelativePath.swift
 )
 set_target_properties(TSCExtensions PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/TSCExtensions/URL+appendingRelativePath.swift
+++ b/Sources/TSCExtensions/URL+appendingRelativePath.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,23 +10,27 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftExtensions
+
 #if compiler(>=6)
+package import struct TSCBasic.AbsolutePath
+package import struct TSCBasic.RelativePath
 package import Foundation
-import ToolchainRegistry
-
-import struct TSCBasic.AbsolutePath
 #else
-import Foundation
-import ToolchainRegistry
-
 import struct TSCBasic.AbsolutePath
+import struct TSCBasic.RelativePath
+import Foundation
 #endif
 
-extension Toolchain {
-  /// The path to `swift-frontend` in the toolchain, found relative to `swift`.
-  ///
-  /// - Note: Not discovered as part of the toolchain because `swift-frontend` is only needed in the diagnose commands.
-  package var swiftFrontend: URL? {
-    return swift?.deletingLastPathComponent().appendingPathComponent("swift-frontend")
+extension URL {
+  package func appending(_ relativePath: RelativePath) -> URL {
+    var result = self
+    for component in relativePath.components {
+      if component == "." {
+        continue
+      }
+      result.appendPathComponent(component)
+    }
+    return result
   }
 }

--- a/Sources/ToolchainRegistry/ToolchainRegistry.swift
+++ b/Sources/ToolchainRegistry/ToolchainRegistry.swift
@@ -11,26 +11,23 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
-import Foundation
 import LanguageServerProtocolExtensions
+import SwiftExtensions
 import TSCExtensions
 
 #if compiler(>=6)
-package import struct TSCBasic.AbsolutePath
-package import protocol TSCBasic.FileSystem
+package import Foundation
 package import class TSCBasic.Process
 package import enum TSCBasic.ProcessEnv
 package import struct TSCBasic.ProcessEnvironmentKey
 package import func TSCBasic.getEnvSearchPaths
-package import var TSCBasic.localFileSystem
 #else
+import Foundation
 import struct TSCBasic.AbsolutePath
-import protocol TSCBasic.FileSystem
 import class TSCBasic.Process
 import enum TSCBasic.ProcessEnv
 import struct TSCBasic.ProcessEnvironmentKey
 import func TSCBasic.getEnvSearchPaths
-import var TSCBasic.localFileSystem
 #endif
 
 /// Set of known toolchains.
@@ -74,7 +71,7 @@ package final actor ToolchainRegistry {
   /// The toolchains indexed by their path.
   ///
   /// Note: Not all toolchains have a path.
-  private let toolchainsByPath: [AbsolutePath: Toolchain]
+  private let toolchainsByPath: [URL: Toolchain]
 
   /// The currently selected toolchain identifier on Darwin.
   package let darwinToolchainOverride: String?
@@ -101,7 +98,7 @@ package final actor ToolchainRegistry {
   ) {
     var toolchainsAndReasons: [(toolchain: Toolchain, reason: ToolchainRegisterReason)] = []
     var toolchainsByIdentifier: [String: [Toolchain]] = [:]
-    var toolchainsByPath: [AbsolutePath: Toolchain] = [:]
+    var toolchainsByPath: [URL: Toolchain] = [:]
     for (toolchain, reason) in toolchainsAndReasonsParam {
       // Non-XcodeDefault toolchain: disallow all duplicates.
       if toolchain.identifier != ToolchainRegistry.darwinDefaultToolchainIdentifier {
@@ -137,7 +134,7 @@ package final actor ToolchainRegistry {
   /// installations but not next to the `sourcekit-lsp` binary because there is no `sourcekit-lsp` binary during
   /// testing.
   package static var forTesting: ToolchainRegistry {
-    ToolchainRegistry(localFileSystem)
+    ToolchainRegistry()
   }
 
   /// Creates a toolchain registry populated by scanning for toolchains according to the given paths
@@ -150,19 +147,20 @@ package final actor ToolchainRegistry {
   /// * (Darwin) `[~]/Library/Developer/Toolchains`
   /// * `env SOURCEKIT_PATH, PATH`
   package init(
-    installPath: AbsolutePath? = nil,
+    installPath: URL? = nil,
     environmentVariables: [ProcessEnvironmentKey] = ["SOURCEKIT_TOOLCHAIN_PATH"],
-    xcodes: [AbsolutePath] = [_currentXcodeDeveloperPath].compactMap({ $0 }),
-    darwinToolchainOverride: String? = ProcessEnv.block["TOOLCHAINS"],
-    _ fileSystem: FileSystem = localFileSystem
+    xcodes: [URL] = [_currentXcodeDeveloperPath].compactMap({ $0 }),
+    libraryDirectories: [URL] = FileManager.default.urls(for: .libraryDirectory, in: .allDomainsMask),
+    pathEnvironmentVariables: [ProcessEnvironmentKey] = ["SOURCEKIT_PATH", "PATH"],
+    darwinToolchainOverride: String? = ProcessEnv.block["TOOLCHAINS"]
   ) {
     // The paths at which we have found toolchains
-    var toolchainPaths: [(path: AbsolutePath, reason: ToolchainRegisterReason)] = []
+    var toolchainPaths: [(path: URL, reason: ToolchainRegisterReason)] = []
 
     // Scan for toolchains in the paths given by `environmentVariables`.
     for envVar in environmentVariables {
-      if let pathStr = ProcessEnv.block[envVar], let path = try? AbsolutePath(validating: pathStr) {
-        toolchainPaths.append((path, .sourcekitToolchainEnvironmentVariable))
+      if let pathStr = ProcessEnv.block[envVar] {
+        toolchainPaths.append((URL(fileURLWithPath: pathStr), .sourcekitToolchainEnvironmentVariable))
       }
     }
 
@@ -172,39 +170,39 @@ package final actor ToolchainRegistry {
     }
 
     // Search for toolchains in the Xcode developer directories and global toolchain install paths
-    let toolchainSearchPaths =
+    var toolchainSearchPaths =
       xcodes.map {
-        if $0.extension == "app" {
-          return $0.appending(components: "Contents", "Developer", "Toolchains")
+        if $0.pathExtension == "app" {
+          return $0.appendingPathComponent("Contents").appendingPathComponent("Developer").appendingPathComponent(
+            "Toolchains"
+          )
         } else {
-          return $0.appending(component: "Toolchains")
+          return $0.appendingPathComponent("Toolchains")
         }
       }
-      + FileManager.default.urls(for: .libraryDirectory, in: .allDomainsMask).compactMap {
-        AbsolutePath(validatingOrNil: $0.appendingPathComponent("Developer").appendingPathComponent("Toolchains").path)
-      }
+    toolchainSearchPaths += libraryDirectories.compactMap {
+      $0.appendingPathComponent("Developer").appendingPathComponent("Toolchains")
+    }
 
     for xctoolchainSearchPath in toolchainSearchPaths {
-      guard let direntries = try? fileSystem.getDirectoryContents(xctoolchainSearchPath) else {
-        continue
-      }
-      for name in direntries {
-        let path = xctoolchainSearchPath.appending(component: name)
-        if path.extension == "xctoolchain" {
-          toolchainPaths.append((path, .xcode))
+      let entries =
+        (try? FileManager.default.contentsOfDirectory(at: xctoolchainSearchPath, includingPropertiesForKeys: nil)) ?? []
+      for entry in entries {
+        if entry.pathExtension == "xctoolchain" {
+          toolchainPaths.append((entry, .xcode))
         }
       }
     }
 
     // Scan for toolchains by the given PATH-like environment variables.
-    for envVar: ProcessEnvironmentKey in ["SOURCEKIT_PATH", "PATH", "Path"] {
+    for envVar: ProcessEnvironmentKey in pathEnvironmentVariables {
       for path in getEnvSearchPaths(pathString: ProcessEnv.block[envVar], currentWorkingDirectory: nil) {
-        toolchainPaths.append((path, .pathEnvironmentVariable))
+        toolchainPaths.append((path.asURL, .pathEnvironmentVariable))
       }
     }
 
     let toolchainsAndReasons = toolchainPaths.compactMap {
-      if let toolchain = Toolchain($0.path, fileSystem) {
+      if let toolchain = Toolchain($0.path) {
         return (toolchain, $0.reason)
       }
       return nil
@@ -253,7 +251,7 @@ package final actor ToolchainRegistry {
   }
 
   /// Returns the preferred toolchain that contains all the tools at the given key paths.
-  package func preferredToolchain(containing requiredTools: [KeyPath<Toolchain, AbsolutePath?>]) -> Toolchain? {
+  package func preferredToolchain(containing requiredTools: [KeyPath<Toolchain, URL?>]) -> Toolchain? {
     if let toolchain = self.default, requiredTools.allSatisfy({ toolchain[keyPath: $0] != nil }) {
       return toolchain
     }
@@ -274,15 +272,15 @@ extension ToolchainRegistry {
     return toolchainsByIdentifier[identifier] ?? []
   }
 
-  package func toolchain(withPath path: AbsolutePath) -> Toolchain? {
+  package func toolchain(withPath path: URL) -> Toolchain? {
     return toolchainsByPath[path]
   }
 }
 
 extension ToolchainRegistry {
   /// The path of the current Xcode.app/Contents/Developer.
-  package static var _currentXcodeDeveloperPath: AbsolutePath? {
+  package static var _currentXcodeDeveloperPath: URL? {
     guard let str = try? Process.checkNonZeroExit(args: "/usr/bin/xcode-select", "-p") else { return nil }
-    return try? AbsolutePath(validating: str.trimmingCharacters(in: .whitespacesAndNewlines))
+    return URL(fileURLWithPath: str.trimmingCharacters(in: .whitespacesAndNewlines))
   }
 }

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -103,7 +103,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let a = try DocumentURI(string: "bsm:a.swift")
     let mainFiles = ManualMainFilesProvider([a: [a]])
     let bsm = await BuildSystemManager(
-      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: try AbsolutePath(validating: "/")),
+      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: URL(fileURLWithPath: "/")),
       toolchainRegistry: ToolchainRegistry.forTesting,
       options: SourceKitLSPOptions(),
       connectionToClient: DummyBuildSystemManagerConnectionToClient(),
@@ -136,7 +136,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let a = try DocumentURI(string: "bsm:a.swift")
     let mainFiles = ManualMainFilesProvider([a: [a]])
     let bsm = await BuildSystemManager(
-      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: try AbsolutePath(validating: "/")),
+      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: URL(fileURLWithPath: "/")),
       toolchainRegistry: ToolchainRegistry.forTesting,
       options: SourceKitLSPOptions(),
       connectionToClient: DummyBuildSystemManagerConnectionToClient(),
@@ -158,7 +158,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let a = try DocumentURI(string: "bsm:a.swift")
     let mainFiles = ManualMainFilesProvider([a: [a]])
     let bsm = await BuildSystemManager(
-      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: try AbsolutePath(validating: "/")),
+      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: URL(fileURLWithPath: "/")),
       toolchainRegistry: ToolchainRegistry.forTesting,
       options: SourceKitLSPOptions(),
       connectionToClient: DummyBuildSystemManagerConnectionToClient(),
@@ -202,7 +202,7 @@ final class BuildSystemManagerTests: XCTestCase {
     )
 
     let bsm = await BuildSystemManager(
-      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: try AbsolutePath(validating: "/")),
+      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: URL(fileURLWithPath: "/")),
       toolchainRegistry: ToolchainRegistry.forTesting,
       options: SourceKitLSPOptions(),
       connectionToClient: DummyBuildSystemManagerConnectionToClient(),
@@ -266,7 +266,7 @@ final class BuildSystemManagerTests: XCTestCase {
     )
 
     let bsm = await BuildSystemManager(
-      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: try AbsolutePath(validating: "/")),
+      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: URL(fileURLWithPath: "/")),
       toolchainRegistry: ToolchainRegistry.forTesting,
       options: SourceKitLSPOptions(),
       connectionToClient: DummyBuildSystemManagerConnectionToClient(),

--- a/Tests/SourceKitDTests/SourceKitDRegistryTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDRegistryTests.swift
@@ -23,9 +23,9 @@ final class SourceKitDRegistryTests: XCTestCase {
   func testAdd() async throws {
     let registry = SourceKitDRegistry()
 
-    let a = try await FakeSourceKitD.getOrCreate(AbsolutePath(validating: "/a"), in: registry)
-    let b = try await FakeSourceKitD.getOrCreate(AbsolutePath(validating: "/b"), in: registry)
-    let a2 = try await FakeSourceKitD.getOrCreate(AbsolutePath(validating: "/a"), in: registry)
+    let a = await FakeSourceKitD.getOrCreate(URL(fileURLWithPath: "/a"), in: registry)
+    let b = await FakeSourceKitD.getOrCreate(URL(fileURLWithPath: "/b"), in: registry)
+    let a2 = await FakeSourceKitD.getOrCreate(URL(fileURLWithPath: "/a"), in: registry)
 
     XCTAssert(a === a2)
     XCTAssert(a !== b)
@@ -34,9 +34,9 @@ final class SourceKitDRegistryTests: XCTestCase {
   func testRemove() async throws {
     let registry = SourceKitDRegistry()
 
-    let a = await FakeSourceKitD.getOrCreate(try AbsolutePath(validating: "/a"), in: registry)
-    await assertTrue(registry.remove(try AbsolutePath(validating: "/a")) === a)
-    await assertNil(registry.remove(try AbsolutePath(validating: "/a")))
+    let a = await FakeSourceKitD.getOrCreate(URL(fileURLWithPath: "/a"), in: registry)
+    await assertTrue(registry.remove(URL(fileURLWithPath: "/a")) === a)
+    await assertNil(registry.remove(URL(fileURLWithPath: "/a")))
   }
 
   func testRemoveResurrect() async throws {
@@ -44,19 +44,19 @@ final class SourceKitDRegistryTests: XCTestCase {
 
     @inline(never)
     func scope(registry: SourceKitDRegistry) async throws -> UInt32 {
-      let a = await FakeSourceKitD.getOrCreate(try AbsolutePath(validating: "/a"), in: registry)
+      let a = await FakeSourceKitD.getOrCreate(URL(fileURLWithPath: "/a"), in: registry)
 
-      await assertTrue(a === FakeSourceKitD.getOrCreate(try AbsolutePath(validating: "/a"), in: registry))
-      await assertTrue(registry.remove(try AbsolutePath(validating: "/a")) === a)
+      await assertTrue(a === FakeSourceKitD.getOrCreate(URL(fileURLWithPath: "/a"), in: registry))
+      await assertTrue(registry.remove(URL(fileURLWithPath: "/a")) === a)
       // Resurrected.
-      await assertTrue(a === FakeSourceKitD.getOrCreate(try AbsolutePath(validating: "/a"), in: registry))
+      await assertTrue(a === FakeSourceKitD.getOrCreate(URL(fileURLWithPath: "/a"), in: registry))
       // Remove again.
-      await assertTrue(registry.remove(try AbsolutePath(validating: "/a")) === a)
+      await assertTrue(registry.remove(URL(fileURLWithPath: "/a")) === a)
       return (a as! FakeSourceKitD).token
     }
 
     let id = try await scope(registry: registry)
-    let a2 = await FakeSourceKitD.getOrCreate(try AbsolutePath(validating: "/a"), in: registry)
+    let a2 = await FakeSourceKitD.getOrCreate(URL(fileURLWithPath: "/a"), in: registry)
     XCTAssertNotEqual(id, (a2 as! FakeSourceKitD).token)
   }
 }
@@ -75,8 +75,8 @@ final class FakeSourceKitD: SourceKitD {
     token = nextToken.fetchAndIncrement()
   }
 
-  static func getOrCreate(_ path: AbsolutePath, in registry: SourceKitDRegistry) async -> SourceKitD {
-    return await registry.getOrAdd(path, create: { Self.init() })
+  static func getOrCreate(_ url: URL, in registry: SourceKitDRegistry) async -> SourceKitD {
+    return await registry.getOrAdd(url, create: { Self.init() })
   }
 
   package func log(request: SKDRequestDictionary) {}

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1245,7 +1245,7 @@ final class BackgroundIndexingTests: XCTestCase {
     //  - We reload the package, which updates `Dependency.swift` in `.build/index-build/checkouts`, which we also watch.
     try await Process.run(
       arguments: [
-        unwrap(ToolchainRegistry.forTesting.default?.swift?.pathString),
+        unwrap(ToolchainRegistry.forTesting.default?.swift?.filePath),
         "package", "update",
         "--package-path", project.scratchDirectory.filePath,
       ],

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -49,7 +49,7 @@ final class BuildSystemTests: XCTestCase {
     let server = testClient.server
 
     let buildSystemManager = await BuildSystemManager(
-      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: try AbsolutePath(validating: "/")),
+      buildSystemSpec: BuildSystemSpec(kind: .testBuildSystem, projectRoot: URL(fileURLWithPath: "/")),
       toolchainRegistry: .forTesting,
       options: .testDefault(),
       connectionToClient: DummyBuildSystemManagerConnectionToClient(),

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -782,7 +782,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
     let testsWithEmptyCompilationDatabase = try await project.testClient.send(WorkspaceTestsRequest())
     XCTAssertEqual(testsWithEmptyCompilationDatabase, [])
 
-    let swiftc = try await unwrap(ToolchainRegistry.forTesting.default?.swiftc?.asURL)
+    let swiftc = try await unwrap(ToolchainRegistry.forTesting.default?.swiftc)
     let uri = try project.uri(for: "MyTests.swift")
 
     let compilationDatabase = JSONCompilationDatabase([

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -688,7 +688,7 @@ final class WorkspaceTests: XCTestCase {
     let packageDir = try project.uri(for: "Package.swift").fileURL!.deletingLastPathComponent()
 
     try await TSCBasic.Process.checkNonZeroExit(arguments: [
-      ToolchainRegistry.forTesting.default!.swift!.pathString,
+      ToolchainRegistry.forTesting.default!.swift!.filePath,
       "build",
       "--package-path", packageDir.filePath,
       "-Xswiftc", "-index-ignore-system-modules",

--- a/Tests/TSCExtensionsTests/ProcessRunTests.swift
+++ b/Tests/TSCExtensionsTests/ProcessRunTests.swift
@@ -21,8 +21,8 @@ import class TSCBasic.Process
 final class ProcessRunTests: XCTestCase {
   func testWorkingDirectory() async throws {
     try await withTestScratchDir { tempDir in
-      let workingDir = tempDir.appending(component: "working-dir")
-      try FileManager.default.createDirectory(at: workingDir.asURL, withIntermediateDirectories: true)
+      let workingDir = tempDir.appendingPathComponent("working-dir")
+      try FileManager.default.createDirectory(at: workingDir, withIntermediateDirectories: true)
 
       #if os(Windows)
       // On Windows, Python 3 gets installed as python.exe
@@ -32,18 +32,18 @@ final class ProcessRunTests: XCTestCase {
       #endif
       let python = try await unwrap(findTool(name: pythonName))
 
-      let pythonFile = tempDir.appending(component: "show-cwd.py")
+      let pythonFile = tempDir.appendingPathComponent("show-cwd.py")
       try """
       import os
       print(os.getcwd(), end='')
-      """.write(to: pythonFile.asURL, atomically: true, encoding: .utf8)
+      """.write(to: pythonFile, atomically: true, encoding: .utf8)
 
       let result = try await Process.run(
-        arguments: [python.filePath, pythonFile.pathString],
-        workingDirectory: workingDir
+        arguments: [python.filePath, pythonFile.filePath],
+        workingDirectory: AbsolutePath(validating: workingDir.filePath)
       )
       let stdout = try unwrap(String(bytes: result.output.get(), encoding: .utf8))
-      XCTAssertEqual(stdout, workingDir.pathString)
+      XCTAssertEqual(stdout, try workingDir.filePath)
     }
   }
 }

--- a/Tests/ToolchainRegistryTests/ToolchainRegistryTests.swift
+++ b/Tests/ToolchainRegistryTests/ToolchainRegistryTests.swift
@@ -42,329 +42,391 @@ final class ToolchainRegistryTests: XCTestCase {
 
   func testFindXcodeDefaultToolchain() async throws {
     try SkipUnless.platformIsDarwin("Finding toolchains in Xcode is only supported on macOS")
-    let fs = InMemoryFileSystem()
-    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
-    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
-    try makeXCToolchain(
-      identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
-      opensource: false,
-      path: toolchains.appending(component: "XcodeDefault.xctoolchain"),
-      fs,
-      sourcekitd: true
-    )
 
-    let tr = ToolchainRegistry(
-      xcodes: [xcodeDeveloper],
-      darwinToolchainOverride: nil,
-      fs
-    )
+    try await withTestScratchDir { tempDir in
+      let xcodeDeveloper =
+        tempDir
+        .appendingPathComponent("Xcode.app")
+        .appendingPathComponent("Developer")
+      let toolchains = xcodeDeveloper.appendingPathComponent("Toolchains")
+      try makeXCToolchain(
+        identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
+        opensource: false,
+        path: toolchains.appendingPathComponent("XcodeDefault.xctoolchain"),
+        sourcekitd: true
+      )
 
-    assertEqual(await tr.toolchains.count, 1)
-    assertEqual(await tr.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
-    assertEqual(await tr.default?.path, toolchains.appending(component: "XcodeDefault.xctoolchain"))
-    assertNotNil(await tr.default?.sourcekitd)
+      let tr = ToolchainRegistry(
+        installPath: nil,
+        environmentVariables: [],
+        xcodes: [xcodeDeveloper],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
 
-    assertTrue(await tr.toolchains.first === tr.default)
+      assertEqual(await tr.toolchains.count, 1)
+      assertEqual(await tr.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
+      assertEqual(
+        await tr.default?.path,
+        toolchains.appendingPathComponent("XcodeDefault.xctoolchain", isDirectory: true)
+      )
+      assertNotNil(await tr.default?.sourcekitd)
+
+      assertTrue(await tr.toolchains.first === tr.default)
+    }
   }
 
   func testFindNonXcodeDefaultToolchains() async throws {
     try SkipUnless.platformIsDarwin("Finding toolchains in Xcode is only supported on macOS")
-    let fs = InMemoryFileSystem()
-    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
-    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
 
-    try makeXCToolchain(
-      identifier: "com.apple.fake.A",
-      opensource: false,
-      path: toolchains.appending(component: "A.xctoolchain"),
-      fs,
-      sourcekitd: true
-    )
-    try makeXCToolchain(
-      identifier: "com.apple.fake.B",
-      opensource: false,
-      path: toolchains.appending(component: "B.xctoolchain"),
-      fs,
-      sourcekitd: true
-    )
+    try await withTestScratchDir { tempDir in
+      let xcodeDeveloper =
+        tempDir
+        .appendingPathComponent("Xcode.app")
+        .appendingPathComponent("Developer")
+      let toolchains = xcodeDeveloper.appendingPathComponent("Toolchains")
 
-    let tr = ToolchainRegistry(
-      xcodes: [xcodeDeveloper],
-      darwinToolchainOverride: nil,
-      fs
-    )
+      try makeXCToolchain(
+        identifier: "com.apple.fake.A",
+        opensource: false,
+        path: toolchains.appendingPathComponent("A.xctoolchain"),
+        sourcekitd: true
+      )
+      try makeXCToolchain(
+        identifier: "com.apple.fake.B",
+        opensource: false,
+        path: toolchains.appendingPathComponent("B.xctoolchain"),
+        sourcekitd: true
+      )
 
-    assertEqual(await tr.toolchains.map(\.identifier).sorted(), ["com.apple.fake.A", "com.apple.fake.B"])
+      let tr = ToolchainRegistry(
+        installPath: nil,
+        environmentVariables: [],
+        xcodes: [xcodeDeveloper],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
+
+      assertEqual(await tr.toolchains.map(\.identifier).sorted(), ["com.apple.fake.A", "com.apple.fake.B"])
+    }
   }
 
   func testIgnoreToolchainsWithWrongExtensions() async throws {
     try SkipUnless.platformIsDarwin("Finding toolchains in Xcode is only supported on macOS")
-    let fs = InMemoryFileSystem()
-    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
-    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
 
-    try makeXCToolchain(
-      identifier: "com.apple.fake.C",
-      opensource: false,
-      path: toolchains.appending(component: "C.wrong_extension"),
-      fs,
-      sourcekitd: true
-    )
-    try makeXCToolchain(
-      identifier: "com.apple.fake.D",
-      opensource: false,
-      path: toolchains.appending(component: "D_no_extension"),
-      fs,
-      sourcekitd: true
-    )
+    try await withTestScratchDir { tempDir in
+      let xcodeDeveloper =
+        tempDir
+        .appendingPathComponent("Xcode.app")
+        .appendingPathComponent("Developer")
+      let toolchains = xcodeDeveloper.appendingPathComponent("Toolchains")
 
-    let tr = ToolchainRegistry(
-      darwinToolchainOverride: nil,
-      fs
-    )
+      try makeXCToolchain(
+        identifier: "com.apple.fake.C",
+        opensource: false,
+        path: toolchains.appendingPathComponent("C.wrong_extension"),
+        sourcekitd: true
+      )
+      try makeXCToolchain(
+        identifier: "com.apple.fake.D",
+        opensource: false,
+        path: toolchains.appendingPathComponent("D_no_extension"),
+        sourcekitd: true
+      )
 
-    assertTrue(await tr.toolchains.isEmpty)
+      let tr = ToolchainRegistry(
+        installPath: nil,
+        environmentVariables: [],
+        xcodes: [xcodeDeveloper],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
 
+      assertEqual(await tr.toolchains.map(\.path), [])
+    }
   }
+
   func testTwoToolchainsWithSameIdentifier() async throws {
     try SkipUnless.platformIsDarwin("Finding toolchains in Xcode is only supported on macOS")
 
-    let fs = InMemoryFileSystem()
-    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
-    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
-    try makeXCToolchain(
-      identifier: "com.apple.fake.A",
-      opensource: false,
-      path: toolchains.appending(component: "A.xctoolchain"),
-      fs,
-      sourcekitd: true
-    )
+    try await withTestScratchDir { tempDir in
+      let xcodeDeveloper =
+        tempDir
+        .appendingPathComponent("Xcode.app")
+        .appendingPathComponent("Developer")
 
-    try makeXCToolchain(
-      identifier: "com.apple.fake.A",
-      opensource: false,
-      path: toolchains.appending(component: "E.xctoolchain"),
-      fs,
-      sourcekitd: true
-    )
+      let toolchains = xcodeDeveloper.appendingPathComponent("Toolchains")
+      try makeXCToolchain(
+        identifier: "com.apple.fake.A",
+        opensource: false,
+        path: toolchains.appendingPathComponent("A.xctoolchain"),
+        sourcekitd: true
+      )
 
-    let tr = ToolchainRegistry(
-      xcodes: [xcodeDeveloper],
-      darwinToolchainOverride: nil,
-      fs
-    )
+      try makeXCToolchain(
+        identifier: "com.apple.fake.A",
+        opensource: false,
+        path: toolchains.appendingPathComponent("E.xctoolchain"),
+        sourcekitd: true
+      )
 
-    assertEqual(await tr.toolchains.count, 1)
+      let tr = ToolchainRegistry(
+        installPath: nil,
+        environmentVariables: [],
+        xcodes: [xcodeDeveloper],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
+
+      assertEqual(await tr.toolchains.count, 1)
+    }
   }
 
   func testGloballyInstalledToolchains() async throws {
     try SkipUnless.platformIsDarwin("Finding toolchains in Xcode is only supported on macOS")
-    let fs = InMemoryFileSystem()
+    try await withTestScratchDir { tempDir in
+      let libraryDir = tempDir.appendingPathComponent("Library")
+      try makeXCToolchain(
+        identifier: "org.fake.global.A",
+        opensource: true,
+        path:
+          libraryDir
+          .appendingPathComponent("Developer")
+          .appendingPathComponent("Toolchains")
+          .appendingPathComponent("A.xctoolchain"),
+        sourcekitd: true
+      )
 
-    try makeXCToolchain(
-      identifier: "org.fake.global.A",
-      opensource: true,
-      path: try AbsolutePath(validating: "/Library/Developer/Toolchains/A.xctoolchain"),
-      fs,
-      sourcekitd: true
-    )
-    try makeXCToolchain(
-      identifier: "org.fake.global.B",
-      opensource: true,
-      path: try AbsolutePath(
-        validating: ("~/Library/Developer/Toolchains/B.xctoolchain" as NSString).expandingTildeInPath
-      ),
-      fs,
-      sourcekitd: true
-    )
-
-    let tr = ToolchainRegistry(
-      darwinToolchainOverride: nil,
-      fs
-    )
-    assertEqual(await tr.toolchains.map(\.identifier), ["org.fake.global.B", "org.fake.global.A"])
+      let tr = ToolchainRegistry(
+        installPath: nil,
+        environmentVariables: [],
+        xcodes: [],
+        libraryDirectories: [libraryDir],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
+      assertEqual(await tr.toolchains.map(\.identifier), ["org.fake.global.A"])
+    }
   }
 
   func testFindToolchainBasedOnInstallPath() async throws {
     try SkipUnless.platformIsDarwin("Finding toolchains in Xcode is only supported on macOS")
-    let fs = InMemoryFileSystem()
-    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
-    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
 
-    let path = toolchains.appending(component: "Explicit.xctoolchain")
-    try makeXCToolchain(
-      identifier: "org.fake.explicit",
-      opensource: false,
-      path: toolchains.appending(component: "Explicit.xctoolchain"),
-      fs,
-      sourcekitd: true
-    )
+    try await withTestScratchDir { tempDir in
+      let xcodeDeveloper =
+        tempDir
+        .appendingPathComponent("Xcode.app")
+        .appendingPathComponent("Developer")
 
-    let trInstall = ToolchainRegistry(
-      installPath: path.appending(components: "usr", "bin"),
-      xcodes: [],
-      darwinToolchainOverride: nil,
-      fs
-    )
-    await assertEqual(trInstall.default?.identifier, "org.fake.explicit")
-    await assertEqual(trInstall.default?.path, path)
+      let toolchains = xcodeDeveloper.appendingPathComponent("Toolchains")
+
+      let path = toolchains.appendingPathComponent("Explicit.xctoolchain", isDirectory: true)
+      try makeXCToolchain(
+        identifier: "org.fake.explicit",
+        opensource: false,
+        path: path,
+        sourcekitd: true
+      )
+
+      let trInstall = ToolchainRegistry(
+        installPath: path.appendingPathComponent("usr").appendingPathComponent("bin"),
+        environmentVariables: [],
+        xcodes: [],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
+      await assertEqual(trInstall.default?.identifier, "org.fake.explicit")
+      await assertEqual(trInstall.default?.path, path)
+    }
   }
 
   func testDarwinToolchainOverride() async throws {
     try SkipUnless.platformIsDarwin("Finding toolchains in Xcode is only supported on macOS")
 
-    let fs = InMemoryFileSystem()
-    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
-    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
-    try makeXCToolchain(
-      identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
-      opensource: false,
-      path: toolchains.appending(component: "XcodeDefault.xctoolchain"),
-      fs,
-      sourcekitd: true
-    )
+    try await withTestScratchDir { tempDir in
+      let xcodeDeveloper =
+        tempDir
+        .appendingPathComponent("Xcode.app")
+        .appendingPathComponent("Developer")
 
-    try makeXCToolchain(
-      identifier: "org.fake.global.A",
-      opensource: false,
-      path: toolchains.appending(component: "A.xctoolchain"),
-      fs,
-      sourcekitd: true
-    )
+      let toolchains = xcodeDeveloper.appendingPathComponent("Toolchains")
+      try makeXCToolchain(
+        identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
+        opensource: false,
+        path: toolchains.appendingPathComponent("XcodeDefault.xctoolchain"),
+        sourcekitd: true
+      )
 
-    let toolchainRegistry = ToolchainRegistry(
-      xcodes: [xcodeDeveloper],
-      darwinToolchainOverride: nil,
-      fs
-    )
-    await assertEqual(toolchainRegistry.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
+      try makeXCToolchain(
+        identifier: "org.fake.global.A",
+        opensource: false,
+        path: toolchains.appendingPathComponent("A.xctoolchain"),
+        sourcekitd: true
+      )
 
-    let darwinToolchainOverrideRegistry = ToolchainRegistry(
-      xcodes: [xcodeDeveloper],
-      darwinToolchainOverride: "org.fake.global.A",
-      fs
-    )
-    await assertEqual(darwinToolchainOverrideRegistry.darwinToolchainIdentifier, "org.fake.global.A")
-    await assertEqual(darwinToolchainOverrideRegistry.default?.identifier, "org.fake.global.A")
+      let toolchainRegistry = ToolchainRegistry(
+        installPath: nil,
+        environmentVariables: [],
+        xcodes: [xcodeDeveloper],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
+
+      await assertEqual(toolchainRegistry.default?.identifier, ToolchainRegistry.darwinDefaultToolchainIdentifier)
+
+      let darwinToolchainOverrideRegistry = ToolchainRegistry(
+        installPath: nil,
+        environmentVariables: [],
+        xcodes: [xcodeDeveloper],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: "org.fake.global.A"
+      )
+      await assertEqual(darwinToolchainOverrideRegistry.darwinToolchainIdentifier, "org.fake.global.A")
+      await assertEqual(darwinToolchainOverrideRegistry.default?.identifier, "org.fake.global.A")
+    }
   }
 
   func testCreateToolchainFromBinPath() async throws {
     try SkipUnless.platformIsDarwin("Finding toolchains in Xcode is only supported on macOS")
 
-    let fs = InMemoryFileSystem()
-    let xcodeDeveloper = try AbsolutePath(validating: "/Applications/Xcode.app/Developer")
-    let toolchains = xcodeDeveloper.appending(components: "Toolchains")
+    try await withTestScratchDir { tempDir in
+      let xcodeDeveloper =
+        tempDir
+        .appendingPathComponent("Xcode.app")
+        .appendingPathComponent("Developer")
+      let toolchains = xcodeDeveloper.appendingPathComponent("Toolchains")
 
-    let path = toolchains.appending(component: "Explicit.xctoolchain")
-    try makeXCToolchain(
-      identifier: "org.fake.explicit",
-      opensource: false,
-      path: toolchains.appending(component: "Explicit.xctoolchain"),
-      fs,
-      sourcekitd: true
-    )
+      let path = toolchains.appendingPathComponent("Explicit.xctoolchain", isDirectory: true)
+      try makeXCToolchain(
+        identifier: "org.fake.explicit",
+        opensource: false,
+        path: path,
+        sourcekitd: true
+      )
 
-    let tc = Toolchain(path, fs)
-    XCTAssertNotNil(tc)
-    XCTAssertEqual(tc?.identifier, "org.fake.explicit")
+      let tc = Toolchain(path)
+      XCTAssertNotNil(tc)
+      XCTAssertEqual(tc?.identifier, "org.fake.explicit")
 
-    let tcBin = Toolchain(path.appending(components: "usr", "bin"), fs)
-    XCTAssertNotNil(tcBin)
-    XCTAssertEqual(tc?.identifier, tcBin?.identifier)
-    XCTAssertEqual(tc?.path, tcBin?.path)
-    XCTAssertEqual(tc?.displayName, tcBin?.displayName)
+      let tcBin = Toolchain(path.appendingPathComponent("usr").appendingPathComponent("bin"))
+      XCTAssertNotNil(tcBin)
+      XCTAssertEqual(tc?.identifier, tcBin?.identifier)
+      XCTAssertEqual(tc?.path, tcBin?.path)
+      XCTAssertEqual(tc?.displayName, tcBin?.displayName)
+    }
   }
 
   func testSearchPATH() async throws {
-    let fs = InMemoryFileSystem()
-    let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
-    try makeToolchain(binPath: binPath, fs, sourcekitd: true)
+    try await withTestScratchDir { tempDir in
+      let binPath = tempDir.appendingPathComponent("bin", isDirectory: true)
+      try makeToolchain(binPath: binPath, sourcekitd: true)
 
-    #if os(Windows)
-    let separator: String = ";"
-    #else
-    let separator: String = ":"
-    #endif
+      #if os(Windows)
+      let separator: String = ";"
+      #else
+      let separator: String = ":"
+      #endif
 
-    try ProcessEnv.setVar(
-      "SOURCEKIT_PATH",
-      value: ["/bogus", binPath.pathString, "/bogus2"].joined(separator: separator)
-    )
-    defer { try! ProcessEnv.setVar("SOURCEKIT_PATH", value: "") }
+      try ProcessEnv.setVar(
+        "SOURCEKIT_PATH_FOR_TEST",
+        value: ["/bogus", binPath.filePath, "/bogus2"].joined(separator: separator)
+      )
+      defer { try! ProcessEnv.setVar("SOURCEKIT_PATH_FOR_TEST", value: "") }
 
-    let tr = ToolchainRegistry(fs)
+      let tr = ToolchainRegistry(
+        installPath: nil,
+        environmentVariables: [],
+        xcodes: [],
+        libraryDirectories: [],
+        pathEnvironmentVariables: ["SOURCEKIT_PATH_FOR_TEST"],
+        darwinToolchainOverride: nil
+      )
 
-    let tc = try unwrap(await tr.toolchains.first(where: { tc in tc.path == binPath }))
+      let tc = try unwrap(await tr.toolchains.first(where: { $0.path == binPath }))
 
-    await assertEqual(tr.default?.identifier, tc.identifier)
-    XCTAssertEqual(tc.identifier, binPath.pathString)
-    XCTAssertNil(tc.clang)
-    XCTAssertNil(tc.clangd)
-    XCTAssertNil(tc.swiftc)
-    XCTAssertNotNil(tc.sourcekitd)
-    XCTAssertNil(tc.libIndexStore)
+      await assertEqual(tr.default?.identifier, tc.identifier)
+      XCTAssertEqual(tc.identifier, try binPath.filePath)
+      XCTAssertNil(tc.clang)
+      XCTAssertNil(tc.clangd)
+      XCTAssertNil(tc.swiftc)
+      XCTAssertNotNil(tc.sourcekitd)
+      XCTAssertNil(tc.libIndexStore)
+    }
   }
 
   func testSearchExplicitEnvBuiltin() async throws {
-    let fs = InMemoryFileSystem()
+    try await withTestScratchDir { tempDir in
+      let binPath = tempDir.appendingPathComponent("bin", isDirectory: true)
+      try makeToolchain(binPath: binPath, sourcekitd: true)
 
-    let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
-    try makeToolchain(binPath: binPath, fs, sourcekitd: true)
+      try ProcessEnv.setVar("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: binPath.deletingLastPathComponent().filePath)
 
-    try ProcessEnv.setVar("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: binPath.parentDirectory.pathString)
+      let tr = ToolchainRegistry(
+        installPath: nil,
+        environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"],
+        xcodes: [],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
 
-    let tr = ToolchainRegistry(
-      environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"],
-      fs
-    )
+      guard let tc = await tr.toolchains.first(where: { tc in tc.path == binPath.deletingLastPathComponent() }) else {
+        XCTFail("couldn't find expected toolchain")
+        return
+      }
 
-    guard let tc = await tr.toolchains.first(where: { tc in tc.path == binPath.parentDirectory }) else {
-      XCTFail("couldn't find expected toolchain")
-      return
+      await assertEqual(tr.default?.identifier, tc.identifier)
+      XCTAssertEqual(tc.identifier, try binPath.deletingLastPathComponent().filePath)
+      XCTAssertNil(tc.clang)
+      XCTAssertNil(tc.clangd)
+      XCTAssertNil(tc.swiftc)
+      XCTAssertNotNil(tc.sourcekitd)
+      XCTAssertNil(tc.libIndexStore)
     }
-
-    await assertEqual(tr.default?.identifier, tc.identifier)
-    XCTAssertEqual(tc.identifier, binPath.parentDirectory.pathString)
-    XCTAssertNil(tc.clang)
-    XCTAssertNil(tc.clangd)
-    XCTAssertNil(tc.swiftc)
-    XCTAssertNotNil(tc.sourcekitd)
-    XCTAssertNil(tc.libIndexStore)
   }
 
   func testSearchExplicitEnv() async throws {
-    let fs = InMemoryFileSystem()
-    let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
-    try makeToolchain(binPath: binPath, fs, sourcekitd: true)
+    try await withTestScratchDir { tempDir in
+      let binPath = tempDir.appendingPathComponent("bin", isDirectory: true)
+      try makeToolchain(binPath: binPath, sourcekitd: true)
 
-    try ProcessEnv.setVar("TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2", value: binPath.parentDirectory.pathString)
+      try ProcessEnv.setVar("TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2", value: binPath.deletingLastPathComponent().filePath)
 
-    let tr = ToolchainRegistry(
-      environmentVariables: ["TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2"],
-      fs
-    )
+      let tr = ToolchainRegistry(
+        installPath: nil,
+        environmentVariables: ["TEST_ENV_SOURCEKIT_TOOLCHAIN_PATH_2"],
+        xcodes: [],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
 
-    guard let tc = await tr.toolchains.first(where: { tc in tc.path == binPath.parentDirectory }) else {
-      XCTFail("couldn't find expected toolchain")
-      return
+      guard let tc = await tr.toolchains.first(where: { tc in tc.path == binPath.deletingLastPathComponent() }) else {
+        XCTFail("couldn't find expected toolchain")
+        return
+      }
+
+      XCTAssertEqual(tc.identifier, try binPath.deletingLastPathComponent().filePath)
+      XCTAssertNil(tc.clang)
+      XCTAssertNil(tc.clangd)
+      XCTAssertNil(tc.swiftc)
+      XCTAssertNotNil(tc.sourcekitd)
+      XCTAssertNil(tc.libIndexStore)
     }
-
-    XCTAssertEqual(tc.identifier, binPath.parentDirectory.pathString)
-    XCTAssertNil(tc.clang)
-    XCTAssertNil(tc.clangd)
-    XCTAssertNil(tc.swiftc)
-    XCTAssertNotNil(tc.sourcekitd)
-    XCTAssertNil(tc.libIndexStore)
   }
 
   func testFromDirectory() async throws {
-    // This test uses the real file system because the in-memory system doesn't support marking files executable.
-    let fs = localFileSystem
     try await withTestScratchDir { tempDir in
-      let path = tempDir.appending(components: "A.xctoolchain", "usr")
+      let path = tempDir.appendingPathComponent("A.xctoolchain").appendingPathComponent("usr")
       try makeToolchain(
-        binPath: path.appending(component: "bin"),
-        fs,
+        binPath: path.appendingPathComponent("bin"),
         clang: true,
         clangd: true,
         swiftc: true,
@@ -372,9 +434,9 @@ final class ToolchainRegistryTests: XCTestCase {
         sourcekitd: true
       )
 
-      try fs.writeFileContents(path.appending(components: "bin", "other"), bytes: "")
+      try Data().write(to: path.appendingPathComponent("bin").appendingPathComponent("other"))
 
-      let t1 = Toolchain(path.parentDirectory, fs)!
+      let t1 = try XCTUnwrap(Toolchain(path.deletingLastPathComponent()))
       XCTAssertNotNil(t1.sourcekitd)
       #if os(Windows)
       // Windows does not have file permissions but rather checks the contents
@@ -389,23 +451,23 @@ final class ToolchainRegistryTests: XCTestCase {
       #endif
 
       #if !os(Windows)
-      func chmodRX(_ path: AbsolutePath) {
-        XCTAssertEqual(chmod(path.pathString, S_IRUSR | S_IXUSR), 0)
+      func chmodRX(_ path: URL) throws {
+        XCTAssertEqual(chmod(try path.filePath, S_IRUSR | S_IXUSR), 0)
       }
 
-      chmodRX(path.appending(components: "bin", "clang"))
-      chmodRX(path.appending(components: "bin", "clangd"))
-      chmodRX(path.appending(components: "bin", "swiftc"))
-      chmodRX(path.appending(components: "bin", "other"))
+      try chmodRX(path.appendingPathComponent("bin").appendingPathComponent("clang"))
+      try chmodRX(path.appendingPathComponent("bin").appendingPathComponent("clangd"))
+      try chmodRX(path.appendingPathComponent("bin").appendingPathComponent("swiftc"))
+      try chmodRX(path.appendingPathComponent("bin").appendingPathComponent("other"))
       #endif
 
-      let t2 = Toolchain(path.parentDirectory, fs)!
+      let t2 = try XCTUnwrap(Toolchain(path.deletingLastPathComponent()))
       XCTAssertNotNil(t2.sourcekitd)
       XCTAssertNotNil(t2.clang)
       XCTAssertNotNil(t2.clangd)
       XCTAssertNotNil(t2.swiftc)
 
-      let tr = ToolchainRegistry(toolchains: [Toolchain(path.parentDirectory, fs)!])
+      let tr = ToolchainRegistry(toolchains: [try XCTUnwrap(Toolchain(path.deletingLastPathComponent()))])
       let t3 = try await unwrap(tr.toolchains(withIdentifier: t2.identifier).only)
       XCTAssertEqual(t3.sourcekitd, t2.sourcekitd)
       XCTAssertEqual(t3.clang, t2.clang)
@@ -414,33 +476,46 @@ final class ToolchainRegistryTests: XCTestCase {
     }
   }
 
-  func testDylibNames() throws {
-    let fs = InMemoryFileSystem()
-    let binPath = try AbsolutePath(validating: "/foo/bar/my_toolchain/bin")
-    try makeToolchain(binPath: binPath, fs, sourcekitdInProc: true, libIndexStore: true)
-    guard let t = Toolchain(binPath, fs) else {
-      XCTFail("could not find any tools")
-      return
+  func testDylibNames() async throws {
+    try await withTestScratchDir { tempDir in
+      let binPath = tempDir.appendingPathComponent("bin", isDirectory: true)
+      try makeToolchain(binPath: binPath, sourcekitdInProc: true, libIndexStore: true)
+      guard let t = Toolchain(binPath) else {
+        XCTFail("could not find any tools")
+        return
+      }
+      XCTAssertNotNil(t.sourcekitd)
+      XCTAssertNotNil(t.libIndexStore)
     }
-    XCTAssertNotNil(t.sourcekitd)
-    XCTAssertNotNil(t.libIndexStore)
   }
 
-  func testSubDirs() throws {
-    let fs = InMemoryFileSystem()
-    try makeToolchain(binPath: try AbsolutePath(validating: "/t1/bin"), fs, sourcekitd: true)
-    try makeToolchain(binPath: try AbsolutePath(validating: "/t2/usr/bin"), fs, sourcekitd: true)
+  func testSubDirs() async throws {
+    try await withTestScratchDir { tempDir in
+      try makeToolchain(binPath: tempDir.appendingPathComponent("t1").appendingPathComponent("bin"), sourcekitd: true)
+      try makeToolchain(
+        binPath: tempDir.appendingPathComponent("t2").appendingPathComponent("usr").appendingPathComponent("bin"),
+        sourcekitd: true
+      )
 
-    XCTAssertNotNil(Toolchain(try AbsolutePath(validating: "/t1"), fs))
-    XCTAssertNotNil(Toolchain(try AbsolutePath(validating: "/t1/bin"), fs))
-    XCTAssertNotNil(Toolchain(try AbsolutePath(validating: "/t2"), fs))
+      XCTAssertNotNil(Toolchain(tempDir.appendingPathComponent("t1")))
+      XCTAssertNotNil(Toolchain(tempDir.appendingPathComponent("t1").appendingPathComponent("bin")))
+      XCTAssertNotNil(Toolchain(tempDir.appendingPathComponent("t2")))
 
-    XCTAssertNil(Toolchain(try AbsolutePath(validating: "/t3"), fs))
-    try fs.createDirectory(try AbsolutePath(validating: "/t3/bin"), recursive: true)
-    try fs.createDirectory(try AbsolutePath(validating: "/t3/lib/sourcekitd.framework"), recursive: true)
-    XCTAssertNil(Toolchain(try AbsolutePath(validating: "/t3"), fs))
-    try makeToolchain(binPath: try AbsolutePath(validating: "/t3/bin"), fs, sourcekitd: true)
-    XCTAssertNotNil(Toolchain(try AbsolutePath(validating: "/t3"), fs))
+      XCTAssertNil(Toolchain(tempDir.appendingPathComponent("t3")))
+      try FileManager.default.createDirectory(
+        at: tempDir.appendingPathComponent("t3").appendingPathComponent("bin"),
+        withIntermediateDirectories: true
+      )
+      try FileManager.default.createDirectory(
+        at: tempDir.appendingPathComponent("t3").appendingPathComponent("lib").appendingPathComponent(
+          "sourcekitd.framework"
+        ),
+        withIntermediateDirectories: true
+      )
+      XCTAssertNil(Toolchain(tempDir.appendingPathComponent("t3")))
+      try makeToolchain(binPath: tempDir.appendingPathComponent("t3").appendingPathComponent("bin"), sourcekitd: true)
+      XCTAssertNotNil(Toolchain(tempDir.appendingPathComponent("t3")))
+    }
   }
 
   func testDuplicateToolchainOnlyRegisteredOnce() async throws {
@@ -450,7 +525,7 @@ final class ToolchainRegistryTests: XCTestCase {
   }
 
   func testDuplicatePathOnlyRegisteredOnce() async throws {
-    let path = try AbsolutePath(validating: "/foo/bar")
+    let path = URL(fileURLWithPath: "/foo/bar")
     let first = Toolchain(identifier: "a", displayName: "a", path: path)
     let second = Toolchain(identifier: "b", displayName: "b", path: path)
 
@@ -459,13 +534,13 @@ final class ToolchainRegistryTests: XCTestCase {
   }
 
   func testMultipleXcodes() async throws {
-    let pathA = try AbsolutePath(validating: "/versionA")
+    let pathA = URL(fileURLWithPath: "/versionA")
     let xcodeA = Toolchain(
       identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
       displayName: "a",
       path: pathA
     )
-    let pathB = try AbsolutePath(validating: "/versionB")
+    let pathB = URL(fileURLWithPath: "/versionB")
     let xcodeB = Toolchain(
       identifier: ToolchainRegistry.darwinDefaultToolchainIdentifier,
       displayName: "b",
@@ -485,63 +560,97 @@ final class ToolchainRegistryTests: XCTestCase {
   }
 
   func testInstallPath() async throws {
-    let fs = InMemoryFileSystem()
-    try makeToolchain(binPath: try AbsolutePath(validating: "/t1/bin"), fs, sourcekitd: true)
+    try await withTestScratchDir { tempDir in
+      let binPath = tempDir.appendingPathComponent("t1").appendingPathComponent("bin", isDirectory: true)
+      try makeToolchain(binPath: binPath, sourcekitd: true)
 
-    let trEmpty = ToolchainRegistry(installPath: nil, fs)
-    await assertNil(trEmpty.default)
+      let trEmpty = ToolchainRegistry(
+        installPath: nil,
+        environmentVariables: [],
+        xcodes: [],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
+      await assertNil(trEmpty.default)
 
-    let tr1 = ToolchainRegistry(installPath: try AbsolutePath(validating: "/t1/bin"), fs)
-    await assertEqual(tr1.default?.path, try AbsolutePath(validating: "/t1/bin"))
-    await assertNotNil(tr1.default?.sourcekitd)
+      let tr1 = ToolchainRegistry(
+        installPath: binPath,
+        environmentVariables: [],
+        xcodes: [],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
+      await assertEqual(tr1.default?.path, binPath)
+      await assertNotNil(tr1.default?.sourcekitd)
 
-    let tr2 = ToolchainRegistry(installPath: try AbsolutePath(validating: "/t2/bin"), fs)
-    await assertNil(tr2.default)
+      let tr2 = ToolchainRegistry(
+        installPath: tempDir.appendingPathComponent("t2").appendingPathComponent("bin", isDirectory: true),
+        environmentVariables: [],
+        xcodes: [],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
+      await assertNil(tr2.default)
+    }
   }
 
   func testInstallPathVsEnv() async throws {
-    let fs = InMemoryFileSystem()
-    try makeToolchain(binPath: try AbsolutePath(validating: "/t1/bin"), fs, sourcekitd: true)
-    try makeToolchain(binPath: try AbsolutePath(validating: "/t2/bin"), fs, sourcekitd: true)
+    try await withTestScratchDir { tempDir in
+      let t1Bin = tempDir.appendingPathComponent("t1").appendingPathComponent("bin", isDirectory: true)
+      let t2Bin = tempDir.appendingPathComponent("t2").appendingPathComponent("bin", isDirectory: true)
+      try makeToolchain(binPath: t1Bin, sourcekitd: true)
+      try makeToolchain(binPath: t2Bin, sourcekitd: true)
 
-    try ProcessEnv.setVar("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: "/t2/bin")
+      try ProcessEnv.setVar("TEST_SOURCEKIT_TOOLCHAIN_PATH_1", value: t2Bin.filePath)
 
-    let tr = ToolchainRegistry(
-      installPath: try AbsolutePath(validating: "/t1/bin"),
-      environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"],
-      fs
-    )
-    await assertEqual(tr.toolchains.count, 2)
+      let tr = ToolchainRegistry(
+        installPath: t1Bin,
+        environmentVariables: ["TEST_SOURCEKIT_TOOLCHAIN_PATH_1"],
+        xcodes: [],
+        libraryDirectories: [],
+        pathEnvironmentVariables: [],
+        darwinToolchainOverride: nil
+      )
+      await assertEqual(tr.toolchains.count, 2)
 
-    // Env variable wins.
-    await assertEqual(tr.default?.path, try AbsolutePath(validating: "/t2/bin"))
+      // Env variable wins.
+      await assertEqual(tr.default?.path, t2Bin)
+    }
   }
 
   func testSupersetToolchains() async throws {
-    let onlySwiftcToolchain = Toolchain(
-      identifier: "onlySwiftc",
-      displayName: "onlySwiftc",
-      path: try AbsolutePath(validating: "/usr/local"),
-      swiftc: try AbsolutePath(validating: "/usr/local/bin/swiftc")
-    )
-    let swiftcAndSourcekitdToolchain = Toolchain(
-      identifier: "swiftcAndSourcekitd",
-      displayName: "swiftcAndSourcekitd",
-      path: try AbsolutePath(validating: "/usr"),
-      swiftc: try AbsolutePath(validating: "/usr/bin/swiftc"),
-      sourcekitd: try AbsolutePath(validating: "/usr/lib/sourcekitd.framework/sourcekitd")
-    )
+    try await withTestScratchDir { tempDir in
+      let usrLocal = tempDir.appendingPathComponent("usr").appendingPathComponent("local")
+      let usr = tempDir.appendingPathComponent("usr")
 
-    let tr = ToolchainRegistry(toolchains: [onlySwiftcToolchain, swiftcAndSourcekitdToolchain])
-    await assertEqual(tr.default?.identifier, "swiftcAndSourcekitd")
+      let onlySwiftcToolchain = Toolchain(
+        identifier: "onlySwiftc",
+        displayName: "onlySwiftc",
+        path: usrLocal,
+        swiftc: usrLocal.appendingPathComponent("bin").appendingPathComponent("swiftc")
+      )
+      let swiftcAndSourcekitdToolchain = Toolchain(
+        identifier: "swiftcAndSourcekitd",
+        displayName: "swiftcAndSourcekitd",
+        path: usr,
+        swiftc: usr.appendingPathComponent("bin").appendingPathComponent("swiftc"),
+        sourcekitd: usrLocal.appendingPathComponent("lib").appendingPathComponent("sourcekitd.framework")
+          .appendingPathComponent("sourcekitd")
+      )
+
+      let tr = ToolchainRegistry(toolchains: [onlySwiftcToolchain, swiftcAndSourcekitdToolchain])
+      await assertEqual(tr.default?.identifier, "swiftcAndSourcekitd")
+    }
   }
 }
 
 private func makeXCToolchain(
   identifier: String,
   opensource: Bool,
-  path: AbsolutePath,
-  _ fs: FileSystem,
+  path: URL,
   clang: Bool = false,
   clangd: Bool = false,
   swiftc: Bool = false,
@@ -550,21 +659,15 @@ private func makeXCToolchain(
   sourcekitdInProc: Bool = false,
   libIndexStore: Bool = false
 ) throws {
-  try fs.createDirectory(path, recursive: true)
-  let infoPlistPath = path.appending(component: opensource ? "Info.plist" : "ToolchainInfo.plist")
+  try FileManager.default.createDirectory(at: path, withIntermediateDirectories: true)
+  let infoPlistPath = path.appendingPathComponent(opensource ? "Info.plist" : "ToolchainInfo.plist")
   let infoPlist = try PropertyListEncoder().encode(
     XCToolchainPlist(identifier: identifier, displayName: "name-\(identifier)")
   )
-  try fs.writeFileContents(
-    infoPlistPath,
-    body: { stream in
-      stream.write(infoPlist)
-    }
-  )
+  try infoPlist.write(to: infoPlistPath)
 
   try makeToolchain(
-    binPath: path.appending(components: "usr", "bin"),
-    fs,
+    binPath: path.appendingPathComponent("usr").appendingPathComponent("bin"),
     clang: clang,
     clangd: clangd,
     swiftc: swiftc,
@@ -576,8 +679,7 @@ private func makeXCToolchain(
 }
 
 private func makeToolchain(
-  binPath: AbsolutePath,
-  _ fs: FileSystem,
+  binPath: URL,
   clang: Bool = false,
   clangd: Bool = false,
   swiftc: Bool = false,
@@ -586,11 +688,6 @@ private func makeToolchain(
   sourcekitdInProc: Bool = false,
   libIndexStore: Bool = false
 ) throws {
-  precondition(
-    !clang && !swiftc && !clangd || !shouldChmod,
-    "Cannot make toolchain binaries exectuable with InMemoryFileSystem"
-  )
-
   // tiny PE binary from: https://archive.is/w01DO
   let contents: [UInt8] = [
     0x4d, 0x5a, 0x00, 0x00, 0x50, 0x45, 0x00, 0x00, 0x4c, 0x01, 0x01, 0x00,
@@ -604,15 +701,15 @@ private func makeToolchain(
     0x02,
   ]
 
-  let libPath = binPath.parentDirectory.appending(component: "lib")
-  try fs.createDirectory(binPath, recursive: true)
-  try fs.createDirectory(libPath)
+  let libPath = binPath.deletingLastPathComponent().appendingPathComponent("lib")
+  try FileManager.default.createDirectory(at: binPath, withIntermediateDirectories: true)
+  try FileManager.default.createDirectory(at: libPath, withIntermediateDirectories: true)
 
-  let makeExec = { (path: AbsolutePath) in
-    try fs.writeFileContents(path, bytes: ByteString(contents))
+  let makeExec = { (path: URL) in
+    try Data(contents).write(to: path)
     #if !os(Windows)
     if shouldChmod {
-      XCTAssertEqual(chmod(path.pathString, S_IRUSR | S_IXUSR), 0)
+      XCTAssertEqual(chmod(try path.filePath, S_IRUSR | S_IXUSR), 0)
     }
     #endif
   }
@@ -620,34 +717,37 @@ private func makeToolchain(
   let execExt = Platform.current?.executableExtension ?? ""
 
   if clang {
-    try makeExec(binPath.appending(component: "clang\(execExt)"))
+    try makeExec(binPath.appendingPathComponent("clang\(execExt)"))
   }
   if clangd {
-    try makeExec(binPath.appending(component: "clangd\(execExt)"))
+    try makeExec(binPath.appendingPathComponent("clangd\(execExt)"))
   }
   if swiftc {
-    try makeExec(binPath.appending(component: "swiftc\(execExt)"))
+    try makeExec(binPath.appendingPathComponent("swiftc\(execExt)"))
   }
 
   let dylibSuffix = Platform.current?.dynamicLibraryExtension ?? ".so"
 
   if sourcekitd {
-    try fs.createDirectory(libPath.appending(component: "sourcekitd.framework"))
-    try fs.writeFileContents(libPath.appending(components: "sourcekitd.framework", "sourcekitd"), bytes: "")
+    try FileManager.default.createDirectory(
+      at: libPath.appendingPathComponent("sourcekitd.framework"),
+      withIntermediateDirectories: true
+    )
+    try Data().write(to: libPath.appendingPathComponent("sourcekitd.framework").appendingPathComponent("sourcekitd"))
   }
   if sourcekitdInProc {
     #if os(Windows)
-    try fs.writeFileContents(binPath.appending(component: "sourcekitdInProc\(dylibSuffix)"), bytes: "")
+    try Data().write(to: binPath.appendingPathComponent("sourcekitdInProc\(dylibSuffix)"))
     #else
-    try fs.writeFileContents(libPath.appending(component: "libsourcekitdInProc\(dylibSuffix)"), bytes: "")
+    try Data().write(to: libPath.appendingPathComponent("libsourcekitdInProc\(dylibSuffix)"))
     #endif
   }
   if libIndexStore {
     #if os(Windows)
     // Windows has a prefix of `lib` on this particular library ...
-    try fs.writeFileContents(binPath.appending(component: "libIndexStore\(dylibSuffix)"), bytes: "")
+    try Data().write(to: binPath.appendingPathComponent("libIndexStore\(dylibSuffix)"))
     #else
-    try fs.writeFileContents(libPath.appending(component: "libIndexStore\(dylibSuffix)"), bytes: "")
+    try Data().write(to: libPath.appendingPathComponent("libIndexStore\(dylibSuffix)"))
     #endif
   }
 }


### PR DESCRIPTION
We made quite a few fixes recently to make sure that path handling works correctly using `URL` on Windows. Use `URL` in most places to have a single type that represents file paths instead of sometimes using `AbsolutePath`.

While doing so, also remove usages of `TSCBasic.FileSystem` an `InMemoryFileSystem`. The pattern of using `InMemoryFileSystem` for tests was never consistently used and it was a little confusing that some types took a `FileSystem` parameter while other always assumed to work on the local file system.