### PR TITLE
Skip tests that use background indexing when running tests with a Swift 5.10 toolchain

### DIFF
--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -146,6 +146,9 @@ package final class TestSourceKitLSPClient: MessageHandler, Sendable {
     preInitialization: ((TestSourceKitLSPClient) -> Void)? = nil,
     cleanUp: @Sendable @escaping () -> Void = {}
   ) async throws {
+    if enableBackgroundIndexing {
+      try await SkipUnless.swiftPMSupportsExperimentalPrepareForIndexing()
+    }
     var options = options
     if let globalModuleCache = try globalModuleCache {
       options.swiftPMOrDefault.swiftCompilerFlags =

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -542,6 +542,8 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testPrepareTargetAfterEditToDependency() async throws {
+    try await SkipUnless.swiftPMSupportsExperimentalPrepareForIndexing()
+
     var testHooks = TestHooks()
     let expectedPreparationTracker = ExpectedIndexTaskTracker(expectedPreparations: [
       [
@@ -641,6 +643,8 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testDontStackTargetPreparationForEditorFunctionality() async throws {
+    try await SkipUnless.swiftPMSupportsExperimentalPrepareForIndexing()
+
     let allDocumentsOpened = WrappedSemaphore(name: "All documents opened")
     let libBStartedPreparation = WrappedSemaphore(name: "LibB started preparing")
     let libDPreparedForEditing = WrappedSemaphore(name: "LibD prepared for editing")


### PR DESCRIPTION
https://github.com/swiftlang/sourcekit-lsp/pull/1714 changed the background preparation mode to `enabled` but a Swift 5.10 toolchain does not support `--experimental-prepare-for-indexing`. Thus, these tests fail. Skip tests that rely on background indexing when testing SourceKit-LSP with a Swift 5.10 host toolchain.