### PR TITLE
[cmake] Build with CMake on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16.1)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
 project(SourceKit-LSP
-  LANGUAGES C Swift)
+  LANGUAGES C CXX Swift)
 
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 

--- a/Sources/sourcekit-lsp/CMakeLists.txt
+++ b/Sources/sourcekit-lsp/CMakeLists.txt
@@ -18,5 +18,8 @@ target_compile_options(sourcekit-lsp PRIVATE
 target_link_libraries(sourcekit-lsp PRIVATE
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 
+set_target_properties(sourcekit-lsp PROPERTIES
+  INSTALL_RPATH "$<$<PLATFORM_ID:Darwin>:@executable_path/../lib;@executable_path/../lib/swift/macosx;@executable_path/../lib/swift/host;@executable_path/../lib/swift/pm/llbuild>")
+
 install(TARGETS sourcekit-lsp
   DESTINATION bin)


### PR DESCRIPTION
* Add CXX as a language. This is required to link in the standard library on macOS, which is used by dependencies.
* Set up rpath for the macOS binary. This is necessary to produce a working binary post-installation.