### PR TITLE
Fix quadratic performance issue in `AsyncQueue<Serial>`

### DIFF
--- a/Sources/BuildSystemIntegration/BuildSystemMessageDependencyTracker.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemMessageDependencyTracker.swift
@@ -15,7 +15,7 @@ import BuildServerProtocol
 package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
-import SwiftExtensions
+package import SwiftExtensions
 #else
 import BuildServerProtocol
 import LanguageServerProtocol
@@ -80,6 +80,10 @@ package enum BuildSystemMessageDependencyTracker: QueueBasedMessageHandlerDepend
       )
       self = .stateRead
     }
+  }
+
+  package func dependencies(in pendingTasks: [PendingTask<Self>]) -> [PendingTask<Self>] {
+    return pendingTasks.filter { $0.metadata.isDependency(of: self) }
   }
 
   package init(_ request: some RequestType) {

--- a/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
+++ b/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
@@ -14,7 +14,7 @@
 package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
-import SwiftExtensions
+package import SwiftExtensions
 #else
 import LanguageServerProtocol
 import LanguageServerProtocolExtensions
@@ -88,6 +88,10 @@ package enum MessageHandlingDependencyTracker: QueueBasedMessageHandlerDependenc
     case (_, .freestanding):
       return false
     }
+  }
+
+  package func dependencies(in pendingTasks: [PendingTask<Self>]) -> [PendingTask<Self>] {
+    return pendingTasks.filter { $0.metadata.isDependency(of: self) }
   }
 
   package init(_ notification: some NotificationType) {

--- a/Sources/SourceKitLSP/Swift/SyntacticTestIndex.swift
+++ b/Sources/SourceKitLSP/Swift/SyntacticTestIndex.swift
@@ -37,7 +37,6 @@ fileprivate enum TaskMetadata: DependencyTracker, Equatable {
     case (.index(_), .read):
       // We require all index tasks scheduled before the read to be finished.
       // This ensures that the index has been updated at least to the state of file at which the read was scheduled.
-      // Adding the dependency also elevates the index task's priorities.
       return true
     case (.index(let lhsUris), .index(let rhsUris)):
       // Technically, we should be able to allow simultaneous indexing of the same file. But conceptually the code
@@ -46,6 +45,10 @@ fileprivate enum TaskMetadata: DependencyTracker, Equatable {
       // file will realize that the index is already up-to-date based on the file's mtime and early exit.
       return !lhsUris.intersection(rhsUris).isEmpty
     }
+  }
+
+  package func dependencies(in pendingTasks: [PendingTask<Self>]) -> [PendingTask<Self>] {
+    return pendingTasks.filter { $0.metadata.isDependency(of: self) }
   }
 }
 

--- a/Sources/SwiftExtensions/AsyncQueue.swift
+++ b/Sources/SwiftExtensions/AsyncQueue.swift
@@ -28,28 +28,31 @@ extension Task: AnyTask {
 
 /// A type that is able to track dependencies between tasks.
 package protocol DependencyTracker: Sendable {
-  /// Whether the task described by `self` needs to finish executing before
-  /// `other` can start executing.
-  func isDependency(of other: Self) -> Bool
+  /// Which tasks need to finish before a task described by `self` may start executing.
+  /// `pendingTasks` is sorted in the order in which the tasks were enqueued to `AsyncQueue`.
+  func dependencies(in pendingTasks: [PendingTask<Self>]) -> [PendingTask<Self>]
 }
 
 /// A dependency tracker where each task depends on every other, i.e. a serial
 /// queue.
 package struct Serial: DependencyTracker {
-  package func isDependency(of other: Serial) -> Bool {
-    return true
+  package func dependencies(in pendingTasks: [PendingTask<Self>]) -> [PendingTask<Self>] {
+    if let lastTask = pendingTasks.last {
+      return [lastTask]
+    }
+    return []
   }
 }
 
-private struct PendingTask<TaskMetadata: Sendable>: Sendable {
+package struct PendingTask<TaskMetadata: Sendable>: Sendable {
   /// The task that is pending.
-  let task: any AnyTask
+  fileprivate let task: any AnyTask
 
-  let metadata: TaskMetadata
+  package let metadata: TaskMetadata
 
   /// A unique value used to identify the task. This allows tasks to get
   /// removed from `pendingTasks` again after they finished executing.
-  let id: UUID
+  fileprivate let id: UUID
 }
 
 /// A list of pending tasks that can be sent across actor boundaries and is guarded by a lock.
@@ -132,7 +135,7 @@ package final class AsyncQueue<TaskMetadata: DependencyTracker>: Sendable {
     return pendingTasks.withLock { tasks in
       // Build the list of tasks that need to finished execution before this one
       // can be executed
-      let dependencies: [PendingTask] = tasks.filter { $0.metadata.isDependency(of: metadata) }
+      let dependencies = metadata.dependencies(in: tasks)
 
       // Schedule the task.
       let task = Task(priority: priority) { [pendingTasks] in


### PR DESCRIPTION
Adding an item to `AsyncQueue` was linear in the number of pending queue items, thus adding n items to an `AsyncQueue` before any can execute is in O(n^2). This decision was made intentionally because the primary use case for `AsyncQueue` was to track pending LSP requests, of which we don’t expect to have too many pending requests at any given time.

While we can't fix the quadratic performance issue in general, we can resolve the quadratic issue of `AsyncQueue<Serial>` by making a new task only depend on the last item in the queue, which then transitively depends on all the previous items. `AsyncQueue<Serial>` are the queues that are most likely to contain many items.

Fixes #1725
rdar://137886469