### PR TITLE
Log integers and booleans as public information by default in `NonDarwinLogger`

### DIFF
--- a/Sources/SKLogging/NonDarwinLogging.swift
+++ b/Sources/SKLogging/NonDarwinLogging.swift
@@ -222,6 +222,17 @@ package struct NonDarwinLogInterpolation: StringInterpolationProtocol, Sendable 
     append(description: String(reflecting: type), redactedDescription: "<private>", privacy: privacy)
   }
 
+  package mutating func appendInterpolation(
+    _ message: some Numeric & Sendable,
+    privacy: NonDarwinLogPrivacy = .public
+  ) {
+    append(description: String(describing: message), redactedDescription: "<private>", privacy: privacy)
+  }
+
+  package mutating func appendInterpolation(_ message: Bool, privacy: NonDarwinLogPrivacy = .public) {
+    append(description: message.description, redactedDescription: "<private>", privacy: privacy)
+  }
+
   /// Builds the string that represents the log message, masking all interpolation
   /// segments whose privacy level is greater that `logPrivacyLevel`.
   fileprivate func string(for logPrivacyLevel: NonDarwinLogPrivacy) -> String {

--- a/Tests/SKLoggingTests/LoggingTests.swift
+++ b/Tests/SKLoggingTests/LoggingTests.swift
@@ -212,4 +212,22 @@ final class LoggingTests: XCTestCase {
       $0.log("got \(LogStringConvertible().forLogging)")
     }
   }
+
+  func testIntegerNotConsideredPrivate() async {
+    await assertLogging(
+      privacyLevel: .public,
+      expected: ["got 42"]
+    ) {
+      $0.log("got \(42)")
+    }
+  }
+
+  func testBoolNotConsideredPrivate() async {
+    await assertLogging(
+      privacyLevel: .public,
+      expected: ["got true"]
+    ) {
+      $0.log("got \(true)")
+    }
+  }
 }


### PR DESCRIPTION
`os_log` doesn’t consider integers and bools as private information and neither should `NonDarwinLogger`.

rdar://138659073