### PR TITLE
Reply with `null` to `shutdown` request

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/ShutdownRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/ShutdownRequest.swift
@@ -18,10 +18,17 @@
 /// - Returns: Void.
 public struct ShutdownRequest: RequestType, Hashable {
   public static let method: String = "shutdown"
-  public typealias Response = VoidResponse
+
+  public struct Response: ResponseType, Equatable {
+    public init() {}
+
+    public init(from decoder: any Decoder) throws {}
+
+    public func encode(to encoder: any Encoder) throws {
+      var container = encoder.singleValueContainer()
+      try container.encodeNil()
+    }
+  }
 
   public init() {}
 }
-
-@available(*, deprecated, renamed: "ShutdownRequest")
-public typealias Shutdown = ShutdownRequest

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1128,7 +1128,7 @@ extension SourceKitLSPServer {
     }
   }
 
-  func shutdown(_ request: ShutdownRequest) async throws -> VoidResponse {
+  func shutdown(_ request: ShutdownRequest) async throws -> ShutdownRequest.Response {
     await prepareForExit()
 
     await withTaskGroup(of: Void.self) { taskGroup in
@@ -1159,7 +1159,7 @@ extension SourceKitLSPServer {
     // Otherwise we might terminate sourcekit-lsp while it still has open
     // connections to the toolchain servers, which could send messages to
     // sourcekit-lsp while it is being deallocated, causing crashes.
-    return VoidResponse()
+    return ShutdownRequest.Response()
   }
 
   func exit(_ notification: ExitNotification) async {

--- a/Tests/LanguageServerProtocolTests/CodingTests.swift
+++ b/Tests/LanguageServerProtocolTests/CodingTests.swift
@@ -1343,6 +1343,10 @@ final class CodingTests: XCTestCase {
         """
     )
   }
+
+  func testShutdownResponse() {
+    checkCoding(ShutdownRequest.Response(), json: "null")
+  }
 }
 
 func with<T>(_ value: T, mutate: (inout T) -> Void) -> T {

--- a/Tests/SourceKitLSPTests/IndexTests.swift
+++ b/Tests/SourceKitLSPTests/IndexTests.swift
@@ -141,7 +141,7 @@ final class IndexTests: XCTestCase {
         "Received unexpected version: \(versionContentsBefore.first?.lastPathComponent ?? "<nil>")"
       )
 
-      try await project.testClient.send(ShutdownRequest())
+      _ = try await project.testClient.send(ShutdownRequest())
       return versionedPath
     }
 


### PR DESCRIPTION
The LSP spec says the result of `shutdown` is `null`, not an empty object.

Fixes #1733
rdar://137886488