### PR TITLE
Don’t crash when opening a file with an empty path

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -56,8 +56,12 @@ public struct DocumentURI: Codable, Hashable, Sendable {
   /// fallback mode that drops semantic functionality.
   public var pseudoPath: String {
     if storage.isFileURL {
-      return storage.withUnsafeFileSystemRepresentation {
-        String(cString: $0!)
+      return storage.withUnsafeFileSystemRepresentation { filePath in
+        if let filePath {
+          String(cString: filePath)
+        } else {
+          ""
+        }
       }
     } else {
       return storage.absoluteString

--- a/Tests/SourceKitLSPTests/LifecycleTests.swift
+++ b/Tests/SourceKitLSPTests/LifecycleTests.swift
@@ -164,4 +164,9 @@ final class LifecycleTests: XCTestCase {
       )
     )
   }
+
+  func testOpenFileWithoutPath() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    testClient.openDocument("", uri: DocumentURI(try XCTUnwrap(URL(string: "file://"))), language: .swift)
+  }
 }


### PR DESCRIPTION
Fixes #1739
rdar://137886470