### PR TITLE
Add another import of new Android overlay and remove non-existent file exclusion from package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -487,7 +487,6 @@ var targets: [Target] = [
       "SwiftExtensions",
       "TSCExtensions",
     ],
-    exclude: ["CMakeLists.txt"],
     swiftSettings: globalSwiftSettings
   ),
 ]

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -16,6 +16,9 @@ public import Foundation
 public import LanguageServerProtocol
 import SKLogging
 import SwiftExtensions
+#if canImport(Android)
+import Android
+#endif
 #else
 import Dispatch
 import Foundation


### PR DESCRIPTION
I don't know what's going on with the symbol lookup in the compiler, as I built the Oct. 8 trunk source snapshot fine without this import and then started seeing this file erroring this month on my Android CI, finagolfin/swift-android-sdk@15b148d1c, and now natively on Android with the Nov. 20 trunk snapshot, without any seemingly relevant changes in this file.

As for the manifest, looks like Alex copy-pasted that line from the non-test target, but tests don't have a CMake config, [causing this warning on the CI](https://ci.swift.org/job/swift-PR-macos-smoke-test/16469/consoleText) which I also saw locally:
```
warning: 'sourcekit-lsp': Invalid Exclude '/Users/ec2-user/jenkins/workspace/swift-PR-macos-smoke-test/branch-main/sourcekit-lsp/Tests/TSCExtensionsTests/CMakeLists.txt': File not found.
```