### PR TITLE
Include parameters in initializer document symbols

### DIFF
--- a/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
@@ -247,7 +247,7 @@ fileprivate final class DocumentSymbolsFinder: SyntaxAnyVisitor {
   override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
     return record(
       node: node,
-      name: node.initKeyword.text,
+      name: node.declName,
       symbolKind: .constructor,
       range: node.rangeWithoutTrivia,
       selection: node.initKeyword
@@ -295,6 +295,18 @@ fileprivate extension EnumCaseElementSyntax {
 fileprivate extension FunctionDeclSyntax {
   var declName: String {
     var result = self.name.text
+    result += "("
+    for parameter in self.signature.parameterClause.parameters {
+      result += "\(parameter.firstName.text):"
+    }
+    result += ")"
+    return result
+  }
+}
+
+fileprivate extension InitializerDeclSyntax {
+  var declName: String {
+    var result = self.initKeyword.text
     result += "("
     for parameter in self.signature.parameterClause.parameters {
       result += "\(parameter.firstName.text):"

--- a/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentSymbolTests.swift
@@ -552,7 +552,39 @@ final class DocumentSymbolTests: XCTestCase {
           selectionRange: positions["2️⃣"]..<positions["3️⃣"],
           children: [
             DocumentSymbol(
-              name: "init",
+              name: "init()",
+              detail: nil,
+              kind: .constructor,
+              deprecated: nil,
+              range: positions["4️⃣"]..<positions["6️⃣"],
+              selectionRange: positions["4️⃣"]..<positions["5️⃣"],
+              children: []
+            )
+          ]
+        )
+      ]
+    }
+  }
+
+  func testInitializerWithParameters() async throws {
+    try await assertDocumentSymbols(
+      """
+      1️⃣class 2️⃣Foo3️⃣ {
+        4️⃣init(_ first: Int, second: Int)5️⃣ { }6️⃣
+      }7️⃣
+      """
+    ) { positions in
+      [
+        DocumentSymbol(
+          name: "Foo",
+          detail: nil,
+          kind: .class,
+          deprecated: nil,
+          range: positions["1️⃣"]..<positions["7️⃣"],
+          selectionRange: positions["2️⃣"]..<positions["3️⃣"],
+          children: [
+            DocumentSymbol(
+              name: "init(_:second:)",
               detail: nil,
               kind: .constructor,
               deprecated: nil,


### PR DESCRIPTION
I noticed that initializer document symbols do not contain the initializer's parameters while working on the DocC support. This PR adds the parameters to the symbol name in the same way as functions.