### PR TITLE
Include all resources in a build target's sources list

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -565,6 +565,27 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
           data: SourceKitSourceItemData(isHeader: true).encodeToLSPAny()
         )
       }
+      sources += swiftPMTarget.resources.map {
+        SourceItem(
+          uri: DocumentURI($0),
+          kind: $0.isDirectory ? .directory : .file,
+          generated: false,
+        )
+      }
+      sources += swiftPMTarget.ignored.map {
+        SourceItem(
+          uri: DocumentURI($0),
+          kind: $0.isDirectory ? .directory : .file,
+          generated: false,
+        )
+      }
+      sources += swiftPMTarget.others.map {
+        SourceItem(
+          uri: DocumentURI($0),
+          kind: $0.isDirectory ? .directory : .file,
+          generated: false,
+        )
+      }
       result.append(SourcesItem(target: target, sources: sources))
     }
     return BuildTargetSourcesResponse(items: result)
@@ -758,5 +779,11 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
   private func settings(forPackageManifest path: AbsolutePath) throws -> TextDocumentSourceKitOptionsResponse? {
     let compilerArgs = swiftPMWorkspace.interpreterFlags(for: path.parentDirectory) + [path.pathString]
     return TextDocumentSourceKitOptionsResponse(compilerArguments: compilerArgs)
+  }
+}
+
+fileprivate extension URL {
+  var isDirectory: Bool {
+    (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
   }
 }

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -565,21 +565,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
           data: SourceKitSourceItemData(isHeader: true).encodeToLSPAny()
         )
       }
-      sources += swiftPMTarget.resources.map {
-        SourceItem(
-          uri: DocumentURI($0),
-          kind: $0.isDirectory ? .directory : .file,
-          generated: false,
-        )
-      }
-      sources += swiftPMTarget.ignored.map {
-        SourceItem(
-          uri: DocumentURI($0),
-          kind: $0.isDirectory ? .directory : .file,
-          generated: false,
-        )
-      }
-      sources += swiftPMTarget.others.map {
+      sources += (swiftPMTarget.resources + swiftPMTarget.ignored + swiftPMTarget.others).map {
         SourceItem(
           uri: DocumentURI($0),
           kind: $0.isDirectory ? .directory : .file,


### PR DESCRIPTION
Companion PR to swiftlang/swift-package-manager#8107. This will allow SourceKit-LSP to be able to find Swift DocC documentation catalogs within SwiftPM build targets.