### PR TITLE
Only load BSP servers that support one of the language we are interested in

### DIFF
--- a/Sources/BuildSystemIntegration/ExternalBuildSystemAdapter.swift
+++ b/Sources/BuildSystemIntegration/ExternalBuildSystemAdapter.swift
@@ -223,7 +223,13 @@ actor ExternalBuildSystemAdapter {
     for case let buildServerConfigLocation? in buildServerConfigLocations {
       let jsonFiles =
         try? FileManager.default.contentsOfDirectory(at: buildServerConfigLocation, includingPropertiesForKeys: nil)
-        .filter { $0.pathExtension == "json" }
+        .filter {
+          guard let config = try? BuildServerConfig.load(from: $0) else {
+            return false
+          }
+          return !Set([Language.c, .cpp, .objective_c, .objective_cpp, .swift].map(\.rawValue))
+            .intersection(config.languages).isEmpty
+        }
 
       if let configFileURL = jsonFiles?.sorted(by: { $0.lastPathComponent < $1.lastPathComponent }).first {
         return configFileURL

--- a/Sources/SKTestSupport/BuildServerTestProject.swift
+++ b/Sources/SKTestSupport/BuildServerTestProject.swift
@@ -63,10 +63,10 @@ package class BuildServerTestProject: MultiFileTestProject {
     var files = files
     files[buildServerConfigLocation] = """
       {
-        "name": "client name",
-        "version": "10",
+        "name": "Test BSP-server",
+        "version": "1",
         "bspVersion": "2.0",
-        "languages": ["a", "b"],
+        "languages": ["swift"],
         "argv": ["server.py"]
       }
       """


### PR DESCRIPTION
Instead of unconditionally loading any BSP server from one of the search locations, only load those that support, C, C++, Obj-C, Obj-C++ or Swift.