### PR TITLE
Improve logic for build graph generation status

### DIFF
--- a/Sources/SourceKitLSP/IndexProgressManager.swift
+++ b/Sources/SourceKitLSP/IndexProgressManager.swift
@@ -93,8 +93,8 @@ actor IndexProgressManager {
     case .preparingFileForEditorFunctionality:
       message = "Preparing current file"
       percentage = 0
-    case .generatingBuildGraph:
-      message = "Generating build graph"
+    case .schedulingIndexing:
+      message = "Scheduling tasks"
       percentage = 0
     case .indexing(preparationTasks: let preparationTasks, indexTasks: let indexTasks):
       // We can get into a situation where queuedIndexTasks < indexTasks.count if we haven't processed all

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -378,7 +378,7 @@ final class BackgroundIndexingTests: XCTestCase {
       XCTFail("Expected begin notification")
       return
     }
-    XCTAssertEqual(beginData.message, "Generating build graph")
+    XCTAssertEqual(beginData.message, "Scheduling tasks")
     let indexingWorkDoneProgressToken = beginNotification.token
 
     _ = try await project.testClient.nextNotification(


### PR DESCRIPTION
`generateBuildGraph` was named misleadingly because the primary purpose of these tasks was to schedule indexing tasks and generating the build graph was just a necessary step for this. Also update it to take into account that multiple tasks scheduling indexing tasks might be running in parallel.