### PR TITLE
Don’t escape `{` inside placeholder snippets

### DIFF
--- a/Tests/SourceKitLSPTests/RewriteSourceKitPlaceholdersTests.swift
+++ b/Tests/SourceKitLSPTests/RewriteSourceKitPlaceholdersTests.swift
@@ -47,20 +47,20 @@ final class RewriteSourceKitPlaceholdersTests: XCTestCase {
     let input = "foo(bar: <#{ <#T##Int##Int#> }#>)"
     let rewritten = rewriteSourceKitPlaceholders(in: input, clientSupportsSnippets: true)
 
-    XCTAssertEqual(rewritten, #"foo(bar: ${1:\{ ${2:Int} \}})"#)
+    XCTAssertEqual(rewritten, #"foo(bar: ${1:{ ${2:Int} \}})"#)
   }
 
   func testClosurePlaceholderArgumentType() {
     let input = "foo(bar: <#{ <#T##Int##Int#> in <#T##Void##Void#> }#>)"
     let rewritten = rewriteSourceKitPlaceholders(in: input, clientSupportsSnippets: true)
 
-    XCTAssertEqual(rewritten, #"foo(bar: ${1:\{ ${2:Int} in ${3:Void} \}})"#)
+    XCTAssertEqual(rewritten, #"foo(bar: ${1:{ ${2:Int} in ${3:Void} \}})"#)
   }
 
   func testMultipleClosurePlaceholders() {
     let input = "foo(<#{ <#T##Int##Int#> }#>, baz: <#{ <#Int#> in <#T##Bool##Bool#> }#>)"
     let rewritten = rewriteSourceKitPlaceholders(in: input, clientSupportsSnippets: true)
 
-    XCTAssertEqual(rewritten, #"foo(${1:\{ ${2:Int} \}}, baz: ${3:\{ ${4:Int} in ${5:Bool} \}})"#)
+    XCTAssertEqual(rewritten, #"foo(${1:{ ${2:Int} \}}, baz: ${3:{ ${4:Int} in ${5:Bool} \}})"#)
   }
 }

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -864,14 +864,14 @@ final class SwiftCompletionTests: XCTestCase {
           sortText: nil,
           filterText: "myMap(:)",
           insertText: #"""
-            myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+            myMap(${1:{ ${2:Int} in ${3:Bool} \}})
             """#,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
             TextEdit(
               range: Range(positions["1️⃣"]),
               newText: #"""
-                myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+                myMap(${1:{ ${2:Int} in ${3:Bool} \}})
                 """#
             )
           )
@@ -908,14 +908,14 @@ final class SwiftCompletionTests: XCTestCase {
           sortText: nil,
           filterText: ".myMap(:)",
           insertText: #"""
-            ?.myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+            ?.myMap(${1:{ ${2:Int} in ${3:Bool} \}})
             """#,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
             TextEdit(
               range: positions["1️⃣"]..<positions["2️⃣"],
               newText: #"""
-                ?.myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+                ?.myMap(${1:{ ${2:Int} in ${3:Bool} \}})
                 """#
             )
           )
@@ -952,14 +952,14 @@ final class SwiftCompletionTests: XCTestCase {
           sortText: nil,
           filterText: "myMap(::)",
           insertText: #"""
-            myMap(${1:\{ ${2:Int} in ${3:Bool} \}}, ${4:\{ ${5:Int} in ${6:String} \}})
+            myMap(${1:{ ${2:Int} in ${3:Bool} \}}, ${4:{ ${5:Int} in ${6:String} \}})
             """#,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
             TextEdit(
               range: Range(positions["1️⃣"]),
               newText: #"""
-                myMap(${1:\{ ${2:Int} in ${3:Bool} \}}, ${4:\{ ${5:Int} in ${6:String} \}})
+                myMap(${1:{ ${2:Int} in ${3:Bool} \}}, ${4:{ ${5:Int} in ${6:String} \}})
                 """#
             )
           )
@@ -996,14 +996,14 @@ final class SwiftCompletionTests: XCTestCase {
           sortText: nil,
           filterText: "myMap(:second:)",
           insertText: #"""
-            myMap(${1:\{ ${2:Int} in ${3:Bool} \}}, second: ${4:\{ ${5:Int} in ${6:String} \}})
+            myMap(${1:{ ${2:Int} in ${3:Bool} \}}, second: ${4:{ ${5:Int} in ${6:String} \}})
             """#,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
             TextEdit(
               range: Range(positions["1️⃣"]),
               newText: #"""
-                myMap(${1:\{ ${2:Int} in ${3:Bool} \}}, second: ${4:\{ ${5:Int} in ${6:String} \}})
+                myMap(${1:{ ${2:Int} in ${3:Bool} \}}, second: ${4:{ ${5:Int} in ${6:String} \}})
                 """#
             )
           )
@@ -1042,14 +1042,14 @@ final class SwiftCompletionTests: XCTestCase {
           sortText: nil,
           filterText: "myMap(:)",
           insertText: #"""
-            myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+            myMap(${1:{ ${2:Int} in ${3:Bool} \}})
             """#,
           insertTextFormat: .snippet,
           textEdit: .textEdit(
             TextEdit(
               range: Range(positions["1️⃣"]),
               newText: #"""
-                myMap(${1:\{ ${2:Int} in ${3:Bool} \}})
+                myMap(${1:{ ${2:Int} in ${3:Bool} \}})
                 """#
             )
           )


### PR DESCRIPTION
When `\{` is included inside an LSP placeholder, in VS Code will insert `\{` verbatim. At least in VS Code, we only need to escape the closing brace.

@woolsweater I’m not sure which editor you used in the video you included in https://github.com/swiftlang/sourcekit-lsp/pull/1831 but it looked like that did include the opening brace correctly. Could you check that this change doesn’t break your editor?