### PR TITLE
Don’t show warning message when opening projects that don't support background indexing

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -84,12 +84,6 @@ package actor SourceKitLSPServer {
   /// Initialization can be awaited using `waitUntilInitialized`.
   private var initialized: Bool = false
 
-  /// Set to `true` after the user has opened a project that doesn't support background indexing while having background
-  /// indexing enabled.
-  ///
-  /// This ensures that we only inform the user about background indexing not being supported for these projects once.
-  private var didSendBackgroundIndexingNotSupportedNotification = false
-
   var options: SourceKitLSPOptions
 
   let testHooks: TestHooks
@@ -841,20 +835,6 @@ extension SourceKitLSPServer {
       testHooks: testHooks,
       indexTaskScheduler: indexTaskScheduler
     )
-    if options.backgroundIndexingOrDefault, workspace.semanticIndexManager == nil,
-      !self.didSendBackgroundIndexingNotSupportedNotification
-    {
-      self.sendNotificationToClient(
-        ShowMessageNotification(
-          type: .info,
-          message: """
-            Background indexing is currently only supported for SwiftPM projects. \
-            For all other project types, please run a build to update the index.
-            """
-        )
-      )
-      self.didSendBackgroundIndexingNotSupportedNotification = true
-    }
     return workspace
   }
 

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -885,17 +885,6 @@ final class BackgroundIndexingTests: XCTestCase {
     )
   }
 
-  func testShowMessageWhenOpeningAProjectThatDoesntSupportBackgroundIndexing() async throws {
-    let project = try await MultiFileTestProject(
-      files: [
-        "compile_commands.json": ""
-      ],
-      enableBackgroundIndexing: true
-    )
-    let message = try await project.testClient.nextNotification(ofType: ShowMessageNotification.self)
-    XCTAssert(message.message.contains("Background indexing"), "Received unexpected message: \(message.message)")
-  }
-
   func testNoPreparationStatusIfTargetIsUpToDate() async throws {
     let project = try await SwiftPMTestProject(
       files: [


### PR DESCRIPTION
Since we enabled background indexing by default, the user is no longer explicitly opting into it. A user might be exclusively working with compilation database projects or BSP server without background indexing support and thus not care that we switched the background indexing default. We shouldn’t bother them with a warning message every time they launch sourcekit-lsp.