### PR TITLE
Allow dependency updates in the `index-build` folder

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -329,7 +329,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
     }
 
     var configuration = WorkspaceConfiguration.default
-    configuration.skipDependenciesUpdates = true
+    configuration.skipDependenciesUpdates = !options.backgroundIndexingOrDefault
 
     self.swiftPMWorkspace = try Workspace(
       fileSystem: localFileSystem,


### PR DESCRIPTION
When we have background indexing enabled, SourceKit-LSP manages the dependencies. We should thus allow it to update them, eg. after `Package.resolved` was updated.