### PR TITLE
[6.0] Normalize Windows drive letter to be uppercase

### DIFF
--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -48,8 +48,21 @@ public struct DocumentURI: Codable, Hashable, Sendable {
   /// fallback mode that drops semantic functionality.
   public var pseudoPath: String {
     if storage.isFileURL {
-      return storage.withUnsafeFileSystemRepresentation {
-        String(cString: $0!)
+      return storage.withUnsafeFileSystemRepresentation { filePathPtr in
+        guard let filePathPtr else {
+          return ""
+        }
+        let filePath = String(cString: filePathPtr)
+        #if os(Windows)
+        // VS Code spells file paths with a lowercase drive letter, while the rest of Windows APIs use an uppercase
+        // drive letter. Normalize the drive letter spelling to be uppercase.
+        if filePath.first?.isASCII ?? false, filePath.first?.isLetter ?? false, filePath.first?.isLowercase ?? false,
+          filePath.count > 1, filePath[filePath.index(filePath.startIndex, offsetBy: 1)] == ":"
+        {
+          return filePath.first!.uppercased() + filePath.dropFirst()
+        }
+        #endif
+        return filePath
       }
     } else {
       return storage.absoluteString

--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -415,6 +415,10 @@ public actor SkipUnless {
     try XCTSkipUnless(Platform.current == .darwin, message)
   }
 
+  public static func platformIsWindows(_ message: String) throws {
+    try XCTSkipUnless(Platform.current == .windows, message)
+  }
+
   public static func platformSupportsTaskPriorityElevation() throws {
     #if os(macOS)
     guard #available(macOS 14.0, *) else {


### PR DESCRIPTION
- **Explanation**: VS Code spells file paths with a lowercase drive letter, while the rest of Windows APIs use an uppercase drive letter. Because of this casing inconsistency, we don’t show diagnostics on Windows. Normalize the drive letter spelling to be uppercase to fix the issue.
- **Scope**: LSP messages on Windows that use a lowercase drive letter
- **Risk**: Only affects Windows but modifies that at a very central position. But uppercasing the drive letter for internal processing should be safe.
- **Testing**: Verified that we show diagnostics with this fix
- **Issue**: #1855 / rdar://141001203
- **Reviewer**:   @bnbarham on https://github.com/swiftlang/sourcekit-lsp/pull/1880