### PR TITLE
When a sourcekitd diagnostics request fails, show the request error as a diagnostic on the source file

### DIFF
--- a/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
+++ b/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
@@ -110,11 +110,27 @@ actor DiagnosticReportManager {
       keys.compilerArgs: compilerArgs as [SKDRequestValue],
     ])
 
-    let dict = try await self.sourcekitd.send(
-      skreq,
-      timeout: options.sourcekitdRequestTimeoutOrDefault,
-      fileContents: snapshot.text
-    )
+    let dict: SKDResponseDictionary
+    do {
+      dict = try await self.sourcekitd.send(
+        skreq,
+        timeout: options.sourcekitdRequestTimeoutOrDefault,
+        fileContents: snapshot.text
+      )
+    } catch SKDError.requestFailed(let sourcekitdError) {
+      var errorMessage = sourcekitdError
+      if errorMessage.hasPrefix("error response (Request Failed): error: ") {
+        errorMessage = String(errorMessage.dropFirst(40))
+      }
+      return RelatedFullDocumentDiagnosticReport(items: [
+        Diagnostic(
+          range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 0),
+          severity: .error,
+          source: "SourceKit",
+          message: "Internal SourceKit error: \(errorMessage)"
+        )
+      ])
+    }
 
     try Task.checkCancellation()
 

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -376,4 +376,30 @@ final class PullDiagnosticsTests: XCTestCase {
     let note = try XCTUnwrap(diagnostic.relatedInformation?.only)
     XCTAssertEqual(note.location, try project.location(from: "1️⃣", to: "1️⃣", in: "FileA.swift"))
   }
+
+  func testDiagnosticsFromSourcekitdRequestError() async throws {
+    let project = try await MultiFileTestProject(
+      files: [
+        "test.swift": """
+        func test() {}
+        """,
+        "compile_flags.txt": "-invalid-argument",
+      ]
+    )
+    let (uri, _) = try project.openDocument("test.swift")
+    let diagnostics = try await project.testClient.send(
+      DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
+    )
+    XCTAssertEqual(
+      diagnostics.fullReport?.items,
+      [
+        Diagnostic(
+          range: Range(Position(line: 0, utf16index: 0)),
+          severity: .error,
+          source: "SourceKit",
+          message: "Internal SourceKit error: unknown argument: '-invalid-argument'"
+        )
+      ]
+    )
+  }
 }


### PR DESCRIPTION
The missing diagnostics might be due to an error that the user can fix. Report it to them.

Fixes #1812
rdar://139514623