### PR TITLE
Interpret the `-index-store-path` relative to the command’s directory

### DIFF
--- a/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
@@ -99,7 +99,10 @@ package actor CompilationDatabaseBuildSystem: BuiltInBuildSystem {
           let args = command.commandLine
           for i in args.indices.reversed() {
             if args[i] == "-index-store-path" && i + 1 < args.count {
-              return URL(fileURLWithPath: args[i + 1])
+              return URL(
+                fileURLWithPath: args[i + 1],
+                relativeTo: URL(fileURLWithPath: command.directory, isDirectory: true)
+              )
             }
           }
         }

--- a/Tests/BuildSystemIntegrationTests/CompilationDatabaseTests.swift
+++ b/Tests/BuildSystemIntegrationTests/CompilationDatabaseTests.swift
@@ -412,6 +412,25 @@ final class CompilationDatabaseTests: XCTestCase {
       )
     }
   }
+
+  func testIndexStorePathRelativeToWorkingDirectory() async throws {
+    try await checkCompilationDatabaseBuildSystem(
+      """
+      [
+        {
+          "file": "a.swift",
+          "directory": "/a",
+          "arguments": ["swift", "a.swift", "-index-store-path", "index-store"]
+        }
+      ]
+      """
+    ) { buildSystem in
+      assertEqual(
+        try await buildSystem.indexStorePath?.filePath,
+        "\(pathSeparator)a\(pathSeparator)index-store"
+      )
+    }
+  }
 }
 
 fileprivate var pathSeparator: String {


### PR DESCRIPTION
Fixes #1856
rdar://141004197