### PR TITLE
Merge `main` into `release/6.1`

### DIFF
--- a/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/CompilationDatabaseBuildSystem.swift
@@ -99,7 +99,10 @@ package actor CompilationDatabaseBuildSystem: BuiltInBuildSystem {
           let args = command.commandLine
           for i in args.indices.reversed() {
             if args[i] == "-index-store-path" && i + 1 < args.count {
-              return URL(fileURLWithPath: args[i + 1])
+              return URL(
+                fileURLWithPath: args[i + 1],
+                relativeTo: URL(fileURLWithPath: command.directory, isDirectory: true)
+              )
             }
           }
         }

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -587,7 +587,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
         SourceItem(
           uri: DocumentURI($0),
           kind: $0.isDirectory ? .directory : .file,
-          generated: false,
+          generated: false
         )
       }
       result.append(SourcesItem(target: target, sources: sources))

--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -56,12 +56,21 @@ public struct DocumentURI: Codable, Hashable, Sendable {
   /// fallback mode that drops semantic functionality.
   public var pseudoPath: String {
     if storage.isFileURL {
-      return storage.withUnsafeFileSystemRepresentation { filePath in
-        if let filePath {
-          String(cString: filePath)
-        } else {
-          ""
+      return storage.withUnsafeFileSystemRepresentation { filePathPtr in
+        guard let filePathPtr else {
+          return ""
         }
+        let filePath = String(cString: filePathPtr)
+        #if os(Windows)
+        // VS Code spells file paths with a lowercase drive letter, while the rest of Windows APIs use an uppercase
+        // drive letter. Normalize the drive letter spelling to be uppercase.
+        if filePath.first?.isASCII ?? false, filePath.first?.isLetter ?? false, filePath.first?.isLowercase ?? false,
+          filePath.count > 1, filePath[filePath.index(filePath.startIndex, offsetBy: 1)] == ":"
+        {
+          return filePath.first!.uppercased() + filePath.dropFirst()
+        }
+        #endif
+        return filePath
       }
     } else {
       return storage.absoluteString

--- a/Sources/SKTestSupport/MultiFileTestProject.swift
+++ b/Sources/SKTestSupport/MultiFileTestProject.swift
@@ -88,7 +88,9 @@ package class MultiFileTestProject {
   /// File contents can also contain `$TEST_DIR`, which gets replaced by the temporary directory.
   package init(
     files: [RelativeFileLocation: String],
-    workspaces: (URL) async throws -> [WorkspaceFolder] = { [WorkspaceFolder(uri: DocumentURI($0))] },
+    workspaces: (_ scratchDirectory: URL) async throws -> [WorkspaceFolder] = {
+      [WorkspaceFolder(uri: DocumentURI($0))]
+    },
     initializationOptions: LSPAny? = nil,
     capabilities: ClientCapabilities = ClientCapabilities(),
     options: SourceKitLSPOptions = .testDefault(),

--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -418,6 +418,10 @@ package actor SkipUnless {
     try XCTSkipUnless(Platform.current == .darwin, message)
   }
 
+  package static func platformIsWindows(_ message: String) throws {
+    try XCTSkipUnless(Platform.current == .windows, message)
+  }
+
   package static func platformSupportsTaskPriorityElevation() throws {
     #if os(macOS)
     guard #available(macOS 14.0, *) else {

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -163,7 +163,9 @@ package class SwiftPMTestProject: MultiFileTestProject {
   package init(
     files: [RelativeFileLocation: String],
     manifest: String = SwiftPMTestProject.defaultPackageManifest,
-    workspaces: (URL) async throws -> [WorkspaceFolder] = { [WorkspaceFolder(uri: DocumentURI($0))] },
+    workspaces: (_ scratchDirectory: URL) async throws -> [WorkspaceFolder] = {
+      [WorkspaceFolder(uri: DocumentURI($0))]
+    },
     initializationOptions: LSPAny? = nil,
     capabilities: ClientCapabilities = ClientCapabilities(),
     options: SourceKitLSPOptions = .testDefault(),

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -291,7 +291,8 @@ package final actor SemanticIndexManager {
             filesToIndex
           } else {
             await orLog("Getting files to index") {
-              try await self.buildSystemManager.buildableSourceFiles().keys.sorted { $0.stringValue < $1.stringValue }
+              try await self.buildSystemManager.sourceFiles(includeNonBuildableFiles: false).keys
+                .sorted { $0.stringValue < $1.stringValue }
             } ?? []
           }
         if !indexFilesWithUpToDateUnit {
@@ -408,7 +409,7 @@ package final actor SemanticIndexManager {
     toCover files: some Collection<DocumentURI> & Sendable
   ) async -> [FileToIndex] {
     let sourceFiles = await orLog("Getting source files in project") {
-      Set(try await buildSystemManager.buildableSourceFiles().keys)
+      Set(try await buildSystemManager.sourceFiles(includeNonBuildableFiles: false).keys)
     }
     guard let sourceFiles else {
       return []

--- a/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
+++ b/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
@@ -110,27 +110,11 @@ actor DiagnosticReportManager {
       keys.compilerArgs: compilerArgs as [SKDRequestValue],
     ])
 
-    let dict: SKDResponseDictionary
-    do {
-      dict = try await self.sourcekitd.send(
-        skreq,
-        timeout: options.sourcekitdRequestTimeoutOrDefault,
-        fileContents: snapshot.text
-      )
-    } catch SKDError.requestFailed(let sourcekitdError) {
-      var errorMessage = sourcekitdError
-      if errorMessage.hasPrefix("error response (Request Failed): error: ") {
-        errorMessage = String(errorMessage.dropFirst(40))
-      }
-      return RelatedFullDocumentDiagnosticReport(items: [
-        Diagnostic(
-          range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 0),
-          severity: .error,
-          source: "SourceKit",
-          message: "Internal SourceKit error: \(errorMessage)"
-        )
-      ])
-    }
+    let dict = try await self.sourcekitd.send(
+      skreq,
+      timeout: options.sourcekitdRequestTimeoutOrDefault,
+      fileContents: snapshot.text
+    )
 
     try Task.checkCancellation()
 

--- a/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
+++ b/Sources/SourceKitLSP/Swift/DiagnosticReportManager.swift
@@ -110,11 +110,27 @@ actor DiagnosticReportManager {
       keys.compilerArgs: compilerArgs as [SKDRequestValue],
     ])
 
-    let dict = try await self.sourcekitd.send(
-      skreq,
-      timeout: options.sourcekitdRequestTimeoutOrDefault,
-      fileContents: snapshot.text
-    )
+    let dict: SKDResponseDictionary
+    do {
+      dict = try await self.sourcekitd.send(
+        skreq,
+        timeout: options.sourcekitdRequestTimeoutOrDefault,
+        fileContents: snapshot.text
+      )
+    } catch SKDError.requestFailed(let sourcekitdError) {
+      var errorMessage = sourcekitdError
+      if errorMessage.hasPrefix("error response (Request Failed): error: ") {
+        errorMessage = String(errorMessage.dropFirst(40))
+      }
+      return RelatedFullDocumentDiagnosticReport(items: [
+        Diagnostic(
+          range: Position(line: 0, utf16index: 0)..<Position(line: 0, utf16index: 0),
+          severity: .error,
+          source: "SourceKit",
+          message: "Internal SourceKit error: \(errorMessage)"
+        )
+      ])
+    }
 
     try Task.checkCancellation()
 

--- a/Sources/SwiftExtensions/URLExtensions.swift
+++ b/Sources/SwiftExtensions/URLExtensions.swift
@@ -67,11 +67,21 @@ extension URL {
       guard self.isFileURL else {
         throw FilePathError.noFileURL(self)
       }
-      return try self.withUnsafeFileSystemRepresentation { buffer in
-        guard let buffer else {
+      return try self.withUnsafeFileSystemRepresentation { filePathPtr in
+        guard let filePathPtr else {
           throw FilePathError.noFileSystemRepresentation(self)
         }
-        return String(cString: buffer)
+        let filePath = String(cString: filePathPtr)
+        #if os(Windows)
+        // VS Code spells file paths with a lowercase drive letter, while the rest of Windows APIs use an uppercase
+        // drive letter. Normalize the drive letter spelling to be uppercase.
+        if filePath.first?.isASCII ?? false, filePath.first?.isLetter ?? false, filePath.first?.isLowercase ?? false,
+          filePath.count > 1, filePath[filePath.index(filePath.startIndex, offsetBy: 1)] == ":"
+        {
+          return filePath.first!.uppercased() + filePath.dropFirst()
+        }
+        #endif
+        return filePath
       }
     }
   }

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -10,8 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
-public import ArgumentParser
 import BuildSystemIntegration
 import Csourcekitd  // Not needed here, but fixes debugging...
 import Diagnose
@@ -26,24 +24,16 @@ import SourceKitLSP
 import SwiftExtensions
 import ToolchainRegistry
 
-#if canImport(Android)
-import Android
-#endif
+import struct TSCBasic.AbsolutePath
+
+#if compiler(>=6)
+public import ArgumentParser
 #else
 import ArgumentParser
-import BuildSystemIntegration
-import Csourcekitd  // Not needed here, but fixes debugging...
-import Diagnose
-import Dispatch
-import Foundation
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import LanguageServerProtocolJSONRPC
-import SKLogging
-import SKOptions
-import SourceKitLSP
-import SwiftExtensions
-import ToolchainRegistry
+#endif
+
+#if canImport(Android)
+import Android
 #endif
 
 extension PathPrefixMapping {
@@ -278,6 +268,10 @@ struct SourceKitLSP: AsyncParsableCommand {
       inFD: FileHandle.standardInput,
       outFD: realStdoutHandle
     )
+
+    // For reasons that are completely oblivious to me, `DispatchIO.write`, which is used to write LSP responses to
+    // stdout fails with error code 5 on Windows unless we call `AbsolutePath(validating:)` on some URL first.
+    _ = try AbsolutePath(validating: Bundle.main.bundlePath)
 
     var inputMirror: FileHandle? = nil
     if let inputMirrorDirectory = globalConfigurationOptions.loggingOrDefault.inputMirrorDirectory {

--- a/Tests/BuildSystemIntegrationTests/CompilationDatabaseTests.swift
+++ b/Tests/BuildSystemIntegrationTests/CompilationDatabaseTests.swift
@@ -412,6 +412,25 @@ final class CompilationDatabaseTests: XCTestCase {
       )
     }
   }
+
+  func testIndexStorePathRelativeToWorkingDirectory() async throws {
+    try await checkCompilationDatabaseBuildSystem(
+      """
+      [
+        {
+          "file": "a.swift",
+          "directory": "/a",
+          "arguments": ["swift", "a.swift", "-index-store-path", "index-store"]
+        }
+      ]
+      """
+    ) { buildSystem in
+      assertEqual(
+        try await buildSystem.indexStorePath?.filePath,
+        "\(pathSeparator)a\(pathSeparator)index-store"
+      )
+    }
+  }
 }
 
 fileprivate var pathSeparator: String {

--- a/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
@@ -1156,7 +1156,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         files: [
           "pkg/Sources/lib/a.swift": "",
           "pkg/Package.swift": """
-          // swift-tools-version: 4.2
+          // swift-tools-version:5.1
           import PackageDescription
           """,
         ]
@@ -1177,7 +1177,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         fallbackAfterTimeout: false
       )
       let compilerArgs = try XCTUnwrap(settings?.compilerArguments)
-      XCTAssert(compilerArgs.contains("-package-description-version"))
+      assertArgumentsContain("-package-description-version", "5.1.0", arguments: compilerArgs)
       XCTAssert(compilerArgs.contains(try manifestURL.filePath))
     }
   }

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -405,30 +405,4 @@ final class PullDiagnosticsTests: XCTestCase {
     let note = try XCTUnwrap(diagnostic.relatedInformation?.only)
     XCTAssertEqual(note.location, try project.location(from: "1️⃣", to: "1️⃣", in: "FileA.swift"))
   }
-
-  func testDiagnosticsFromSourcekitdRequestError() async throws {
-    let project = try await MultiFileTestProject(
-      files: [
-        "test.swift": """
-        func test() {}
-        """,
-        "compile_flags.txt": "-invalid-argument",
-      ]
-    )
-    let (uri, _) = try project.openDocument("test.swift")
-    let diagnostics = try await project.testClient.send(
-      DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
-    )
-    XCTAssertEqual(
-      diagnostics.fullReport?.items,
-      [
-        Diagnostic(
-          range: Range(Position(line: 0, utf16index: 0)),
-          severity: .error,
-          source: "SourceKit",
-          message: "Internal SourceKit error: unknown argument: '-invalid-argument'"
-        )
-      ]
-    )
-  }
 }

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -48,6 +48,35 @@ final class PullDiagnosticsTests: XCTestCase {
     XCTAssertEqual(diagnostic.range, Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9))
   }
 
+  func testDiagnosticsIfFileIsOpenedWithLowercaseDriveLetter() async throws {
+    try SkipUnless.platformIsWindows("Drive letters only exist on Windows")
+
+    let fileContents = """
+      func foo() {
+        invalid
+      }
+      """
+
+    // We use `IndexedSingleSwiftFileTestProject` so that the test file exists on disk, which causes sourcekitd to
+    // uppercase the drive letter.
+    let project = try await IndexedSingleSwiftFileTestProject(fileContents, allowBuildFailure: true)
+    project.testClient.send(DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(project.fileURI)))
+
+    let filePath = try XCTUnwrap(project.fileURI.fileURL?.filePath)
+    XCTAssertEqual(filePath[filePath.index(filePath.startIndex, offsetBy: 1)], ":")
+    let lowercaseDriveLetterPath = filePath.first!.lowercased() + filePath.dropFirst()
+    let uri = DocumentURI(filePath: lowercaseDriveLetterPath, isDirectory: false)
+    project.testClient.openDocument(fileContents, uri: uri)
+
+    let report = try await project.testClient.send(
+      DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
+    )
+
+    XCTAssertEqual(report.fullReport?.items.count, 1)
+    let diagnostic = try XCTUnwrap(report.fullReport?.items.first)
+    XCTAssertEqual(diagnostic.range, Position(line: 1, utf16index: 2)..<Position(line: 1, utf16index: 9))
+  }
+
   /// Test that we can get code actions for pulled diagnostics (https://github.com/swiftlang/sourcekit-lsp/issues/776)
   func testCodeActions() async throws {
     let testClient = try await TestSourceKitLSPClient(
@@ -375,5 +404,31 @@ final class PullDiagnosticsTests: XCTestCase {
     let diagnostic = try XCTUnwrap(diagnostics.fullReport?.items.only)
     let note = try XCTUnwrap(diagnostic.relatedInformation?.only)
     XCTAssertEqual(note.location, try project.location(from: "1️⃣", to: "1️⃣", in: "FileA.swift"))
+  }
+
+  func testDiagnosticsFromSourcekitdRequestError() async throws {
+    let project = try await MultiFileTestProject(
+      files: [
+        "test.swift": """
+        func test() {}
+        """,
+        "compile_flags.txt": "-invalid-argument",
+      ]
+    )
+    let (uri, _) = try project.openDocument("test.swift")
+    let diagnostics = try await project.testClient.send(
+      DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
+    )
+    XCTAssertEqual(
+      diagnostics.fullReport?.items,
+      [
+        Diagnostic(
+          range: Range(Position(line: 0, utf16index: 0)),
+          severity: .error,
+          source: "SourceKit",
+          message: "Internal SourceKit error: unknown argument: '-invalid-argument'"
+        )
+      ]
+    )
   }
 }


### PR DESCRIPTION
Merge the following PRs into `release/6.1`:
- https://github.com/swiftlang/sourcekit-lsp/pull/1858
- https://github.com/swiftlang/sourcekit-lsp/pull/1865
- https://github.com/swiftlang/sourcekit-lsp/pull/1880
- https://github.com/swiftlang/sourcekit-lsp/pull/1882
- https://github.com/swiftlang/sourcekit-lsp/pull/1885
- https://github.com/swiftlang/sourcekit-lsp/pull/1888

Do not merge the following PRs into `release/6.1` because I want to qualify them on `main` for a little longer:
- https://github.com/swiftlang/sourcekit-lsp/pull/1886