### PR TITLE
[Test] Link macro binaries to _SwiftSyntaxCShims objects

### DIFF
--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -100,6 +100,7 @@ package class SwiftPMTestProject: MultiFileTestProject {
         "SwiftSyntaxBuilder",
         "SwiftSyntaxMacroExpansion",
         "SwiftSyntaxMacros",
+        "_SwiftSyntaxCShims",
       ]
 
       var objectFiles: [String] = []


### PR DESCRIPTION
Update for https://github.com/swiftlang/swift-syntax/pull/2925 but this can be merged independently.

`_SwiftSyntaxCShims` objects weren't linked because it was a header-only library. But since actual code is being added, we need to link it.