### PR TITLE
Clear `inProgressTextDocumentRequests` on `textDocumentTrackingQueue`

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -654,7 +654,9 @@ extension SourceKitLSPServer: QueueBasedMessageHandler {
   ) async {
     defer {
       if let request = params as? any TextDocumentRequest {
-        self.inProgressTextDocumentRequests[request.textDocument.uri, default: []].removeAll { $0.id == id }
+        textDocumentTrackingQueue.async(priority: .background) {
+          self.inProgressTextDocumentRequests[request.textDocument.uri, default: []].removeAll { $0.id == id }
+        }
       }
     }
 


### PR DESCRIPTION
`inProgressTextDocumentRequests` is supposed to only be accessed on `textDocumentTrackingQueue` but we were accessing it outside of that queue. Because of this, we might try to remove requests from `inProgressTextDocumentRequests` before adding them, which would cause them to stay in the list indefinitely.