### PR TITLE
Add option to generate an output mirror file that contains the exact data sent from SourceKit-LSP to the client

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -44,6 +44,7 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `level: "debug"|"info"|"default"|"error"|"fault"`: The level from which one onwards log messages should be written.
   - `privacyLevel: "public"|"private"|"sensitive"`: Whether potentially sensitive information should be redacted. Default is `public`, which redacts potentially sensitive information.
   - `inputMirrorDirectory: string`: Write all input received by SourceKit-LSP on stdin to a file in this directory. Useful to record and replay an entire SourceKit-LSP session.
+  - `outputMirrorDirectory: string`: Write all data sent from SourceKit-LSP to the client to a file in this directory. Useful to record the raw communication between SourceKit-LSP and the client on a low level.
 - `defaultWorkspaceType: "buildServer"|"compilationDatabase"|"swiftPM"`: Default workspace type. Overrides workspace type selection logic.
 - `generatedFilesPath: string`: Directory in which generated interfaces and macro expansions should be stored.
 - `backgroundIndexing: boolean`: Whether background indexing is enabled.

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -223,21 +223,29 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     /// Useful to record and replay an entire SourceKit-LSP session.
     public var inputMirrorDirectory: String?
 
+    /// Write all data sent from SourceKit-LSP to the client to a file in this directory.
+    ///
+    /// Useful to record the raw communication between SourceKit-LSP and the client on a low level.
+    public var outputMirrorDirectory: String?
+
     public init(
       level: String? = nil,
       privacyLevel: String? = nil,
-      inputMirrorDirectory: String? = nil
+      inputMirrorDirectory: String? = nil,
+      outputMirrorDirectory: String? = nil
     ) {
       self.level = level
       self.privacyLevel = privacyLevel
       self.inputMirrorDirectory = inputMirrorDirectory
+      self.outputMirrorDirectory = outputMirrorDirectory
     }
 
     static func merging(base: LoggingOptions, override: LoggingOptions?) -> LoggingOptions {
       return LoggingOptions(
         level: override?.level ?? base.level,
         privacyLevel: override?.privacyLevel ?? base.privacyLevel,
-        inputMirrorDirectory: override?.inputMirrorDirectory ?? base.inputMirrorDirectory
+        inputMirrorDirectory: override?.inputMirrorDirectory ?? base.inputMirrorDirectory,
+        outputMirrorDirectory: override?.outputMirrorDirectory ?? base.outputMirrorDirectory
       )
     }
   }

--- a/config.schema.json
+++ b/config.schema.json
@@ -173,6 +173,11 @@
           "markdownDescription" : "The level from which one onwards log messages should be written.",
           "type" : "string"
         },
+        "outputMirrorDirectory" : {
+          "description" : "Write all data sent from SourceKit-LSP to the client to a file in this directory. Useful to record the raw communication between SourceKit-LSP and the client on a low level.",
+          "markdownDescription" : "Write all data sent from SourceKit-LSP to the client to a file in this directory. Useful to record the raw communication between SourceKit-LSP and the client on a low level.",
+          "type" : "string"
+        },
         "privacyLevel" : {
           "description" : "Whether potentially sensitive information should be redacted. Default is `public`, which redacts potentially sensitive information.",
           "enum" : [


### PR DESCRIPTION
This could help us debug low-level issues of SourceKit-LSP to client communication such as https://github.com/swiftlang/sourcekit-lsp/issues/1890.