### PR TITLE
Cache container names in `CheckedIndex`

### DIFF
--- a/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
@@ -95,4 +95,32 @@ class WorkspaceSymbolsTests: XCTestCase {
       ]
     )
   }
+
+  func testContainerNameOfFunctionInExtension() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      struct Foo {
+        struct Bar {}
+      }
+
+      extension Foo.Bar {
+        func 1️⃣barMethod() {}
+      }
+      """
+    )
+    let response = try await project.testClient.send(WorkspaceSymbolsRequest(query: "barMethod"))
+    XCTAssertEqual(
+      response,
+      [
+        .symbolInformation(
+          SymbolInformation(
+            name: "barMethod()",
+            kind: .method,
+            location: Location(uri: project.fileURI, range: Range(project.positions["1️⃣"])),
+            containerName: "Foo.Bar"
+          )
+        )
+      ]
+    )
+  }
 }


### PR DESCRIPTION
It is important that we cache this because we might find a lot of symbols in the same container for eg. workspace symbols (eg. consider many symbols in the same C++ namespace). If we didn't cache this value, then we would need to perform a `primaryDefinitionOrDeclarationOccurrence` lookup for all of these containers, which is expensive.

For example, searching for `only` in SourceKit-LSP’s codebase used to not return results in more than 20s (after which I gave up) and now returns >8000 results in <2s.