### PR TITLE
Improve two imports

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -444,7 +444,6 @@ var targets: [Target] = [
   .target(
     name: "ToolchainRegistry",
     dependencies: [
-      "LanguageServerProtocolExtensions",
       "SKLogging",
       "SKUtilities",
       "SwiftExtensions",

--- a/Sources/BuildServerProtocol/SupportTypes/TextDocumentIdentifier.swift
+++ b/Sources/BuildServerProtocol/SupportTypes/TextDocumentIdentifier.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+public import LanguageServerProtocol
+
 public struct TextDocumentIdentifier: Codable, Sendable, Hashable {
   /// The text document's URI.
   public var uri: URI

--- a/Sources/ToolchainRegistry/ToolchainRegistry.swift
+++ b/Sources/ToolchainRegistry/ToolchainRegistry.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
-import LanguageServerProtocolExtensions
 import SwiftExtensions
 import TSCExtensions
 

--- a/Sources/ToolchainRegistry/XCToolchainPlist.swift
+++ b/Sources/ToolchainRegistry/XCToolchainPlist.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import LanguageServerProtocolExtensions
 import SwiftExtensions
 import TSCExtensions
 


### PR DESCRIPTION
- Import `LanguageServerProtocol` in `BuildServerProtocol/TextDocumentIdentifier.swift` because we use `URI` publicly within it.
- Don’t import `LanguageServerProtocolExtensions` in `ToolchainRegistry` because it’s not needed