### PR TITLE
Mark all closures in the `.stream` outputRedirection of TSC as `@Sendable`

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -655,8 +655,8 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
       arguments: arguments,
       workingDirectory: nil,
       outputRedirection: .stream(
-        stdout: { stdoutHandler.handleDataFromPipe(Data($0)) },
-        stderr: { stderrHandler.handleDataFromPipe(Data($0)) }
+        stdout: { @Sendable bytes in stdoutHandler.handleDataFromPipe(Data(bytes)) },
+        stderr: { @Sendable bytes in stderrHandler.handleDataFromPipe(Data(bytes)) }
       )
     )
     let exitStatus = result.exitStatus.exhaustivelySwitchable

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -404,8 +404,8 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
           arguments: processArguments,
           workingDirectory: workingDirectory,
           outputRedirection: .stream(
-            stdout: { stdoutHandler.handleDataFromPipe(Data($0)) },
-            stderr: { stderrHandler.handleDataFromPipe(Data($0)) }
+            stdout: { @Sendable bytes in stdoutHandler.handleDataFromPipe(Data(bytes)) },
+            stderr: { @Sendable bytes in stderrHandler.handleDataFromPipe(Data(bytes)) }
           )
         )
       }


### PR DESCRIPTION
The closures aren’t guaranteed to be called on the same thread as the process was launched, which can cause assertion failure by the concurrency runtime.

rdar://142813605