### PR TITLE
Avoid logging options for a workspace twice

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -835,7 +835,7 @@ extension SourceKitLSPServer {
           .appendingPathComponent("config.json")
       )
     )
-    logger.log("Creating workspace at \(workspaceFolder.forLogging) with options: \(options.forLogging)")
+    logger.log("Creating workspace at \(workspaceFolder.forLogging)")
     logger.logFullObjectInMultipleLogMessages(header: "Options for workspace", options.loggingProxy)
 
     let workspace = await Workspace(


### PR DESCRIPTION
We are already logging the options below.