### PR TITLE
Support background indexing when cross-compiling

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -626,6 +626,15 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
     if let configuration = options.swiftPMOrDefault.configuration {
       arguments += ["-c", configuration.rawValue]
     }
+    if let triple = options.swiftPMOrDefault.triple {
+      arguments += ["--triple", triple]
+    }
+    if let swiftSDKsDirectory = options.swiftPMOrDefault.swiftSDKsDirectory {
+      arguments += ["--swift-sdks-path", swiftSDKsDirectory]
+    }
+    if let swiftSDK = options.swiftPMOrDefault.swiftSDK {
+      arguments += ["--swift-sdk", swiftSDK]
+    }
     arguments += options.swiftPMOrDefault.cCompilerFlags?.flatMap { ["-Xcc", $0] } ?? []
     arguments += options.swiftPMOrDefault.cxxCompilerFlags?.flatMap { ["-Xcxx", $0] } ?? []
     arguments += options.swiftPMOrDefault.swiftCompilerFlags?.flatMap { ["-Xswiftc", $0] } ?? []

--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -477,6 +477,34 @@ package actor SkipUnless {
     }
   }
 
+  package static func canSwiftPMCompileForIOS(
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async throws {
+    return try await shared.skipUnlessSupported(allowSkippingInCI: true, file: file, line: line) {
+      #if os(macOS)
+      let project = try await SwiftPMTestProject(files: [
+        "MyFile.swift": """
+        public func foo() {}
+        """
+      ])
+      do {
+        try await SwiftPMTestProject.build(
+          at: project.scratchDirectory,
+          extraArguments: [
+            "--swift-sdk", "arm64-apple-ios",
+          ]
+        )
+        return .featureSupported
+      } catch {
+        return .featureUnsupported(skipMessage: "Cannot build for iOS: \(error)")
+      }
+      #else
+      return .featureUnsupported(skipMessage: "Cannot build for iOS outside macOS by default")
+      #endif
+    }
+  }
+
   package static func canCompileForWasm(
     file: StaticString = #filePath,
     line: UInt = #line

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1018,6 +1018,53 @@ final class BackgroundIndexingTests: XCTestCase {
     )
   }
 
+  func testUseSwiftSDKFlagsDuringPreparation() async throws {
+    try await SkipUnless.canSwiftPMCompileForIOS()
+
+    var options = SourceKitLSPOptions.testDefault()
+    options.swiftPMOrDefault.swiftSDK = "arm64-apple-ios"
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Lib/Lib.swift": """
+        #if os(iOS)
+        public func foo() -> Int { 1 }
+        #endif
+        """,
+        "Client/Client.swift": """
+        import Lib
+
+        func test() -> String {
+          return foo()
+        }
+        """,
+      ],
+      manifest: """
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+            .target(name: "Lib"),
+            .target(name: "Client", dependencies: ["Lib"]),
+          ]
+        )
+        """,
+      options: options,
+      enableBackgroundIndexing: true
+    )
+
+    // Check that we get an error about the return type of `foo` (`Int`) not being convertible to the return type of
+    // `test` (`String`), which indicates that `Lib` had `foo` and was thus compiled for iOS
+    let (uri, _) = try project.openDocument("Client.swift")
+    let diagnostics = try await project.testClient.send(
+      DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
+    )
+    XCTAssert(
+      (diagnostics.fullReport?.items ?? []).contains(where: {
+        $0.message == "Cannot convert return expression of type 'Int' to return type 'String'"
+      }),
+      "Did not get expected diagnostic: \(diagnostics)"
+    )
+  }
+
   func testLibraryUsedByExecutableTargetAndPackagePlugin() async throws {
     try await SkipUnless.swiftPMStoresModulesForTargetAndHostInSeparateFolders()
     let project = try await SwiftPMTestProject(


### PR DESCRIPTION
Previously, if you selected a Swift SDK via the `swiftPM.swiftSDK` configuration option, background indexing would fail because the `swift build --experimental-prepare-for-indexing` invocation did not pass along the `--swift-sdk` argument. This PR fixes this by passing along that flag (+ other relevant cross-compilation flags) to `swift build`.

Best I can tell, the reason this was previously missing is simply that the PRs that added these two features ([background indexing](https://github.com/swiftlang/sourcekit-lsp/pull/1273) and [Swift SDK support](https://github.com/swiftlang/sourcekit-lsp/pull/1535)) were being worked on in parallel and didn't end up accounting for each other. Fortunately it's a trivial fix.