### PR TITLE
Fix test failures when running SourceKit-LSP tests with an Xcode toolchain

### DIFF
--- a/Sources/SourceKitD/dlopen.swift
+++ b/Sources/SourceKitD/dlopen.swift
@@ -34,6 +34,10 @@ package final class DLHandle: Sendable {
     #endif
   }
 
+  #if canImport(Darwin)
+  package static let rtldDefault = DLHandle(rawValue: Handle(handle: UnsafeMutableRawPointer(bitPattern: -2)!))
+  #endif
+
   fileprivate let rawValue: ThreadSafeBox<Handle?>
 
   fileprivate init(rawValue: Handle) {


### PR DESCRIPTION
We need to jump through a few extra hoops when the SourceKit plugin is located in SourceKit-LSP’s build folder and we are using `sourcekitd_plugin_initialize` instead of `sourcekitd_plugin_initialize_2`.