### PR TITLE
build: remove SwiftSystem check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ find_package(SwiftPM QUIET)
 find_package(LLBuild QUIET)
 find_package(ArgumentParser CONFIG REQUIRED)
 find_package(SwiftCollections QUIET)
-find_package(SwiftSystem CONFIG REQUIRED)
 find_package(SwiftSyntax CONFIG REQUIRED)
 find_package(SwiftCrypto CONFIG REQUIRED)
 


### PR DESCRIPTION
The swift-system package is not used in SourceKit LSP. It was required to fulfil the dependencies for swift-package-manager. With the changes in swiftlang/swift-package-manager#8231 which internalised the SystemPackage import, we no longer need this to be provided.