### PR TITLE
Increase default test timeout in VS Code settings to 20s

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
     // Show log messages when running tests on macOS
     "SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER": "1",
     // Decrease timeout to 10s locally from the default 3min we allow by default. This is usually sufficient and makes test fail faster.
-    "SOURCEKIT_LSP_TEST_TIMEOUT": "10"
+    "SOURCEKIT_LSP_TEST_TIMEOUT": "20"
   },
 }


### PR DESCRIPTION
With the plugin tests added, 10s does seem to be too short.