### PR TITLE
Split build systems for JSON compilation database and fixed compilation database

### DIFF
--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -195,12 +195,22 @@ private extension BuildSystemSpec {
       }
       logger.log("Created external build server at \(projectRoot)")
       return .external(buildSystem)
-    case .compilationDatabase:
+    case .jsonCompilationDatabase:
       return await createBuiltInBuildSystemAdapter(
         messagesToSourceKitLSPHandler: messagesToSourceKitLSPHandler,
         buildSystemHooks: buildSystemHooks
       ) { connectionToSourceKitLSP in
-        try CompilationDatabaseBuildSystem(
+        try JSONCompilationDatabaseBuildSystem(
+          configPath: configPath,
+          connectionToSourceKitLSP: connectionToSourceKitLSP
+        )
+      }
+    case .fixedCompilationDatabase:
+      return await createBuiltInBuildSystemAdapter(
+        messagesToSourceKitLSPHandler: messagesToSourceKitLSPHandler,
+        buildSystemHooks: buildSystemHooks
+      ) { connectionToSourceKitLSP in
+        try FixedCompilationDatabaseBuildSystem(
           configPath: configPath,
           connectionToSourceKitLSP: connectionToSourceKitLSP
         )

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
@@ -28,7 +28,8 @@ import Foundation
 package struct BuildSystemSpec {
   package enum Kind {
     case buildServer
-    case compilationDatabase
+    case jsonCompilationDatabase
+    case fixedCompilationDatabase
     case swiftPM
     case injected(BuildSystemInjector)
   }

--- a/Sources/BuildSystemIntegration/CMakeLists.txt
+++ b/Sources/BuildSystemIntegration/CMakeLists.txt
@@ -9,11 +9,12 @@ add_library(BuildSystemIntegration STATIC
   BuiltInBuildSystem.swift
   BuiltInBuildSystemAdapter.swift
   CompilationDatabase.swift
-  CompilationDatabaseBuildSystem.swift
   DetermineBuildSystem.swift
   ExternalBuildSystemAdapter.swift
   FallbackBuildSettings.swift
   FileBuildSettings.swift
+  FixedCompilationDatabaseBuildSystem.swift
+  JSONCompilationDatabaseBuildSystem.swift
   LegacyBuildServerBuildSystem.swift
   MainFilesProvider.swift
   PathPrefixMapping.swift

--- a/Sources/BuildSystemIntegration/FixedCompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/FixedCompilationDatabaseBuildSystem.swift
@@ -1,0 +1,154 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SKLogging
+import SwiftExtensions
+
+#if compiler(>=6)
+package import BuildServerProtocol
+package import Foundation
+package import LanguageServerProtocol
+#else
+import BuildServerProtocol
+import Foundation
+import LanguageServerProtocol
+#endif
+
+func lastIndexStorePathArgument(in compilerArgs: [String]) -> String? {
+  for i in compilerArgs.indices.reversed() {
+    if compilerArgs[i] == "-index-store-path" && i + 1 < compilerArgs.count {
+      return compilerArgs[i + 1]
+    }
+  }
+  return nil
+}
+
+/// A `BuildSystem` that provides compiler arguments from a `compile_flags.txt` file.
+package actor FixedCompilationDatabaseBuildSystem: BuiltInBuildSystem {
+  package static let dbName = "compile_flags.txt"
+
+  private let connectionToSourceKitLSP: any Connection
+
+  package let configPath: URL
+
+  /// The compiler arguments from the fixed compilation database.
+  ///
+  /// Note that this does not contain the path to a compiler.
+  var compilerArgs: [String]
+
+  // Watch for all all changes to `compile_flags.txt` and `compile_flags.txt` instead of just the one at
+  // `configPath` so that we cover the following semi-common scenario:
+  // The user has a build that stores `compile_flags.txt` in `mybuild`. In order to pick it  up, they create a
+  // symlink from `<project root>/compile_flags.txt` to `mybuild/compile_flags.txt`.  We want to get notified
+  // about the change to `mybuild/compile_flags.txt` because it effectively changes the contents of
+  // `<project root>/compile_flags.txt`.
+  package let fileWatchers: [FileSystemWatcher] = [
+    FileSystemWatcher(globPattern: "**/compile_flags.txt", kind: [.create, .change, .delete])
+  ]
+
+  package var indexStorePath: URL? {
+    guard let indexStorePath = lastIndexStorePathArgument(in: compilerArgs) else {
+      return nil
+    }
+    return URL(fileURLWithPath: indexStorePath, relativeTo: configPath.deletingLastPathComponent())
+  }
+
+  package var indexDatabasePath: URL? {
+    indexStorePath?.deletingLastPathComponent().appendingPathComponent("IndexDatabase")
+  }
+
+  package nonisolated var supportsPreparation: Bool { false }
+
+  private static func parseCompileFlags(at configPath: URL) throws -> [String] {
+    let fileContents: String = try String(contentsOf: configPath, encoding: .utf8)
+
+    var compilerArgs: [String] = []
+    fileContents.enumerateLines { line, _ in
+      compilerArgs.append(line.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+    return compilerArgs
+  }
+
+  package init(
+    configPath: URL,
+    connectionToSourceKitLSP: any Connection
+  ) throws {
+    self.connectionToSourceKitLSP = connectionToSourceKitLSP
+    self.configPath = configPath
+    self.compilerArgs = try Self.parseCompileFlags(at: configPath)
+  }
+
+  package func buildTargets(request: WorkspaceBuildTargetsRequest) async throws -> WorkspaceBuildTargetsResponse {
+    return WorkspaceBuildTargetsResponse(targets: [
+      BuildTarget(
+        id: .dummy,
+        displayName: nil,
+        baseDirectory: nil,
+        tags: [.test],
+        capabilities: BuildTargetCapabilities(),
+        // Be conservative with the languages that might be used in the target. SourceKit-LSP doesn't use this property.
+        languageIds: [.c, .cpp, .objective_c, .objective_cpp, .swift],
+        dependencies: []
+      )
+    ])
+  }
+
+  package func buildTargetSources(request: BuildTargetSourcesRequest) async throws -> BuildTargetSourcesResponse {
+    guard request.targets.contains(.dummy) else {
+      return BuildTargetSourcesResponse(items: [])
+    }
+    return BuildTargetSourcesResponse(items: [
+      SourcesItem(
+        target: .dummy,
+        sources: [SourceItem(uri: URI(configPath.deletingLastPathComponent()), kind: .directory, generated: false)]
+      )
+    ])
+  }
+
+  package func didChangeWatchedFiles(notification: OnWatchedFilesDidChangeNotification) {
+    if notification.changes.contains(where: { $0.uri.fileURL?.lastPathComponent == Self.dbName }) {
+      self.reloadCompilationDatabase()
+    }
+  }
+
+  package func prepare(request: BuildTargetPrepareRequest) async throws -> VoidResponse {
+    throw PrepareNotSupportedError()
+  }
+
+  package func sourceKitOptions(
+    request: TextDocumentSourceKitOptionsRequest
+  ) async throws -> TextDocumentSourceKitOptionsResponse? {
+    let compilerName: String
+    switch request.language {
+    case .swift: compilerName = "swiftc"
+    case .c, .cpp, .objective_c, .objective_cpp: compilerName = "clang"
+    default: return nil
+    }
+    return TextDocumentSourceKitOptionsResponse(
+      compilerArguments: [compilerName] + compilerArgs + [request.textDocument.uri.pseudoPath],
+      workingDirectory: try? configPath.deletingLastPathComponent().filePath
+    )
+  }
+
+  package func waitForBuildSystemUpdates(request: WorkspaceWaitForBuildSystemUpdatesRequest) async -> VoidResponse {
+    return VoidResponse()
+  }
+
+  /// The compilation database has been changed on disk.
+  /// Reload it and notify the delegate about build setting changes.
+  private func reloadCompilationDatabase() {
+    orLog("Reloading fixed compilation database") {
+      self.compilerArgs = try Self.parseCompileFlags(at: configPath)
+      connectionToSourceKitLSP.send(OnBuildTargetDidChangeNotification(changes: nil))
+    }
+  }
+}

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -124,7 +124,7 @@ package struct IndexedSingleSwiftFileTestProject {
 
     let compilationDatabase = JSONCompilationDatabase(
       [
-        JSONCompilationDatabase.Command(
+        CompilationDatabaseCompileCommand(
           directory: try testWorkspaceDirectory.filePath,
           filename: try testFileURL.filePath,
           commandLine: [try swiftc.filePath] + compilerArguments
@@ -134,7 +134,7 @@ package struct IndexedSingleSwiftFileTestProject {
     let encoder = JSONEncoder()
     encoder.outputFormatting = .prettyPrinted
     try encoder.encode(compilationDatabase).write(
-      to: testWorkspaceDirectory.appendingPathComponent(JSONCompilationDatabase.dbName)
+      to: testWorkspaceDirectory.appendingPathComponent(JSONCompilationDatabaseBuildSystem.dbName)
     )
 
     // Run swiftc to build the index store

--- a/Sources/SwiftExtensions/CMakeLists.txt
+++ b/Sources/SwiftExtensions/CMakeLists.txt
@@ -9,6 +9,7 @@ set(sources
   Collection+PartitionIntoBatches.swift
   Duration+Seconds.swift
   FileManagerExtensions.swift
+  LazyValue.swift
   NSLock+WithLock.swift
   PipeAsStringHandler.swift
   Platform.swift

--- a/Sources/SwiftExtensions/LazyValue.swift
+++ b/Sources/SwiftExtensions/LazyValue.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// A value that is computed on its first access and saved for later retrievals.
+package enum LazyValue<T> {
+  case computed(T)
+  case uninitialized
+
+  /// If the value has already been computed return it, otherwise compute it using `compute`.
+  package mutating func cachedValueOrCompute(_ compute: () -> T) -> T {
+    switch self {
+    case .computed(let value):
+      return value
+    case .uninitialized:
+      let newValue = compute()
+      self = .computed(newValue)
+      return newValue
+    }
+  }
+
+  package mutating func reset() {
+    self = .uninitialized
+  }
+}

--- a/Sources/SwiftSourceKitPlugin/ASTCompletion/ASTCompletionItem.swift
+++ b/Sources/SwiftSourceKitPlugin/ASTCompletion/ASTCompletionItem.swift
@@ -14,24 +14,7 @@ import CompletionScoring
 import Csourcekitd
 import Foundation
 import SourceKitD
-
-/// A value that is computed on its first access and saved for later retrievals.
-enum LazyValue<T> {
-  case computed(T)
-  case uninitialized
-
-  /// If the value has already been computed return it, otherwise compute it using `compute`.
-  mutating func cachedValueOrCompute(_ compute: () -> T) -> T {
-    switch self {
-    case .computed(let value):
-      return value
-    case .uninitialized:
-      let newValue = compute()
-      self = .computed(newValue)
-      return newValue
-    }
-  }
-}
+import SwiftExtensions
 
 /// A single code completion result returned from sourcekitd + additional information. This is effectively a wrapper
 /// around `swiftide_api_completion_item_t` that caches the properties which have already been retrieved.

--- a/Sources/SwiftSourceKitPlugin/CodeCompletion/Connection.swift
+++ b/Sources/SwiftSourceKitPlugin/CodeCompletion/Connection.swift
@@ -16,6 +16,7 @@ import Foundation
 import SKLogging
 import SKUtilities
 import SourceKitD
+import SwiftExtensions
 
 extension PopularityIndex.Scope {
   init(string name: String) {

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -55,7 +55,7 @@ final class CompilationDatabaseTests: XCTestCase {
 
     // Remove -DFOO from the compile commands.
 
-    let compileFlagsUri = try project.uri(for: FixedCompilationDatabase.dbName)
+    let compileFlagsUri = try project.uri(for: FixedCompilationDatabaseBuildSystem.dbName)
     try "".write(to: compileFlagsUri.fileURL!, atomically: false, encoding: .utf8)
 
     project.testClient.send(

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -786,19 +786,19 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
     let uri = try project.uri(for: "MyTests.swift")
 
     let compilationDatabase = JSONCompilationDatabase([
-      JSONCompilationDatabase.Command(
+      CompilationDatabaseCompileCommand(
         directory: try project.scratchDirectory.filePath,
         filename: uri.pseudoPath,
         commandLine: [try swiftc.filePath, uri.pseudoPath]
       )
     ])
 
-    try JSONEncoder()
-      .encode(compilationDatabase).write(to: XCTUnwrap(project.uri(for: JSONCompilationDatabase.dbName).fileURL))
+    try JSONEncoder().encode(compilationDatabase)
+      .write(to: XCTUnwrap(project.uri(for: JSONCompilationDatabaseBuildSystem.dbName).fileURL))
 
     project.testClient.send(
       DidChangeWatchedFilesNotification(changes: [
-        FileEvent(uri: try project.uri(for: JSONCompilationDatabase.dbName), type: .changed)
+        FileEvent(uri: try project.uri(for: JSONCompilationDatabaseBuildSystem.dbName), type: .changed)
       ])
     )
 


### PR DESCRIPTION
I feel like the implementations are actually simpler if we split them. This will also allow us to add more advanced logic to the JSON compilation database build system in the future, such as inferring the toolchain from the compile command.