### PR TITLE
Flush the `NonDarwinLogger` before shutting down `SourceKitLSPServer`

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1158,6 +1158,8 @@ extension SourceKitLSPServer {
       await workspace.buildSystemManager.setMainFilesProvider(nil)
       workspace.closeIndex()
     }
+    // Make sure we emit all pending log messages. When we're not using `NonDarwinLogger` this is a no-op.
+    await NonDarwinLogger.flush()
   }
 
   func shutdown(_ request: ShutdownRequest) async throws -> ShutdownRequest.Response {


### PR DESCRIPTION
This ensures that we don't drop any log messages when stopping the LSP server, in particular while running tests.