### PR TITLE
Use the SourceKit plugin for the code completion request

### DIFF
--- a/Sources/SKTestSupport/CompletionItem+clearingUnstableValues.swift
+++ b/Sources/SKTestSupport/CompletionItem+clearingUnstableValues.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6)
+package import LanguageServerProtocol
+#else
+import LanguageServerProtocol
+#endif
+
+extension Array<CompletionItem> {
+  /// Remove `sortText` and `data` from all completion items as these are not stable across runs. Instead, sort items
+  /// by `sortText` to ensure we test them in the order that an editor would display them in.
+  package var clearingUnstableValues: [CompletionItem] {
+    return
+      self
+      .sorted(by: { ($0.sortText ?? "") < ($1.sortText ?? "") })
+      .map {
+        var item = $0
+        item.sortText = nil
+        item.data = nil
+        return item
+      }
+  }
+}

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -29,8 +29,7 @@ extension SwiftLanguageService {
     let snapshot = try documentManager.latestSnapshot(req.textDocument.uri)
 
     let completionPos = await adjustPositionToStartOfIdentifier(req.position, in: snapshot)
-    let offset = snapshot.utf8Offset(of: completionPos)
-    let filterText = String(snapshot.text[snapshot.indexOf(utf8Offset: offset)..<snapshot.index(of: req.position)])
+    let filterText = String(snapshot.text[snapshot.index(of: completionPos)..<snapshot.index(of: req.position)])
 
     let clientSupportsSnippets =
       capabilityRegistry.clientCapabilities.textDocument?.completion?.completionItem?.snippetSupport ?? false
@@ -44,7 +43,6 @@ extension SwiftLanguageService {
       options: options,
       indentationWidth: inferredIndentationWidth,
       completionPosition: completionPos,
-      completionUtf8Offset: offset,
       cursorPosition: req.position,
       compileCommand: buildSettings,
       clientSupportsSnippets: clientSupportsSnippets,

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -1163,6 +1163,16 @@ extension SwiftLanguageService: SKDNotificationHandler {
 
 // MARK: - Position conversion
 
+/// A line:column position as it is used in sourcekitd, using UTF-8 for the column index and using a one-based line and
+/// column number.
+struct SourceKitDPosition {
+  /// Line number within a document (one-based).
+  public var line: Int
+
+  /// UTF-8 code-unit offset from the start of a line (1-based).
+  public var utf8Column: Int
+}
+
 extension DocumentSnapshot {
 
   // MARK: String.Index <-> Raw UTF-8
@@ -1378,6 +1388,23 @@ extension DocumentSnapshot {
       callerFile: callerFile,
       callerLine: callerLine
     )
+  }
+
+  // MARK: Position <-> SourceKitDPosition
+
+  func sourcekitdPosition(
+    of position: Position,
+    callerFile: StaticString = #fileID,
+    callerLine: UInt = #line
+  ) -> SourceKitDPosition {
+    let utf8Column = lineTable.utf8ColumnAt(
+      line: position.line,
+      utf16Column: position.utf16index,
+      callerFile: callerFile,
+      callerLine: callerLine
+    )
+    // FIXME: Introduce new type for UTF-8 based positions
+    return SourceKitDPosition(line: position.line + 1, utf8Column: utf8Column + 1)
   }
 
   // MAR: Position <-> SymbolLocation

--- a/Sources/SwiftSourceKitPlugin/ASTCompletion/CompletionSession.swift
+++ b/Sources/SwiftSourceKitPlugin/ASTCompletion/CompletionSession.swift
@@ -13,6 +13,7 @@
 import CompletionScoring
 import Csourcekitd
 import Foundation
+import SKLogging
 import SourceKitD
 
 /// Represents a code completion session.
@@ -51,6 +52,8 @@ final class CompletionSession {
 
   /// Convenience accessor to the `SourceKitD` instance.
   var sourcekitd: SourceKitD { connection.sourcekitd }
+
+  var logger: Logger { connection.logger }
 
   init(
     connection: Connection,

--- a/Sources/SwiftSourceKitPlugin/CodeCompletion/Connection.swift
+++ b/Sources/SwiftSourceKitPlugin/CodeCompletion/Connection.swift
@@ -74,7 +74,7 @@ final class Connection {
     }
   }
 
-  fileprivate let logger = Logger(subsystem: "org.swift.sourcekit.service-plugin", category: "Connection")
+  let logger = Logger(subsystem: "org.swift.sourcekit.service-plugin", category: "Connection")
 
   private let impl: swiftide_api_connection_t
   let sourcekitd: SourceKitD

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1607,6 +1607,8 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testCodeCompletionShowsUpdatedResultsAfterDependencyUpdated() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let project = try await SwiftPMTestProject(
       files: [
         "LibA/LibA.swift": """
@@ -1631,9 +1633,7 @@ final class BackgroundIndexingTests: XCTestCase {
           ]
         )
         """,
-      options: SourceKitLSPOptions(
-        backgroundPreparationMode: .enabled
-      ),
+      options: .testDefault(),
       enableBackgroundIndexing: true
     )
 

--- a/Tests/SourceKitLSPTests/LifecycleTests.swift
+++ b/Tests/SourceKitLSPTests/LifecycleTests.swift
@@ -57,6 +57,8 @@ final class LifecycleTests: XCTestCase {
   }
 
   func testCancellation() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -29,6 +29,8 @@ final class SwiftCompletionTests: XCTestCase {
   // MARK: - Tests
 
   func testCompletionBasic() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -98,6 +100,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCompletionSnippetSupport() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -152,6 +156,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCompletionNoSnippetSupport() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -206,6 +212,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCompletionPositionServerFilter() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     testClient.openDocument("foo", uri: uri)
@@ -239,6 +247,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCompletionOptional() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -273,6 +283,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCompletionOverride() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -303,6 +315,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCompletionOverrideInNewLine() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -337,6 +351,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testRefilterAfterIncompleteResults() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -456,6 +472,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testRefilterAfterIncompleteResultsWithEdits() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -610,6 +628,8 @@ final class SwiftCompletionTests: XCTestCase {
   /// Regression test for https://bugs.swift.org/browse/SR-13561 to make sure the a session
   /// close waits for its respective open to finish to prevent a session geting stuck open.
   func testSessionCloseWaitsforOpen() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -656,6 +676,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testCodeCompleteSwiftPackage() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let project = try await SwiftPMTestProject(
       files: [
         "a.swift": """
@@ -678,14 +700,13 @@ final class SwiftCompletionTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      results.items,
+      results.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "method(a: Int)",
           kind: .method,
           detail: "Void",
           deprecated: false,
-          sortText: nil,
           filterText: "method(a:)",
           insertText: "method(a: )",
           insertTextFormat: .plain,
@@ -701,7 +722,6 @@ final class SwiftCompletionTests: XCTestCase {
           kind: .keyword,
           detail: "A",
           deprecated: false,
-          sortText: nil,
           filterText: "self",
           insertText: "self",
           insertTextFormat: .plain,
@@ -714,6 +734,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testTriggerFromIncompleteAfterStartingStringLiteral() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -773,6 +795,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testNonAsciiCompletionFilter() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -790,7 +814,7 @@ final class SwiftCompletionTests: XCTestCase {
       CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
     )
     XCTAssertEqual(
-      completions.items,
+      completions.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "👨‍👩‍👦👨‍👩‍👦()",
@@ -807,6 +831,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testExpandClosurePlaceholder() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -824,14 +850,13 @@ final class SwiftCompletionTests: XCTestCase {
       CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
     )
     XCTAssertEqual(
-      completions.items.filter { $0.label.contains("myMap") },
+      completions.items.clearingUnstableValues.filter { $0.label.contains("myMap") },
       [
         CompletionItem(
           label: "myMap(body: (Int) -> Bool)",
           kind: .method,
           detail: "Void",
           deprecated: false,
-          sortText: nil,
           filterText: "myMap(:)",
           insertText: #"""
             myMap(${1:{ ${2:Int} in ${3:Bool} \}})
@@ -851,6 +876,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testExpandClosurePlaceholderOnOptional() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -868,14 +895,13 @@ final class SwiftCompletionTests: XCTestCase {
       CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["2️⃣"])
     )
     XCTAssertEqual(
-      completions.items.filter { $0.label.contains("myMap") },
+      completions.items.clearingUnstableValues.filter { $0.label.contains("myMap") },
       [
         CompletionItem(
-          label: "?.myMap(body: (Int) -> Bool)",
+          label: "myMap(body: (Int) -> Bool)",
           kind: .method,
           detail: "Void",
           deprecated: false,
-          sortText: nil,
           filterText: ".myMap(:)",
           insertText: #"""
             ?.myMap(${1:{ ${2:Int} in ${3:Bool} \}})
@@ -895,6 +921,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testExpandMultipleClosurePlaceholders() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -912,14 +940,13 @@ final class SwiftCompletionTests: XCTestCase {
       CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
     )
     XCTAssertEqual(
-      completions.items.filter { $0.label.contains("myMap") },
+      completions.items.clearingUnstableValues.filter { $0.label.contains("myMap") },
       [
         CompletionItem(
           label: "myMap(body: (Int) -> Bool, second: (Int) -> String)",
           kind: .method,
           detail: "Void",
           deprecated: false,
-          sortText: nil,
           filterText: "myMap(::)",
           insertText: #"""
             myMap(${1:{ ${2:Int} in ${3:Bool} \}}, ${4:{ ${5:Int} in ${6:String} \}})
@@ -939,6 +966,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testExpandMultipleClosurePlaceholdersWithLabel() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -956,14 +985,13 @@ final class SwiftCompletionTests: XCTestCase {
       CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
     )
     XCTAssertEqual(
-      completions.items.filter { $0.label.contains("myMap") },
+      completions.items.clearingUnstableValues.filter { $0.label.contains("myMap") },
       [
         CompletionItem(
           label: "myMap(body: (Int) -> Bool, second: (Int) -> String)",
           kind: .method,
           detail: "Void",
           deprecated: false,
-          sortText: nil,
           filterText: "myMap(:second:)",
           insertText: #"""
             myMap(${1:{ ${2:Int} in ${3:Bool} \}}, second: ${4:{ ${5:Int} in ${6:String} \}})
@@ -983,6 +1011,8 @@ final class SwiftCompletionTests: XCTestCase {
   }
 
   func testInferIndentationWhenExpandingClosurePlaceholder() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -1002,14 +1032,13 @@ final class SwiftCompletionTests: XCTestCase {
       CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
     )
     XCTAssertEqual(
-      completions.items.filter { $0.label.contains("myMap") },
+      completions.items.filter { $0.label.contains("myMap") }.clearingUnstableValues,
       [
         CompletionItem(
           label: "myMap(body: (Int) -> Bool)",
           kind: .method,
           detail: "Int",
           deprecated: false,
-          sortText: nil,
           filterText: "myMap(:)",
           insertText: #"""
             myMap(${1:{ ${2:Int} in ${3:Bool} \}})
@@ -1025,6 +1054,33 @@ final class SwiftCompletionTests: XCTestCase {
           )
         )
       ]
+    )
+  }
+
+  func testCompletionScoring() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
+    let testClient = try await TestSourceKitLSPClient(capabilities: snippetCapabilities)
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      struct Foo {
+        func makeBool() -> Bool { true }
+        func makeInt() -> Int { 1 }
+        func makeString() -> String { "" }
+      }
+      func test(foo: Foo) {
+        let x: Int = foo.make1️⃣
+      }
+      """,
+      uri: uri
+    )
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    XCTAssertEqual(
+      completions.items.clearingUnstableValues.map(\.label),
+      ["makeInt()", "makeBool()", "makeString()"]
     )
   }
 }

--- a/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
@@ -20,6 +20,8 @@ import XCTest
 final class SwiftPMIntegrationTests: XCTestCase {
 
   func testSwiftPMIntegration() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let project = try await SwiftPMTestProject(
       files: [
         "Lib.swift": """
@@ -60,7 +62,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      completions.items,
+      completions.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "foo()",
@@ -93,6 +95,8 @@ final class SwiftPMIntegrationTests: XCTestCase {
   }
 
   func testAddFile() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let project = try await SwiftPMTestProject(
       files: [
         "Lib.swift": """
@@ -144,7 +148,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      completions.items,
+      completions.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "foo()",
@@ -185,6 +189,8 @@ final class SwiftPMIntegrationTests: XCTestCase {
   }
 
   func testNestedPackage() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let project = try await MultiFileTestProject(files: [
       "pkg/Sources/lib/lib.swift": "",
       "pkg/Package.swift": """
@@ -220,7 +226,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      result.items,
+      result.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "bar()",

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -25,6 +25,8 @@ import XCTest
 final class WorkspaceTests: XCTestCase {
 
   func testMultipleSwiftPMWorkspaces() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     // The package manifest is the same for both packages we open.
     let packageManifest = """
       // swift-tools-version: 5.7
@@ -88,14 +90,13 @@ final class WorkspaceTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      completions.items,
+      completions.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "foo()",
           kind: .method,
           detail: "Void",
           deprecated: false,
-          sortText: nil,
           filterText: "foo()",
           insertText: "foo()",
           insertTextFormat: .plain,
@@ -108,7 +109,6 @@ final class WorkspaceTests: XCTestCase {
           kind: .keyword,
           detail: "Lib",
           deprecated: false,
-          sortText: nil,
           filterText: "self",
           insertText: "self",
           insertTextFormat: .plain,
@@ -126,7 +126,7 @@ final class WorkspaceTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      otherCompletions.items,
+      otherCompletions.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "sayHello()",
@@ -134,7 +134,6 @@ final class WorkspaceTests: XCTestCase {
           detail: "Void",
           documentation: nil,
           deprecated: false,
-          sortText: nil,
           filterText: "sayHello()",
           insertText: "sayHello()",
           insertTextFormat: .plain,
@@ -148,7 +147,6 @@ final class WorkspaceTests: XCTestCase {
           detail: "FancyLib",
           documentation: nil,
           deprecated: false,
-          sortText: nil,
           filterText: "self",
           insertText: "self",
           insertTextFormat: .plain,
@@ -237,6 +235,8 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testSwiftPMPackageInSubfolder() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let packageManifest = """
       // swift-tools-version: 5.7
 
@@ -281,7 +281,7 @@ final class WorkspaceTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      otherCompletions.items,
+      otherCompletions.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "sayHello()",
@@ -289,7 +289,6 @@ final class WorkspaceTests: XCTestCase {
           detail: "Void",
           documentation: nil,
           deprecated: false,
-          sortText: nil,
           filterText: "sayHello()",
           insertText: "sayHello()",
           insertTextFormat: .plain,
@@ -303,7 +302,6 @@ final class WorkspaceTests: XCTestCase {
           detail: "FancyLib",
           documentation: nil,
           deprecated: false,
-          sortText: nil,
           filterText: "self",
           insertText: "self",
           insertTextFormat: .plain,
@@ -316,6 +314,8 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testNestedSwiftPMWorkspacesWithoutDedicatedWorkspaceFolder() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     // The package manifest is the same for both packages we open.
     let packageManifest = """
       // swift-tools-version: 5.7
@@ -374,14 +374,13 @@ final class WorkspaceTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      completions.items,
+      completions.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "foo()",
           kind: .method,
           detail: "Void",
           deprecated: false,
-          sortText: nil,
           filterText: "foo()",
           insertText: "foo()",
           insertTextFormat: .plain,
@@ -394,7 +393,6 @@ final class WorkspaceTests: XCTestCase {
           kind: .keyword,
           detail: "Lib",
           deprecated: false,
-          sortText: nil,
           filterText: "self",
           insertText: "self",
           insertTextFormat: .plain,
@@ -414,7 +412,7 @@ final class WorkspaceTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      otherCompletions.items,
+      otherCompletions.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "sayHello()",
@@ -422,7 +420,6 @@ final class WorkspaceTests: XCTestCase {
           detail: "Void",
           documentation: nil,
           deprecated: false,
-          sortText: nil,
           filterText: "sayHello()",
           insertText: "sayHello()",
           insertTextFormat: .plain,
@@ -436,7 +433,6 @@ final class WorkspaceTests: XCTestCase {
           detail: "FancyLib",
           documentation: nil,
           deprecated: false,
-          sortText: nil,
           filterText: "self",
           insertText: "self",
           insertTextFormat: .plain,
@@ -587,6 +583,8 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testMixedPackage() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let project = try await SwiftPMTestProject(
       files: [
         "clib/include/clib.h": """
@@ -637,6 +635,8 @@ final class WorkspaceTests: XCTestCase {
   }
 
   func testChangeWorkspaceFolders() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     let project = try await MultiFileTestProject(
       files: [
         "subdir/Sources/otherPackage/otherPackage.swift": """
@@ -730,7 +730,7 @@ final class WorkspaceTests: XCTestCase {
     )
 
     XCTAssertEqual(
-      postChangeWorkspaceResponse.items,
+      postChangeWorkspaceResponse.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "helloWorld()",
@@ -738,7 +738,6 @@ final class WorkspaceTests: XCTestCase {
           detail: "Void",
           documentation: nil,
           deprecated: false,
-          sortText: nil,
           filterText: "helloWorld()",
           insertText: "helloWorld()",
           insertTextFormat: .plain,
@@ -755,7 +754,6 @@ final class WorkspaceTests: XCTestCase {
           detail: "Package",
           documentation: nil,
           deprecated: false,
-          sortText: nil,
           filterText: "self",
           insertText: "self",
           insertTextFormat: .plain,
@@ -770,6 +768,8 @@ final class WorkspaceTests: XCTestCase {
     )
   }
   func testIntegrationTest() async throws {
+    try await SkipUnless.sourcekitdSupportsPlugin()
+
     // This test is doing the same as `test-sourcekit-lsp` in the `swift-integration-tests` repo.
 
     let project = try await SwiftPMTestProject(
@@ -843,7 +843,7 @@ final class WorkspaceTests: XCTestCase {
       CompletionRequest(textDocument: TextDocumentIdentifier(mainUri), position: mainPositions["3️⃣"])
     )
     XCTAssertEqual(
-      swiftCompletionResponse.items,
+      swiftCompletionResponse.items.clearingUnstableValues,
       [
         CompletionItem(
           label: "foo()",


### PR DESCRIPTION
This allows us to sort code completion items by their semantic score.

rdar://142909859