### PR TITLE
[6.1] Support background indexing when cross-compiling

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -684,6 +684,15 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
     if let configuration = options.swiftPMOrDefault.configuration {
       arguments += ["-c", configuration.rawValue]
     }
+    if let triple = options.swiftPMOrDefault.triple {
+      arguments += ["--triple", triple]
+    }
+    if let swiftSDKsDirectory = options.swiftPMOrDefault.swiftSDKsDirectory {
+      arguments += ["--swift-sdks-path", swiftSDKsDirectory]
+    }
+    if let swiftSDK = options.swiftPMOrDefault.swiftSDK {
+      arguments += ["--swift-sdk", swiftSDK]
+    }
     arguments += options.swiftPMOrDefault.cCompilerFlags?.flatMap { ["-Xcc", $0] } ?? []
     arguments += options.swiftPMOrDefault.cxxCompilerFlags?.flatMap { ["-Xcxx", $0] } ?? []
     arguments += options.swiftPMOrDefault.swiftCompilerFlags?.flatMap { ["-Xswiftc", $0] } ?? []

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1012,6 +1012,53 @@ final class BackgroundIndexingTests: XCTestCase {
     )
   }
 
+  func testUseSwiftSDKFlagsDuringPreparation() async throws {
+    try await SkipUnless.canSwiftPMCompileForIOS()
+
+    var options = SourceKitLSPOptions.testDefault()
+    options.swiftPMOrDefault.swiftSDK = "arm64-apple-ios"
+    let project = try await SwiftPMTestProject(
+      files: [
+        "Lib/Lib.swift": """
+        #if os(iOS)
+        public func foo() -> Int { 1 }
+        #endif
+        """,
+        "Client/Client.swift": """
+        import Lib
+
+        func test() -> String {
+          return foo()
+        }
+        """,
+      ],
+      manifest: """
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+            .target(name: "Lib"),
+            .target(name: "Client", dependencies: ["Lib"]),
+          ]
+        )
+        """,
+      options: options,
+      enableBackgroundIndexing: true
+    )
+
+    // Check that we get an error about the return type of `foo` (`Int`) not being convertible to the return type of
+    // `test` (`String`), which indicates that `Lib` had `foo` and was thus compiled for iOS
+    let (uri, _) = try project.openDocument("Client.swift")
+    let diagnostics = try await project.testClient.send(
+      DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
+    )
+    XCTAssert(
+      (diagnostics.fullReport?.items ?? []).contains(where: {
+        $0.message == "Cannot convert return expression of type 'Int' to return type 'String'"
+      }),
+      "Did not get expected diagnostic: \(diagnostics)"
+    )
+  }
+
   func testLibraryUsedByExecutableTargetAndPackagePlugin() async throws {
     try await SkipUnless.swiftPMStoresModulesForTargetAndHostInSeparateFolders()
     let project = try await SwiftPMTestProject(


### PR DESCRIPTION
- **Explanation**: Previously, if you selected a Swift SDK via the `swiftPM.swiftSDK` configuration option, background indexing would fail because the `swift build --experimental-prepare-for-indexing` invocation did not pass along the `--swift-sdk` argument. 
- **Scope**: Background indexing when `swiftPM.swiftSDK` is specified in the SourceKit-LSP configuration file
- **Issue**: n/a
- **Original PR**: #1923
- **Risk**: Low, only passes a few options through
- **Testing**: Added a test case
- **Reviewer**:  @ahoppen 