### PR TITLE
Log the request methods when logging a request's reply

### DIFF
--- a/Sources/LanguageServerProtocolExtensions/LocalConnection.swift
+++ b/Sources/LanguageServerProtocolExtensions/LocalConnection.swift
@@ -138,6 +138,7 @@ package final class LocalConnection: Connection, Sendable {
         logger.info(
           """
           Received reply for request \(id, privacy: .public) from \(self.name, privacy: .public)
+          \(Request.method, privacy: .public)
           \(response.forLogging)
           """
         )
@@ -145,6 +146,7 @@ package final class LocalConnection: Connection, Sendable {
         logger.error(
           """
           Received error for request \(id, privacy: .public) from \(self.name, privacy: .public)
+          \(Request.method, privacy: .public)
           \(error.forLogging)
           """
         )

--- a/Sources/LanguageServerProtocolExtensions/QueueBasedMessageHandler.swift
+++ b/Sources/LanguageServerProtocolExtensions/QueueBasedMessageHandler.swift
@@ -192,7 +192,7 @@ extension QueueBasedMessageHandler {
       )
       .makeSignposter()
       let signpostID = signposter.makeSignpostID()
-      let state = signposter.beginInterval("Notification", id: signpostID, "\(type(of: notification))")
+      let state = signposter.beginInterval("Notification", id: signpostID, "\(type(of: notification).method)")
       messageHandlingQueue.async(metadata: DependencyTracker(notification)) {
         signposter.emitEvent("Start handling", id: signpostID)
         await self.handle(notification: notification)
@@ -209,7 +209,7 @@ extension QueueBasedMessageHandler {
     let signposter = Logger(subsystem: LoggingScope.subsystem, category: messageHandlingHelper.signpostLoggingCategory)
       .makeSignposter()
     let signpostID = signposter.makeSignpostID()
-    let state = signposter.beginInterval("Request", id: signpostID, "\(Request.self)")
+    let state = signposter.beginInterval("Request", id: signpostID, "\(Request.method)")
 
     self.didReceive(request: request, id: id)
 

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -708,6 +708,7 @@ public final class JSONRPCConnection: Connection {
             logger.info(
               """
               Received reply for request \(id, privacy: .public) from \(self.name, privacy: .public)
+              \(Request.method, privacy: .public)
               \(response.forLogging)
               """
             )
@@ -715,6 +716,7 @@ public final class JSONRPCConnection: Connection {
             logger.error(
               """
               Received error for request \(id, privacy: .public) from \(self.name, privacy: .public)
+              \(Request.method, privacy: .public)
               \(error.forLogging)
               """
             )


### PR DESCRIPTION
This should make it easier to find a request response when searching for the response method.