### PR TITLE
Revert "Support background indexing when cross-compiling"

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -616,15 +616,6 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
     if let configuration = options.swiftPMOrDefault.configuration {
       arguments += ["-c", configuration.rawValue]
     }
-    if let triple = options.swiftPMOrDefault.triple {
-      arguments += ["--triple", triple]
-    }
-    if let swiftSDKsDirectory = options.swiftPMOrDefault.swiftSDKsDirectory {
-      arguments += ["--swift-sdks-path", swiftSDKsDirectory]
-    }
-    if let swiftSDK = options.swiftPMOrDefault.swiftSDK {
-      arguments += ["--swift-sdk", swiftSDK]
-    }
     arguments += options.swiftPMOrDefault.cCompilerFlags?.flatMap { ["-Xcc", $0] } ?? []
     arguments += options.swiftPMOrDefault.cxxCompilerFlags?.flatMap { ["-Xcxx", $0] } ?? []
     arguments += options.swiftPMOrDefault.swiftCompilerFlags?.flatMap { ["-Xswiftc", $0] } ?? []

--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -478,34 +478,6 @@ package actor SkipUnless {
     }
   }
 
-  package static func canSwiftPMCompileForIOS(
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) async throws {
-    return try await shared.skipUnlessSupported(allowSkippingInCI: true, file: file, line: line) {
-      #if os(macOS)
-      let project = try await SwiftPMTestProject(files: [
-        "MyFile.swift": """
-        public func foo() {}
-        """
-      ])
-      do {
-        try await SwiftPMTestProject.build(
-          at: project.scratchDirectory,
-          extraArguments: [
-            "--swift-sdk", "arm64-apple-ios",
-          ]
-        )
-        return .featureSupported
-      } catch {
-        return .featureUnsupported(skipMessage: "Cannot build for iOS: \(error)")
-      }
-      #else
-      return .featureUnsupported(skipMessage: "Cannot build for iOS outside macOS by default")
-      #endif
-    }
-  }
-
   package static func canCompileForWasm(
     file: StaticString = #filePath,
     line: UInt = #line

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -583,7 +583,6 @@ final class CodeActionTests: XCTestCase {
   }
 
   func testPackageManifestEditingCodeActionResult() async throws {
-    try XCTSkipIf(true, "Temporarily disable while investigating rdar://143336492")
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(
@@ -658,7 +657,6 @@ final class CodeActionTests: XCTestCase {
   }
 
   func testPackageManifestEditingCodeActionNoTestResult() async throws {
-    try XCTSkipIf(true, "Temporarily disable while investigating rdar://143336492")
     let testClient = try await TestSourceKitLSPClient(capabilities: clientCapabilitiesWithCodeActionSupport)
     let uri = DocumentURI(for: .swift)
     let positions = testClient.openDocument(


### PR DESCRIPTION
Reverts swiftlang/sourcekit-lsp#1923