### PR TITLE
Cache the mapping from compiler to toolchain

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -425,7 +425,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
         languageIds: [.c, .cpp, .objective_c, .objective_cpp, .swift],
         dependencies: self.targetDependencies[targetId, default: []].sorted { $0.uri.stringValue < $1.uri.stringValue },
         dataKind: .sourceKit,
-        data: SourceKitBuildTarget(toolchain: toolchain.path.map(URI.init)).encodeToLSPAny()
+        data: SourceKitBuildTarget(toolchain: URI(toolchain.path)).encodeToLSPAny()
       )
     }
     targets.append(

--- a/Sources/Diagnose/ReproducerBundle.swift
+++ b/Sources/Diagnose/ReproducerBundle.swift
@@ -28,14 +28,12 @@ func makeReproducerBundle(for requestInfo: RequestInfo, toolchain: Toolchain, bu
     atomically: true,
     encoding: .utf8
   )
-  if let toolchainPath = toolchain.path {
-    try toolchainPath.realpath.filePath
-      .write(
-        to: bundlePath.appendingPathComponent("toolchain.txt"),
-        atomically: true,
-        encoding: .utf8
-      )
-  }
+  try toolchain.path.realpath.filePath
+    .write(
+      to: bundlePath.appendingPathComponent("toolchain.txt"),
+      atomically: true,
+      encoding: .utf8
+    )
   if requestInfo.requestTemplate == RequestInfo.fakeRequestTemplateForFrontendIssues {
     let command =
       "swift-frontend \\\n"

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -567,7 +567,7 @@ package actor SourceKitLSPServer {
 
     logger.log(
       """
-      Using toolchain at \(toolchain.path?.description ?? "<nil>") (\(toolchain.identifier, privacy: .public)) \
+      Using toolchain at \(toolchain.path.description) (\(toolchain.identifier, privacy: .public)) \
       for \(uri.forLogging)
       """
     )

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -237,7 +237,7 @@ package actor SwiftLanguageService: LanguageService, Sendable {
     } else if let clientPlugin = toolchain.sourceKitClientPlugin, let servicePlugin = toolchain.sourceKitServicePlugin {
       pluginPaths = PluginPaths(clientPlugin: clientPlugin, servicePlugin: servicePlugin)
     } else {
-      logger.fault("Failed to find SourceKit plugin for toolchain at \(toolchain.path?.path ?? "nil")")
+      logger.fault("Failed to find SourceKit plugin for toolchain at \(toolchain.path.path)")
       pluginPaths = nil
     }
     self.sourcekitd = try await DynamicallyLoadedSourceKitD.getOrCreate(

--- a/Sources/ToolchainRegistry/Toolchain.swift
+++ b/Sources/ToolchainRegistry/Toolchain.swift
@@ -77,7 +77,7 @@ public final class Toolchain: Sendable {
   /// The path to this toolchain, if applicable.
   ///
   /// For example, this may be the path to an ".xctoolchain" directory.
-  package let path: URL?
+  package let path: URL
 
   // MARK: Tool Paths
 

--- a/Tests/DiagnoseTests/DiagnoseTests.swift
+++ b/Tests/DiagnoseTests/DiagnoseTests.swift
@@ -239,7 +239,7 @@ private func assertReduceSourceKitD(
   let (markers, fileContents) = extractMarkers(markedFileContents)
 
   let toolchain = try await unwrap(ToolchainRegistry.forTesting.default)
-  logger.debug("Using \(toolchain.path?.description ?? "<nil>") to reduce source file")
+  logger.debug("Using \(toolchain.path.description) to reduce source file")
 
   let markerOffset = try XCTUnwrap(markers["1️⃣"], "Failed to find position marker 1️⃣ in file contents")
 


### PR DESCRIPTION
While at it, also make `Toolchain.path` non-optional and clean up `ToolchainRegistry.init` slightly.