### PR TITLE
Add target display name to run and debug code lenses

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftCodeLensScanner.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftCodeLensScanner.swift
@@ -70,8 +70,10 @@ final class SwiftCodeLensScanner: SyntaxVisitor {
     if attribute.trimmedDescription == "@main" {
       let range = self.snapshot.absolutePositionRange(of: attribute.trimmedRange)
       var targetNameToAppend: String = ""
+      var arguments: [LSPAny] = []
       if let targetName {
         targetNameToAppend = " \(targetName)"
+        arguments.append(.string(targetName))
       }
 
       if let runCommand = supportedCommands[SupportedCodeLensCommand.run] {
@@ -80,7 +82,7 @@ final class SwiftCodeLensScanner: SyntaxVisitor {
         self.result.append(
           CodeLens(
             range: range,
-            command: Command(title: "Run" + targetNameToAppend, command: runCommand, arguments: nil)
+            command: Command(title: "Run" + targetNameToAppend, command: runCommand, arguments: arguments)
           )
         )
       }
@@ -89,7 +91,7 @@ final class SwiftCodeLensScanner: SyntaxVisitor {
         self.result.append(
           CodeLens(
             range: range,
-            command: Command(title: "Debug" + targetNameToAppend, command: debugCommand, arguments: nil)
+            command: Command(title: "Debug" + targetNameToAppend, command: debugCommand, arguments: arguments)
           )
         )
       }

--- a/Tests/SourceKitLSPTests/CodeLensTests.swift
+++ b/Tests/SourceKitLSPTests/CodeLensTests.swift
@@ -73,13 +73,23 @@ final class CodeLensTests: XCTestCase {
 
     let project = try await SwiftPMTestProject(
       files: [
-        "Test.swift": """
+        "Sources/MyApp/Test.swift": """
         1️⃣@main2️⃣
         struct MyApp {
           public static func main() {}
         }
         """
       ],
+      manifest: """
+        // swift-tools-version: 5.7
+
+        import PackageDescription
+
+        let package = Package(
+          name: "MyApp",
+          targets: [.executableTarget(name: "MyApp")]
+        )
+        """,
       capabilities: capabilities
     )
 
@@ -94,11 +104,11 @@ final class CodeLensTests: XCTestCase {
       [
         CodeLens(
           range: positions["1️⃣"]..<positions["2️⃣"],
-          command: Command(title: "Run", command: "swift.run", arguments: nil)
+          command: Command(title: "Run MyApp", command: "swift.run", arguments: nil)
         ),
         CodeLens(
           range: positions["1️⃣"]..<positions["2️⃣"],
-          command: Command(title: "Debug", command: "swift.debug", arguments: nil)
+          command: Command(title: "Debug MyApp", command: "swift.debug", arguments: nil)
         ),
       ]
     )

--- a/Tests/SourceKitLSPTests/CodeLensTests.swift
+++ b/Tests/SourceKitLSPTests/CodeLensTests.swift
@@ -104,11 +104,11 @@ final class CodeLensTests: XCTestCase {
       [
         CodeLens(
           range: positions["1️⃣"]..<positions["2️⃣"],
-          command: Command(title: "Run MyApp", command: "swift.run", arguments: nil)
+          command: Command(title: "Run MyApp", command: "swift.run", arguments: [.string("MyApp")])
         ),
         CodeLens(
           range: positions["1️⃣"]..<positions["2️⃣"],
-          command: Command(title: "Debug MyApp", command: "swift.debug", arguments: nil)
+          command: Command(title: "Debug MyApp", command: "swift.debug", arguments: [.string("MyApp")])
         ),
       ]
     )


### PR DESCRIPTION
The `SwiftLanguageService` can retrieve the canonical build target and its display name for a given source file. Add this information (if available) to the run and debug code lenses.