### PR TITLE
Retry writing file contents in tests on Windows

### DIFF
--- a/Sources/SKTestSupport/String+writeWithRetry.swift
+++ b/Sources/SKTestSupport/String+writeWithRetry.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SKLogging
+
+#if compiler(>=6)
+package import Foundation
+#else
+import Foundation
+#endif
+
+extension String {
+  /// Write this string to the given URL using UTF-8 encoding.
+  ///
+  /// Sometimes file writes fail on Windows because another process (like sourcekitd or clangd) still has exclusive
+  /// access to the file but releases it soon after. Retry to save the file if this happens. This matches what a user
+  /// would do.
+  package func writeWithRetry(to url: URL) async throws {
+    #if os(Windows)
+    try await repeatUntilExpectedResult(timeout: .seconds(10), sleepInterval: .milliseconds(200)) {
+      do {
+        try self.write(to: url, atomically: true, encoding: .utf8)
+        return true
+      } catch {
+        logger.error("Writing file contents to \(url) failed, will retry: \(error.forLogging)")
+        return false
+      }
+    }
+    #else
+    try self.write(to: url, atomically: true, encoding: .utf8)
+    #endif
+  }
+}

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -57,7 +57,7 @@ final class CompilationDatabaseTests: XCTestCase {
     // Remove -DFOO from the compile commands.
 
     let compileFlagsUri = try project.uri(for: FixedCompilationDatabaseBuildSystem.dbName)
-    try "".write(to: compileFlagsUri.fileURL!, atomically: false, encoding: .utf8)
+    try await "".writeWithRetry(to: XCTUnwrap(compileFlagsUri.fileURL))
 
     project.testClient.send(
       DidChangeWatchedFilesNotification(changes: [

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -354,7 +354,7 @@ class DefinitionTests: XCTestCase {
     let (updatedAPositions, updatedACode) = DocumentPositions.extract(from: "func 2️⃣sayHello() {}")
 
     let aUri = try project.uri(for: "FileA.swift")
-    try updatedACode.write(to: try XCTUnwrap(aUri.fileURL), atomically: true, encoding: .utf8)
+    try await updatedACode.writeWithRetry(to: XCTUnwrap(aUri.fileURL))
     project.testClient.send(
       DidChangeWatchedFilesNotification(changes: [FileEvent(uri: aUri, type: .changed)])
     )

--- a/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
+++ b/Tests/SourceKitLSPTests/DependencyTrackingTests.swift
@@ -98,7 +98,7 @@ final class DependencyTrackingTests: XCTestCase {
 
     // Write an empty header file first since clangd doesn't handle missing header
     // files without a recently upstreamed extension.
-    try "".write(to: generatedHeaderURL, atomically: true, encoding: .utf8)
+    try await "".writeWithRetry(to: generatedHeaderURL)
     let (mainUri, _) = try project.openDocument("main.c")
 
     let openDiags = try await project.testClient.nextDiagnosticsNotification()
@@ -108,7 +108,7 @@ final class DependencyTrackingTests: XCTestCase {
 
     // Update the header file to have the proper contents for our code to build.
     let contents = "int libX(int value);"
-    try contents.write(to: generatedHeaderURL, atomically: true, encoding: .utf8)
+    try await contents.writeWithRetry(to: generatedHeaderURL)
 
     let workspace = try await unwrap(project.testClient.server.workspaceForDocument(uri: mainUri))
     await workspace.filesDependenciesUpdated([mainUri])

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -332,13 +332,13 @@ final class LocalClangTests: XCTestCase {
     XCTAssert(initialDiags.diagnostics.isEmpty)
 
     // We rename Object to MyObject in the header.
-    try """
+    try await """
     struct MyObject {
       int field;
     };
 
     struct MyObject * newObject();
-    """.write(to: headerUri.fileURL!, atomically: false, encoding: .utf8)
+    """.writeWithRetry(to: XCTUnwrap(headerUri.fileURL))
 
     let clangdServer = await project.testClient.server.languageService(
       for: mainUri,

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -192,7 +192,7 @@ final class MainFilesProviderTests: XCTestCase {
       #include "\(try project.scratchDirectory.filePath)/Sources/shared.h"
       """
     let fancyLibraryUri = try project.uri(for: "MyFancyLibrary.c")
-    try newFancyLibraryContents.write(to: try XCTUnwrap(fancyLibraryUri.fileURL), atomically: false, encoding: .utf8)
+    try await newFancyLibraryContents.writeWithRetry(to: XCTUnwrap(fancyLibraryUri.fileURL))
     project.testClient.send(
       DidChangeWatchedFilesNotification(changes: [FileEvent(uri: fancyLibraryUri, type: .changed)])
     )

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -148,7 +148,7 @@ final class PublishDiagnosticsTests: XCTestCase {
 
     let updatedACode = "func sayHello() {}"
     let aUri = try project.uri(for: "FileA.swift")
-    try updatedACode.write(to: try XCTUnwrap(aUri.fileURL), atomically: true, encoding: .utf8)
+    try await updatedACode.writeWithRetry(to: XCTUnwrap(aUri.fileURL))
     project.testClient.send(
       DidChangeWatchedFilesNotification(changes: [FileEvent(uri: aUri, type: .changed)])
     )

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -198,7 +198,7 @@ final class PullDiagnosticsTests: XCTestCase {
 
     let updatedACode = "func sayHello() {}"
     let aUri = try project.uri(for: "FileA.swift")
-    try updatedACode.write(to: try XCTUnwrap(aUri.fileURL), atomically: true, encoding: .utf8)
+    try await updatedACode.writeWithRetry(to: XCTUnwrap(aUri.fileURL))
     project.testClient.send(
       DidChangeWatchedFilesNotification(changes: [FileEvent(uri: aUri, type: .changed)])
     )

--- a/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
@@ -121,7 +121,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
         l.2️⃣foo()
       }
       """
-    try extractMarkers(newFileContents).textWithoutMarkers.write(to: newFileUrl, atomically: false, encoding: .utf8)
+    try await extractMarkers(newFileContents).textWithoutMarkers.writeWithRetry(to: newFileUrl)
 
     // Check that we don't get cross-file code completion before we send a `DidChangeWatchedFilesNotification` to make
     // sure we didn't include the file in the initial retrieval of build settings.

--- a/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTestDiscoveryTests.swift
@@ -172,7 +172,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
         }6️⃣
         """
     )
-    try newFileContents.write(to: try XCTUnwrap(myTestsUri.fileURL), atomically: true, encoding: .utf8)
+    try await newFileContents.writeWithRetry(to: XCTUnwrap(myTestsUri.fileURL))
     project.testClient.send(DidChangeWatchedFilesNotification(changes: [FileEvent(uri: myTestsUri, type: .changed)]))
 
     let testsAfterDocumentChanged = try await project.testClient.send(WorkspaceTestsRequest())
@@ -672,7 +672,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
       .deletingLastPathComponent()
       .appendingPathComponent("MyNewTests.swift")
     let uri = DocumentURI(url)
-    try fileContents.write(to: url, atomically: true, encoding: .utf8)
+    try await fileContents.writeWithRetry(to: url)
     project.testClient.send(
       DidChangeWatchedFilesNotification(changes: [FileEvent(uri: uri, type: .created)])
     )
@@ -867,7 +867,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
     let testsAfterFileRemove = try await project.testClient.send(WorkspaceTestsRequest())
     XCTAssertEqual(testsAfterFileRemove, [])
 
-    try extractMarkers(markedFileContents).textWithoutMarkers.write(to: myTestsUrl, atomically: true, encoding: .utf8)
+    try await extractMarkers(markedFileContents).textWithoutMarkers.writeWithRetry(to: myTestsUrl)
     project.testClient.send(DidChangeWatchedFilesNotification(changes: [FileEvent(uri: myTestsUri, type: .created)]))
 
     let testsAfterFileReAdded = try await project.testClient.send(WorkspaceTestsRequest())
@@ -935,7 +935,7 @@ final class WorkspaceTestDiscoveryTests: XCTestCase {
 
     let uri = try XCTUnwrap(project.fileURI.fileURL)
 
-    try (originalContents + addedTest).write(to: uri, atomically: true, encoding: .utf8)
+    try await (originalContents + addedTest).writeWithRetry(to: uri)
 
     project.testClient.send(
       DidChangeWatchedFilesNotification(changes: [FileEvent(uri: project.fileURI, type: .changed)])


### PR DESCRIPTION
Sometimes file writes fail on Windows because another process (like sourcekitd or clangd) still has exclusive access to the file but releases it soon after. Retry to save the file if this happens. This matches what a user would do.

This should fix some test flakiness on Windows.