### PR TITLE
When using `SOURCEKIT_LSP_TEST_PLUGIN_PATHS=RELATIVE_TO_SOURCEKITD` infer plugin paths from default testing toolchain

### DIFF
--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -147,7 +147,7 @@ package struct IndexedSingleSwiftFileTestProject {
     }
 
     // Create the test client
-    var options = SourceKitLSPOptions.testDefault()
+    var options = try await SourceKitLSPOptions.testDefault()
     options.indexOrDefault = SourceKitLSPOptions.IndexOptions(
       indexStorePath: try indexURL.filePath,
       indexDatabasePath: try indexDBURL.filePath

--- a/Sources/SKTestSupport/MultiFileTestProject.swift
+++ b/Sources/SKTestSupport/MultiFileTestProject.swift
@@ -138,7 +138,7 @@ package class MultiFileTestProject {
     },
     initializationOptions: LSPAny? = nil,
     capabilities: ClientCapabilities = ClientCapabilities(),
-    options: SourceKitLSPOptions = .testDefault(),
+    options: SourceKitLSPOptions? = nil,
     toolchainRegistry: ToolchainRegistry = .forTesting,
     hooks: Hooks = Hooks(),
     enableBackgroundIndexing: Bool = false,

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -196,7 +196,7 @@ package class SwiftPMTestProject: MultiFileTestProject {
     },
     initializationOptions: LSPAny? = nil,
     capabilities: ClientCapabilities = ClientCapabilities(),
-    options: SourceKitLSPOptions = .testDefault(),
+    options: SourceKitLSPOptions? = nil,
     hooks: Hooks = Hooks(),
     enableBackgroundIndexing: Bool = false,
     usePullDiagnostics: Bool = true,

--- a/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
@@ -53,7 +53,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         ]
       )
       let packageRoot = tempDir.appendingPathComponent("pkg")
-      let buildSystemSpec = SwiftPMBuildSystem.searchForConfig(in: packageRoot, options: .testDefault())
+      let buildSystemSpec = SwiftPMBuildSystem.searchForConfig(in: packageRoot, options: try await .testDefault())
       XCTAssertNil(buildSystemSpec)
     }
   }
@@ -779,7 +779,9 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         withDestinationURL: URL(fileURLWithPath: tempDir.appendingPathComponent("pkg_real").filePath)
       )
 
-      let buildSystemSpec = try XCTUnwrap(SwiftPMBuildSystem.searchForConfig(in: packageRoot, options: .testDefault()))
+      let buildSystemSpec = try unwrap(
+        SwiftPMBuildSystem.searchForConfig(in: packageRoot, options: await .testDefault())
+      )
       let buildSystemManager = await BuildSystemManager(
         buildSystemSpec: buildSystemSpec,
         toolchainRegistry: .forTesting,
@@ -864,7 +866,9 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         withDestinationURL: URL(fileURLWithPath: tempDir.appendingPathComponent("pkg_real").filePath)
       )
 
-      let buildSystemSpec = try XCTUnwrap(SwiftPMBuildSystem.searchForConfig(in: symlinkRoot, options: .testDefault()))
+      let buildSystemSpec = try unwrap(
+        SwiftPMBuildSystem.searchForConfig(in: symlinkRoot, options: await .testDefault())
+      )
       let buildSystemManager = await BuildSystemManager(
         buildSystemSpec: buildSystemSpec,
         toolchainRegistry: .forTesting,
@@ -961,7 +965,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         .appendingPathComponent("Sources")
         .appendingPathComponent("lib")
 
-      let buildSystemSpec = SwiftPMBuildSystem.searchForConfig(in: workspaceRoot, options: .testDefault())
+      let buildSystemSpec = SwiftPMBuildSystem.searchForConfig(in: workspaceRoot, options: try await .testDefault())
       XCTAssertNil(buildSystemSpec)
     }
   }

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -969,7 +969,7 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testUseBuildFlagsDuringPreparation() async throws {
-    var options = SourceKitLSPOptions.testDefault()
+    var options = try await SourceKitLSPOptions.testDefault()
     options.swiftPMOrDefault.swiftCompilerFlags = ["-D", "MY_FLAG"]
     let project = try await SwiftPMTestProject(
       files: [
@@ -1016,7 +1016,7 @@ final class BackgroundIndexingTests: XCTestCase {
   func testUseSwiftSDKFlagsDuringPreparation() async throws {
     try await SkipUnless.canSwiftPMCompileForIOS()
 
-    var options = SourceKitLSPOptions.testDefault()
+    var options = try await SourceKitLSPOptions.testDefault()
     options.swiftPMOrDefault.swiftSDK = "arm64-apple-ios"
     let project = try await SwiftPMTestProject(
       files: [
@@ -1108,7 +1108,7 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testCrossModuleFunctionalityEvenIfLowLevelModuleHasErrors() async throws {
-    var options = SourceKitLSPOptions.testDefault()
+    var options = try await SourceKitLSPOptions.testDefault()
     options.backgroundPreparationMode = .enabled
     let project = try await SwiftPMTestProject(
       files: [
@@ -1154,7 +1154,7 @@ final class BackgroundIndexingTests: XCTestCase {
   }
 
   func testCrossModuleFunctionalityWithPreparationNoSkipping() async throws {
-    var options = SourceKitLSPOptions.testDefault()
+    var options = try await SourceKitLSPOptions.testDefault()
     options.backgroundPreparationMode = .noLazy
     let project = try await SwiftPMTestProject(
       files: [
@@ -1438,7 +1438,7 @@ final class BackgroundIndexingTests: XCTestCase {
   func testCancelIndexing() async throws {
     try SkipUnless.longTestsEnabled()
 
-    var options = SourceKitLSPOptions.testDefault()
+    var options = try await SourceKitLSPOptions.testDefault()
     options.backgroundPreparationMode = .enabled
     options.indexOrDefault.updateIndexStoreTimeout = 1 /* second */
 

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -67,14 +67,14 @@ final class BuildSystemTests: XCTestCase {
         configPath: URL(fileURLWithPath: "/")
       ),
       toolchainRegistry: .forTesting,
-      options: .testDefault(),
+      options: try .testDefault(),
       connectionToClient: DummyBuildSystemManagerConnectionToClient(),
       buildSystemHooks: BuildSystemHooks()
     )
     buildSystem = try await unwrap(buildSystemInjector.testBuildSystem)
 
     self.workspace = await Workspace.forTesting(
-      options: SourceKitLSPOptions.testDefault(),
+      options: try .testDefault(),
       testHooks: Hooks(),
       buildSystemManager: buildSystemManager,
       indexTaskScheduler: .forTesting

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -1425,7 +1425,7 @@ final class LocalSwiftTests: XCTestCase {
   func testSourceKitdTimeout() async throws {
     try SkipUnless.longTestsEnabled()
 
-    var options = SourceKitLSPOptions.testDefault()
+    var options = try await SourceKitLSPOptions.testDefault()
     // This is how long we wait until implicitly cancelling the first diagnostics request.
     // It needs to be long enough so we can compute diagnostics for the second requests.
     // 1s is not sufficient on Windows for that.

--- a/Tests/SwiftSourceKitPluginTests/PluginSwiftPMTestProject.swift
+++ b/Tests/SwiftSourceKitPluginTests/PluginSwiftPMTestProject.swift
@@ -28,7 +28,7 @@ final class PluginSwiftPMTestProject {
 
   private var _buildSystemManager: BuildSystemManager?
   private var buildSystemManager: BuildSystemManager {
-    get async {
+    get async throws {
       if let _buildSystemManager {
         return _buildSystemManager
       }
@@ -39,7 +39,7 @@ final class PluginSwiftPMTestProject {
           configPath: scratchDirectory.appendingPathComponent("Package.swift")
         ),
         toolchainRegistry: .forTesting,
-        options: .testDefault(backgroundIndexing: false),
+        options: try .testDefault(backgroundIndexing: false),
         connectionToClient: DummyBuildSystemManagerConnectionToClient(),
         buildSystemHooks: BuildSystemHooks()
       )
@@ -98,8 +98,8 @@ final class PluginSwiftPMTestProject {
   }
 
   package func compilerArguments(for fileName: String) async throws -> [String] {
-    await buildSystemManager.waitForUpToDateBuildGraph()
-    let buildSettings = await buildSystemManager.buildSettingsInferredFromMainFile(
+    try await buildSystemManager.waitForUpToDateBuildGraph()
+    let buildSettings = try await buildSystemManager.buildSettingsInferredFromMainFile(
       for: try uri(for: fileName),
       language: .swift,
       fallbackAfterTimeout: false


### PR DESCRIPTION
Otherwise, we infer the SourceKit plugin paths from the toolchain when creating a `SourceKitLSPServer` during testing because we don’t override the plugin paths in the SourceKitLSPOptions. But when running `SourceKitDTests`, we pass `pluginPaths: nil`, which would not load any plugins. If both of the tests run in the same process, this causes a fault to get logged because sourcekitd can only loaded once per process and we can’t modify which plugins are loaded after the fact.