### PR TITLE
Use an active compilation condition to build SourceKit-LSP without SwiftPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,10 +4,16 @@ import Foundation
 import PackageDescription
 
 /// Swift settings that should be applied to every Swift target.
-let globalSwiftSettings: [SwiftSetting] = [
-  .enableUpcomingFeature("InternalImportsByDefault"),
-  .enableUpcomingFeature("MemberImportVisibility"),
-]
+var globalSwiftSettings: [SwiftSetting] {
+  var result: [SwiftSetting] = [
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("MemberImportVisibility"),
+  ]
+  if noSwiftPMDependency {
+    result += [.define("NO_SWIFTPM_DEPENDENCY")]
+  }
+  return result
+}
 
 var products: [Product] = [
   .executable(name: "sourcekit-lsp", targets: ["sourcekit-lsp"]),

--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -217,7 +217,7 @@ private extension BuildSystemSpec {
         )
       }
     case .swiftPM:
-      #if canImport(PackageModel)
+      #if !NO_SWIFTPM_DEPENDENCY
       return await createBuiltInBuildSystemAdapter(
         messagesToSourceKitLSPHandler: messagesToSourceKitLSPHandler,
         buildSystemHooks: buildSystemHooks

--- a/Sources/BuildSystemIntegration/DetermineBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/DetermineBuildSystem.swift
@@ -103,7 +103,7 @@ package func determineBuildSystem(
     case .compilationDatabase:
       spec = searchForCompilationDatabaseConfig(in: workspaceFolderUrl, options: options)
     case .swiftPM:
-      #if canImport(PackageModel)
+      #if !NO_SWIFTPM_DEPENDENCY
       spec = SwiftPMBuildSystem.searchForConfig(in: workspaceFolderUrl, options: options)
       #endif
     }

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(PackageModel)
+#if !NO_SWIFTPM_DEPENDENCY
 import Basics
 @preconcurrency import Build
 import Dispatch

--- a/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/PackageManifestEdits.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(PackageModel)
+#if !NO_SWIFTPM_DEPENDENCY
 
 import Foundation
 import LanguageServerProtocol

--- a/Sources/SourceKitLSP/Swift/CodeActions/SyntaxCodeActions.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/SyntaxCodeActions.swift
@@ -26,7 +26,7 @@ let allSyntaxCodeActions: [SyntaxCodeActionProvider.Type] = {
     OpaqueParameterToGeneric.self,
     RemoveSeparatorsFromIntegerLiteral.self,
   ]
-  #if canImport(PackageModel)
+  #if !NO_SWIFTPM_DEPENDENCY
   result.append(PackageManifestEdits.self)
   #endif
   return result

--- a/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if canImport(PackageModel)
+#if !NO_SWIFTPM_DEPENDENCY
 import BuildServerProtocol
 @_spi(Testing) import BuildSystemIntegration
 import LanguageServerProtocol


### PR DESCRIPTION
This is more explicit than using `#if canImport(PackageModel)`.