### PR TITLE
[6.1] Update the compiler arguments used for background AST builds

### DIFF
--- a/Contributor Documentation/Implementing a BSP server.md
+++ b/Contributor Documentation/Implementing a BSP server.md
@@ -29,7 +29,7 @@ If the build system loads the entire build graph during initialization, it may i
 
 ## Supporting background indexing
 
-To support background indexing, the build system must set `data.prepareProvider: true` in the `build/initialize` response and implement the `buildTarget/prepare` method.
+To support background indexing, the build system must set `data.prepareProvider: true` in the `build/initialize` response and implement the `buildTarget/prepare` method. The compiler options used to prepare a target should match those sent for `textDocument/sourceKitOptions` in order to avoid mismatches when loading modules.
 
 ## Optional methods
 

--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -314,7 +314,7 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
     }
   }
 
-  private var cachedSourceKitOptions = RequestCache<TextDocumentSourceKitOptionsRequest>()
+  private var cachedAdjustedSourceKitOptions = RequestCache<TextDocumentSourceKitOptionsRequest>()
 
   private var cachedBuildTargets = Cache<WorkspaceBuildTargetsRequest, [BuildTargetIdentifier: BuildTargetInfo]>()
 
@@ -518,7 +518,7 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
       } else {
         nil
       }
-    self.cachedSourceKitOptions.clear(isolation: self) { cacheKey in
+    self.cachedAdjustedSourceKitOptions.clear(isolation: self) { cacheKey in
       guard let updatedTargets else {
         // All targets might have changed
         return true
@@ -747,13 +747,22 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
       target: target,
       language: language
     )
-
-    let response = try await cachedSourceKitOptions.get(request, isolation: self) { request in
-      try await buildSystemAdapter.send(request)
+    let response = try await cachedAdjustedSourceKitOptions.get(request, isolation: self) { request in
+      let options = try await buildSystemAdapter.send(request)
+      switch language.semanticKind {
+      case .swift:
+        return options?.adjustArgsForSemanticSwiftFunctionality(fileToIndex: document)
+      case .clang:
+        return options?.adjustingArgsForSemanticClangFunctionality()
+      default:
+        return options
+      }
     }
+
     guard let response else {
       return nil
     }
+
     return FileBuildSettings(
       compilerArguments: response.compilerArguments,
       workingDirectory: response.workingDirectory,
@@ -1228,3 +1237,153 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
 private func isDescendant(_ selfPathComponents: [String], of otherPathComponents: [String]) -> Bool {
   return selfPathComponents.dropLast().starts(with: otherPathComponents)
 }
+
+fileprivate extension TextDocumentSourceKitOptionsResponse {
+  /// Adjust compiler arguments that were created for building to compiler arguments that should be used for indexing
+  /// or background AST builds.
+  ///
+  /// This removes compiler arguments that produce output files and adds arguments to eg. allow errors and index the
+  /// file.
+  func adjustArgsForSemanticSwiftFunctionality(fileToIndex: DocumentURI) -> TextDocumentSourceKitOptionsResponse {
+    let optionsToRemove: [CompilerCommandLineOption] = [
+      .flag("c", [.singleDash]),
+      .flag("disable-cmo", [.singleDash]),
+      .flag("emit-dependencies", [.singleDash]),
+      .flag("emit-module-interface", [.singleDash]),
+      .flag("emit-module", [.singleDash]),
+      .flag("emit-objc-header", [.singleDash]),
+      .flag("incremental", [.singleDash]),
+      .flag("no-color-diagnostics", [.singleDash]),
+      .flag("parseable-output", [.singleDash]),
+      .flag("save-temps", [.singleDash]),
+      .flag("serialize-diagnostics", [.singleDash]),
+      .flag("use-frontend-parseable-output", [.singleDash]),
+      .flag("validate-clang-modules-once", [.singleDash]),
+      .flag("whole-module-optimization", [.singleDash]),
+      .flag("experimental-skip-all-function-bodies", frontendName: "Xfrontend", [.singleDash]),
+      .flag("experimental-skip-non-inlinable-function-bodies", frontendName: "Xfrontend", [.singleDash]),
+      .flag("experimental-skip-non-exportable-decls", frontendName: "Xfrontend", [.singleDash]),
+      .flag("experimental-lazy-typecheck", frontendName: "Xfrontend", [.singleDash]),
+
+      .option("clang-build-session-file", [.singleDash], [.separatedBySpace]),
+      .option("emit-module-interface-path", [.singleDash], [.separatedBySpace]),
+      .option("emit-module-path", [.singleDash], [.separatedBySpace]),
+      .option("emit-objc-header-path", [.singleDash], [.separatedBySpace]),
+      .option("emit-package-module-interface-path", [.singleDash], [.separatedBySpace]),
+      .option("emit-private-module-interface-path", [.singleDash], [.separatedBySpace]),
+      .option("num-threads", [.singleDash], [.separatedBySpace]),
+      // Technically, `-o` and the output file don't need to be separated by a space. Eg. `swiftc -oa file.swift` is
+      // valid and will write to an output file named `a`.
+      // We can't support that because the only way to know that `-output-file-map` is a different flag and not an option
+      // to write to an output file named `utput-file-map` is to know all compiler arguments of `swiftc`, which we don't.
+      .option("o", [.singleDash], [.separatedBySpace]),
+      .option("output-file-map", [.singleDash], [.separatedBySpace, .separatedByEqualSign]),
+    ]
+
+    var result: [String] = []
+    result.reserveCapacity(compilerArguments.count)
+    var iterator = compilerArguments.makeIterator()
+    while let argument = iterator.next() {
+      switch optionsToRemove.firstMatch(for: argument) {
+      case .removeOption:
+        continue
+      case .removeOptionAndNextArgument:
+        _ = iterator.next()
+        continue
+      case .removeOptionAndPreviousArgument(let name):
+        if let previousArg = result.last, previousArg.hasSuffix("-\(name)") {
+          _ = result.popLast()
+        }
+        continue
+      case nil:
+        break
+      }
+      result.append(argument)
+    }
+
+    result += [
+      // Avoid emitting the ABI descriptor, we don't need it
+      "-Xfrontend", "-empty-abi-descriptor",
+    ]
+
+    result += supplementalClangIndexingArgs.flatMap { ["-Xcc", $0] }
+
+    return TextDocumentSourceKitOptionsResponse(compilerArguments: result, workingDirectory: workingDirectory)
+  }
+
+  /// Adjust compiler arguments that were created for building to compiler arguments that should be used for indexing
+  /// or background AST builds.
+  ///
+  /// This removes compiler arguments that produce output files and adds arguments to eg. typecheck only.
+  func adjustingArgsForSemanticClangFunctionality() -> TextDocumentSourceKitOptionsResponse {
+    let optionsToRemove: [CompilerCommandLineOption] = [
+      // Disable writing of a depfile
+      .flag("M", [.singleDash]),
+      .flag("MD", [.singleDash]),
+      .flag("MMD", [.singleDash]),
+      .flag("MG", [.singleDash]),
+      .flag("MM", [.singleDash]),
+      .flag("MV", [.singleDash]),
+      // Don't create phony targets
+      .flag("MP", [.singleDash]),
+      // Don't write out compilation databases
+      .flag("MJ", [.singleDash]),
+      // Don't compile
+      .flag("c", [.singleDash]),
+
+      .flag("fmodules-validate-once-per-build-session", [.singleDash]),
+
+      // Disable writing of a depfile
+      .option("MT", [.singleDash], [.noSpace, .separatedBySpace]),
+      .option("MF", [.singleDash], [.noSpace, .separatedBySpace]),
+      .option("MQ", [.singleDash], [.noSpace, .separatedBySpace]),
+
+      // Don't write serialized diagnostic files
+      .option("serialize-diagnostics", [.singleDash, .doubleDash], [.separatedBySpace]),
+
+      .option("fbuild-session-file", [.singleDash], [.separatedByEqualSign]),
+    ]
+
+    var result: [String] = []
+    result.reserveCapacity(compilerArguments.count)
+    var iterator = compilerArguments.makeIterator()
+    while let argument = iterator.next() {
+      switch optionsToRemove.firstMatch(for: argument) {
+      case .removeOption:
+        continue
+      case .removeOptionAndNextArgument:
+        _ = iterator.next()
+        continue
+      case .removeOptionAndPreviousArgument(let name):
+        if let previousArg = result.last, previousArg.hasSuffix("-\(name)") {
+          _ = result.popLast()
+        }
+        continue
+      case nil:
+        break
+      }
+      result.append(argument)
+    }
+    result += supplementalClangIndexingArgs
+    result.append(
+      "-fsyntax-only"
+    )
+    return TextDocumentSourceKitOptionsResponse(compilerArguments: result, workingDirectory: workingDirectory)
+  }
+}
+
+fileprivate let supplementalClangIndexingArgs: [String] = [
+  // Retain extra information for indexing
+  "-fretain-comments-from-system-headers",
+  // Pick up macro definitions during indexing
+  "-Xclang", "-detailed-preprocessing-record",
+
+  // libclang uses 'raw' module-format. Match it so we can reuse the module cache and PCHs that libclang uses.
+  "-Xclang", "-fmodule-format=raw",
+
+  // Be less strict - we want to continue and typecheck/index as much as possible
+  "-Xclang", "-fallow-pch-with-compiler-errors",
+  "-Xclang", "-fallow-pcm-with-compiler-errors",
+  "-Wno-non-modular-include-in-framework-module",
+  "-Wno-incomplete-umbrella",
+]

--- a/Sources/BuildSystemIntegration/CMakeLists.txt
+++ b/Sources/BuildSystemIntegration/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(BuildSystemIntegration STATIC
   BuiltInBuildSystemAdapter.swift
   CompilationDatabase.swift
   CompilationDatabaseBuildSystem.swift
+  CompilerCommandLineOption.swift
   DetermineBuildSystem.swift
   ExternalBuildSystemAdapter.swift
   FallbackBuildSettings.swift

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -309,7 +309,8 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
       configuration: buildConfiguration,
       toolchain: destinationSwiftPMToolchain,
       triple: destinationSDK.targetTriple,
-      flags: buildFlags
+      flags: buildFlags,
+      prepareForIndexing: options.backgroundPreparationModeOrDefault.toSwiftPMPreparation
     )
 
     packageLoadingQueue.async {
@@ -732,6 +733,19 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
 fileprivate extension URL {
   var isDirectory: Bool {
     (try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+  }
+}
+
+fileprivate extension SourceKitLSPOptions.BackgroundPreparationMode {
+  var toSwiftPMPreparation: BuildParameters.PrepareForIndexingMode {
+    switch self {
+    case .build:
+      return .off
+    case .noLazy:
+      return .noLazy
+    case .enabled:
+      return .on
+    }
   }
 }
 

--- a/Sources/LanguageServerProtocolExtensions/CMakeLists.txt
+++ b/Sources/LanguageServerProtocolExtensions/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(LanguageServerProtocolExtensions STATIC
   Connection+Send.swift
   DocumentURI+CustomLogStringConvertible.swift
   DocumentURI+symlinkTarget.swift
-  Language+InferredFromFileExtension.swift
+  Language+Inference.swift
   LocalConnection.swift
   QueueBasedMessageHandler.swift
   RequestAndReply.swift

--- a/Sources/LanguageServerProtocolExtensions/Language+Inference.swift
+++ b/Sources/LanguageServerProtocolExtensions/Language+Inference.swift
@@ -19,6 +19,22 @@ import LanguageServerProtocol
 #endif
 
 extension Language {
+  package enum SemanticKind {
+    case clang
+    case swift
+  }
+
+  package var semanticKind: SemanticKind? {
+    switch self {
+    case .swift:
+      return .swift
+    case .c, .cpp, .objective_c, .objective_cpp:
+      return .clang
+    default:
+      return nil
+    }
+  }
+
   package init?(inferredFromFileExtension uri: DocumentURI) {
     // URL.pathExtension is only set for file URLs but we want to also infer a file extension for non-file URLs like
     // untitled:file.cpp

--- a/Sources/SemanticIndex/CMakeLists.txt
+++ b/Sources/SemanticIndex/CMakeLists.txt
@@ -1,7 +1,6 @@
 
 add_library(SemanticIndex STATIC
   CheckedIndex.swift
-  CompilerCommandLineOption.swift
   IndexTaskDescription.swift
   IndexTestHooks.swift
   PreparationTaskDescription.swift

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -96,22 +96,6 @@ package struct FileAndTarget: Sendable {
   package let target: BuildTargetIdentifier
 }
 
-private enum IndexKind {
-  case clang
-  case swift
-
-  init?(language: Language) {
-    switch language {
-    case .swift:
-      self = .swift
-    case .c, .cpp, .objective_c, .objective_cpp:
-      self = .clang
-    default:
-      return nil
-    }
-  }
-}
-
 /// Describes a task to index a set of source files.
 ///
 /// This task description can be scheduled in a `TaskScheduler`.
@@ -162,7 +146,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
   }
 
   static func canIndex(language: Language) -> Bool {
-    return IndexKind(language: language) != nil
+    return language.semanticKind != nil
   }
 
   init(
@@ -284,7 +268,7 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       return
     }
     let startDate = Date()
-    switch IndexKind(language: language) {
+    switch language.semanticKind {
     case .swift:
       do {
         try await updateIndexStore(
@@ -327,15 +311,20 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       return
     }
 
-    let indexingArguments = adjustSwiftCompilerArgumentsForIndexStoreUpdate(
-      buildSettings.compilerArguments,
-      fileToIndex: uri
-    )
+    let args =
+      try [swiftc.filePath] + buildSettings.compilerArguments + [
+        "-index-file",
+        "-index-file-path", uri.pseudoPath,
+        // batch mode is not compatible with -index-file
+        "-disable-batch-mode",
+        // Fake an output path so that we get a different unit file for every Swift file we background index
+        "-index-unit-output-path", uri.pseudoPath + ".o",
+      ]
 
     try await runIndexingProcess(
       indexFile: uri,
       buildSettings: buildSettings,
-      processArguments: [swiftc.filePath] + indexingArguments,
+      processArguments: args,
       workingDirectory: buildSettings.workingDirectory.map(AbsolutePath.init(validating:))
     )
   }
@@ -352,15 +341,10 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
       return
     }
 
-    let indexingArguments = adjustClangCompilerArgumentsForIndexStoreUpdate(
-      buildSettings.compilerArguments,
-      fileToIndex: uri
-    )
-
     try await runIndexingProcess(
       indexFile: uri,
       buildSettings: buildSettings,
-      processArguments: [clang.filePath] + indexingArguments,
+      processArguments: [clang.filePath] + buildSettings.compilerArguments,
       workingDirectory: buildSettings.workingDirectory.map(AbsolutePath.init(validating:))
     )
   }
@@ -447,176 +431,5 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
         BuildSettingsLogger.log(level: .error, settings: buildSettings, for: indexFile)
       }
     }
-  }
-}
-
-/// Adjust compiler arguments that were created for building to compiler arguments that should be used for indexing.
-///
-/// This removes compiler arguments that produce output files and adds arguments to index the file.
-private func adjustSwiftCompilerArgumentsForIndexStoreUpdate(
-  _ compilerArguments: [String],
-  fileToIndex: DocumentURI
-) -> [String] {
-  let optionsToRemove: [CompilerCommandLineOption] = [
-    .flag("c", [.singleDash]),
-    .flag("disable-cmo", [.singleDash]),
-    .flag("emit-dependencies", [.singleDash]),
-    .flag("emit-module-interface", [.singleDash]),
-    .flag("emit-module", [.singleDash]),
-    .flag("emit-objc-header", [.singleDash]),
-    .flag("incremental", [.singleDash]),
-    .flag("no-color-diagnostics", [.singleDash]),
-    .flag("parseable-output", [.singleDash]),
-    .flag("save-temps", [.singleDash]),
-    .flag("serialize-diagnostics", [.singleDash]),
-    .flag("use-frontend-parseable-output", [.singleDash]),
-    .flag("validate-clang-modules-once", [.singleDash]),
-    .flag("whole-module-optimization", [.singleDash]),
-
-    .option("clang-build-session-file", [.singleDash], [.separatedBySpace]),
-    .option("emit-module-interface-path", [.singleDash], [.separatedBySpace]),
-    .option("emit-module-path", [.singleDash], [.separatedBySpace]),
-    .option("emit-objc-header-path", [.singleDash], [.separatedBySpace]),
-    .option("emit-package-module-interface-path", [.singleDash], [.separatedBySpace]),
-    .option("emit-private-module-interface-path", [.singleDash], [.separatedBySpace]),
-    .option("num-threads", [.singleDash], [.separatedBySpace]),
-    // Technically, `-o` and the output file don't need to be separated by a space. Eg. `swiftc -oa file.swift` is
-    // valid and will write to an output file named `a`.
-    // We can't support that because the only way to know that `-output-file-map` is a different flag and not an option
-    // to write to an output file named `utput-file-map` is to know all compiler arguments of `swiftc`, which we don't.
-    .option("o", [.singleDash], [.separatedBySpace]),
-    .option("output-file-map", [.singleDash], [.separatedBySpace, .separatedByEqualSign]),
-  ]
-
-  var result: [String] = []
-  result.reserveCapacity(compilerArguments.count)
-  var iterator = compilerArguments.makeIterator()
-  while let argument = iterator.next() {
-    switch optionsToRemove.firstMatch(for: argument) {
-    case .removeOption:
-      continue
-    case .removeOptionAndNextArgument:
-      _ = iterator.next()
-      continue
-    case nil:
-      break
-    }
-    result.append(argument)
-  }
-  result += supplementalClangIndexingArgs.flatMap { ["-Xcc", $0] }
-  result += [
-    // Preparation produces modules with errors. We should allow reading them.
-    "-Xfrontend", "-experimental-allow-module-with-compiler-errors",
-    // Avoid emitting the ABI descriptor, we don't need it
-    "-Xfrontend", "-empty-abi-descriptor",
-    "-index-file",
-    "-index-file-path", fileToIndex.pseudoPath,
-    // batch mode is not compatible with -index-file
-    "-disable-batch-mode",
-    // Fake an output path so that we get a different unit file for every Swift file we background index
-    "-index-unit-output-path", fileToIndex.pseudoPath + ".o",
-  ]
-  return result
-}
-
-/// Adjust compiler arguments that were created for building to compiler arguments that should be used for indexing.
-///
-/// This removes compiler arguments that produce output files and adds arguments to index the file.
-private func adjustClangCompilerArgumentsForIndexStoreUpdate(
-  _ compilerArguments: [String],
-  fileToIndex: DocumentURI
-) -> [String] {
-  let optionsToRemove: [CompilerCommandLineOption] = [
-    // Disable writing of a depfile
-    .flag("M", [.singleDash]),
-    .flag("MD", [.singleDash]),
-    .flag("MMD", [.singleDash]),
-    .flag("MG", [.singleDash]),
-    .flag("MM", [.singleDash]),
-    .flag("MV", [.singleDash]),
-    // Don't create phony targets
-    .flag("MP", [.singleDash]),
-    // Don't write out compilation databases
-    .flag("MJ", [.singleDash]),
-    // Don't compile
-    .flag("c", [.singleDash]),
-
-    .flag("fmodules-validate-once-per-build-session", [.singleDash]),
-
-    // Disable writing of a depfile
-    .option("MT", [.singleDash], [.noSpace, .separatedBySpace]),
-    .option("MF", [.singleDash], [.noSpace, .separatedBySpace]),
-    .option("MQ", [.singleDash], [.noSpace, .separatedBySpace]),
-
-    // Don't write serialized diagnostic files
-    .option("serialize-diagnostics", [.singleDash, .doubleDash], [.separatedBySpace]),
-
-    .option("fbuild-session-file", [.singleDash], [.separatedByEqualSign]),
-  ]
-
-  var result: [String] = []
-  result.reserveCapacity(compilerArguments.count)
-  var iterator = compilerArguments.makeIterator()
-  while let argument = iterator.next() {
-    switch optionsToRemove.firstMatch(for: argument) {
-    case .removeOption:
-      continue
-    case .removeOptionAndNextArgument:
-      _ = iterator.next()
-      continue
-    case nil:
-      break
-    }
-    result.append(argument)
-  }
-  result += supplementalClangIndexingArgs
-  result.append(
-    "-fsyntax-only"
-  )
-  return result
-}
-
-#if compiler(>=6.1)
-#warning(
-  "Remove -fmodules-validate-system-headers from supplementalClangIndexingArgs once all supported Swift compilers have https://github.com/apple/swift/pull/74063"
-)
-#endif
-
-fileprivate let supplementalClangIndexingArgs: [String] = [
-  // Retain extra information for indexing
-  "-fretain-comments-from-system-headers",
-  // Pick up macro definitions during indexing
-  "-Xclang", "-detailed-preprocessing-record",
-
-  // libclang uses 'raw' module-format. Match it so we can reuse the module cache and PCHs that libclang uses.
-  "-Xclang", "-fmodule-format=raw",
-
-  // Be less strict - we want to continue and typecheck/index as much as possible
-  "-Xclang", "-fallow-pch-with-compiler-errors",
-  "-Xclang", "-fallow-pcm-with-compiler-errors",
-  "-Wno-non-modular-include-in-framework-module",
-  "-Wno-incomplete-umbrella",
-
-  // sourcekitd adds `-fno-modules-validate-system-headers` before https://github.com/apple/swift/pull/74063.
-  // This completely disables system module validation and never re-builds pcm for system modules. The intended behavior
-  // is to only re-build those PCMs once per sourcekitd session.
-  "-fmodules-validate-system-headers",
-]
-
-fileprivate extension Sequence {
-  /// Returns `true` if this sequence contains an element that is equal to an element in `otherSequence` when
-  /// considering two elements as equal if they satisfy `predicate`.
-  func hasIntersection(
-    with otherSequence: some Sequence<Element>,
-    where predicate: (Element, Element) -> Bool
-  ) -> Bool {
-    for outer in self {
-      for inner in otherSequence {
-        if predicate(outer, inner) {
-          return true
-        }
-      }
-    }
-    return false
   }
 }

--- a/Tests/BuildSystemIntegrationTests/CompilerCommandLineOptionMatchingTests.swift
+++ b/Tests/BuildSystemIntegrationTests/CompilerCommandLineOptionMatchingTests.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(Testing) import SemanticIndex
+@_spi(Testing) import BuildSystemIntegration
 import XCTest
 
 final class CompilerCommandLineOptionMatchingTests: XCTestCase {
@@ -19,6 +19,11 @@ final class CompilerCommandLineOptionMatchingTests: XCTestCase {
     assertOption(.flag("a", [.doubleDash]), "--a", .removeOption)
     assertOption(.flag("a", [.singleDash, .doubleDash]), "-a", .removeOption)
     assertOption(.flag("a", [.singleDash, .doubleDash]), "--a", .removeOption)
+    assertOption(
+      .flag("a", frontendName: "Xfrontend", [.singleDash]),
+      "-a",
+      .removeOptionAndPreviousArgument(name: "Xfrontend")
+    )
     assertOption(.flag("a", [.singleDash]), "-another", nil)
     assertOption(.flag("a", [.singleDash]), "--a", nil)
     assertOption(.flag("a", [.doubleDash]), "-a", nil)

--- a/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
@@ -169,12 +169,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       ).compilerArguments
 
       assertArgumentsContain("-module-name", "lib", arguments: arguments)
-      assertArgumentsContain("-emit-dependencies", arguments: arguments)
-      assertArgumentsContain("-emit-module", arguments: arguments)
-      assertArgumentsContain("-emit-module-path", arguments: arguments)
-      assertArgumentsContain("-incremental", arguments: arguments)
       assertArgumentsContain("-parse-as-library", arguments: arguments)
-      assertArgumentsContain("-c", arguments: arguments)
 
       assertArgumentsContain("-target", arguments: arguments)  // Only one!
       #if os(macOS)
@@ -687,15 +682,6 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         )
         assertArgumentsDoNotContain("-I", try build.filePath, arguments: args)
         assertArgumentsDoNotContain(try bcxx.filePath, arguments: args)
-
-        URL(fileURLWithPath: try build.appendingPathComponent("lib.build").appendingPathComponent("a.cpp.d").filePath)
-          .withUnsafeFileSystemRepresentation {
-            assertArgumentsContain("-MD", "-MT", "dependencies", "-MF", String(cString: $0!), arguments: args)
-          }
-
-        URL(fileURLWithPath: try file.filePath).withUnsafeFileSystemRepresentation {
-          assertArgumentsContain("-c", String(cString: $0!), arguments: args)
-        }
 
         URL(fileURLWithPath: try build.appendingPathComponent("lib.build").appendingPathComponent("a.cpp.o").filePath)
           .withUnsafeFileSystemRepresentation {


### PR DESCRIPTION
- **Explanation**: Fixes issues caused by a mismatch between the arguments used during preparation and background ASTs/indexing.
- **Scope**: Settings handling
- **Issue**: rdar://141508656
- **Original PR**: https://github.com/swiftlang/sourcekit-lsp/pull/1971
- **Risk**: Medium, this is a non-trivial change to settings handling. However, this is a well tested area (many tests are really integration tests using a SwiftPM project) and the alternative (crashes, loss of functionality, etc) is much worse.
- **Testing**: Added a test case for a direct use of an invalid function.
- **Reviewer**:  @ahoppen 