### PR TITLE
Hide internal options from SourceKit-LSP configuration file documentation

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -38,7 +38,6 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `indexStorePath: string`: Directory in which a separate compilation stores the index store. By default, inferred from the build system.
   - `indexDatabasePath: string`: Directory in which the indexstore-db should be stored. By default, inferred from the build system.
   - `indexPrefixMap: [string: string]`: Path remappings for remapping index data for local use.
-  - `maxCoresPercentageToUseForBackgroundIndexing: number`: A hint indicating how many cores background indexing should use at most (value between 0 and 1). Background indexing is not required to honor this setting.
   - `updateIndexStoreTimeout: integer`: Number of seconds to wait for an update index store task to finish before killing it.
 - `logging`: Options related to logging, changing SourceKit-LSP’s logging behavior on non-Apple platforms. On Apple platforms, logging is done through the [system log](Diagnose%20Bundle.md#Enable%20Extended%20Logging). These options can only be set globally and not per workspace.
   - `level: "debug"|"info"|"default"|"error"|"fault"`: The level from which one onwards log messages should be written.
@@ -46,8 +45,6 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `inputMirrorDirectory: string`: Write all input received by SourceKit-LSP on stdin to a file in this directory. Useful to record and replay an entire SourceKit-LSP session.
   - `outputMirrorDirectory: string`: Write all data sent from SourceKit-LSP to the client to a file in this directory. Useful to record the raw communication between SourceKit-LSP and the client on a low level.
 - `sourcekitd`: Options modifying the behavior of sourcekitd.
-  - `clientPlugin: string`: When set, load the SourceKit client plugin from this path instead of locating it inside the toolchain.
-  - `servicePlugin: string`: When set, load the SourceKit service plugin from this path instead of locating it inside the toolchain.
 - `defaultWorkspaceType: "buildServer"|"compilationDatabase"|"swiftPM"`: Default workspace type. Overrides workspace type selection logic.
 - `generatedFilesPath: string`: Directory in which generated interfaces and macro expansions should be stored.
 - `backgroundIndexing: boolean`: Whether background indexing is enabled.

--- a/SourceKitLSPDevUtils/Sources/ConfigSchemaGen/OptionSchema.swift
+++ b/SourceKitLSPDevUtils/Sources/ConfigSchemaGen/OptionSchema.swift
@@ -188,6 +188,9 @@ struct OptionSchemaContext {
       let name = binding.pattern.trimmed.description
       let defaultValue = binding.initializer?.value.description
       let description = Self.extractDocComment(variable.leadingTrivia)
+      if description?.contains("- Note: Internal option") ?? false {
+        continue
+      }
       let typeInfo = try resolveType(type.type)
       properties.append(
         .init(name: name, type: typeInfo, description: description, defaultValue: defaultValue)

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -168,6 +168,8 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     /// Path remappings for remapping index data for local use.
     public var indexPrefixMap: [String: String]?
     /// A hint indicating how many cores background indexing should use at most (value between 0 and 1). Background indexing is not required to honor this setting.
+    ///
+    /// - Note: Internal option, may not work as intended
     public var maxCoresPercentageToUseForBackgroundIndexing: Double?
     /// Number of seconds to wait for an update index store task to finish before killing it.
     public var updateIndexStoreTimeout: Int?
@@ -252,9 +254,13 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
 
   public struct SourceKitDOptions: Sendable, Codable, Equatable {
     /// When set, load the SourceKit client plugin from this path instead of locating it inside the toolchain.
+    ///
+    /// - Note: Internal option, only to be used while running SourceKit-LSP tests
     public var clientPlugin: String?
 
     /// When set, load the SourceKit service plugin from this path instead of locating it inside the toolchain.
+    ///
+    /// - Note: Internal option, only to be used while running SourceKit-LSP tests
     public var servicePlugin: String?
 
     public init(clientPlugin: String? = nil, servicePlugin: String? = nil) {

--- a/config.schema.json
+++ b/config.schema.json
@@ -139,11 +139,6 @@
           "markdownDescription" : "Directory in which a separate compilation stores the index store. By default, inferred from the build system.",
           "type" : "string"
         },
-        "maxCoresPercentageToUseForBackgroundIndexing" : {
-          "description" : "A hint indicating how many cores background indexing should use at most (value between 0 and 1). Background indexing is not required to honor this setting.",
-          "markdownDescription" : "A hint indicating how many cores background indexing should use at most (value between 0 and 1). Background indexing is not required to honor this setting.",
-          "type" : "number"
-        },
         "updateIndexStoreTimeout" : {
           "description" : "Number of seconds to wait for an update index store task to finish before killing it.",
           "markdownDescription" : "Number of seconds to wait for an update index store task to finish before killing it.",
@@ -194,18 +189,6 @@
     "sourcekitd" : {
       "description" : "Options modifying the behavior of sourcekitd.",
       "markdownDescription" : "Options modifying the behavior of sourcekitd.",
-      "properties" : {
-        "clientPlugin" : {
-          "description" : "When set, load the SourceKit client plugin from this path instead of locating it inside the toolchain.",
-          "markdownDescription" : "When set, load the SourceKit client plugin from this path instead of locating it inside the toolchain.",
-          "type" : "string"
-        },
-        "servicePlugin" : {
-          "description" : "When set, load the SourceKit service plugin from this path instead of locating it inside the toolchain.",
-          "markdownDescription" : "When set, load the SourceKit service plugin from this path instead of locating it inside the toolchain.",
-          "type" : "string"
-        }
-      },
       "type" : "object"
     },
     "sourcekitdRequestTimeout" : {


### PR DESCRIPTION
These options are not intended to be used by users.