### PR TITLE
Make `LogHandlerActor.shared` a `let`

### DIFF
--- a/Sources/SKLogging/NonDarwinLogging.swift
+++ b/Sources/SKLogging/NonDarwinLogging.swift
@@ -287,7 +287,7 @@ private let dateFormatter = {
 /// Actor that protects `logHandler`
 @globalActor
 actor LogHandlerActor {
-  static var shared: LogHandlerActor = LogHandlerActor()
+  static let shared: LogHandlerActor = LogHandlerActor()
 }
 
 /// The handler that is called to log a message from `NonDarwinLogger` unless `overrideLogHandler` is set on the logger.


### PR DESCRIPTION
To fix a concurrency error that was surfaced by https://github.com/swiftlang/swift/pull/78652.