### PR TITLE
Add notification to inform SourceKit-LSP about the currently active document

### DIFF
--- a/Contributor Documentation/LSP Extensions.md
+++ b/Contributor Documentation/LSP Extensions.md
@@ -434,6 +434,25 @@ export interface DocumentTestsParams {
 }
 ```
 
+## `window/didChangeActiveDocument`
+
+New notification from the client to the server, telling SourceKit-LSP which document is the currently active primary document.
+
+By default, SourceKit-LSP infers the currently active editor document from the last document that received a request.
+If the client supports active reporting of the currently active document, it should check for the
+`window/didChangeActiveDocument` experimental server capability. If that capability is present, it should respond with
+the `window/didChangeActiveDocument` experimental client capability and send this notification whenever the currently
+active document changes.
+
+- params: `DidChangeActiveDocumentParams`
+
+```ts
+export interface DidChangeActiveDocumentParams {
+  /**
+   * The document that is being displayed in the active editor.
+   */
+  textDocument: TextDocumentIdentifier;
+
 ## `window/logMessage`
 
 Added field:

--- a/Sources/LanguageServerProtocol/CMakeLists.txt
+++ b/Sources/LanguageServerProtocol/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(LanguageServerProtocol STATIC
   Notifications/CancelRequestNotification.swift
   Notifications/CancelWorkDoneProgressNotification.swift
   Notifications/ConfigurationNotification.swift
+  Notifications/DidChangeActiveDocumentNotification.swift
   Notifications/DidChangeFileNotifications.swift
   Notifications/DidChangeWatchedFilesNotification.swift
   Notifications/DidChangeWorkspaceFoldersNotification.swift

--- a/Sources/LanguageServerProtocol/Messages.swift
+++ b/Sources/LanguageServerProtocol/Messages.swift
@@ -98,6 +98,7 @@ public let builtinRequests: [_RequestType.Type] = [
 public let builtinNotifications: [NotificationType.Type] = [
   CancelRequestNotification.self,
   CancelWorkDoneProgressNotification.self,
+  DidChangeActiveDocumentNotification.self,
   DidChangeConfigurationNotification.self,
   DidChangeNotebookDocumentNotification.self,
   DidChangeTextDocumentNotification.self,

--- a/Sources/LanguageServerProtocol/Notifications/DidChangeActiveDocumentNotification.swift
+++ b/Sources/LanguageServerProtocol/Notifications/DidChangeActiveDocumentNotification.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public struct DidChangeActiveDocumentNotification: NotificationType {
+  public static let method: String = "window/didChangeActiveDocument"
+
+  /// The document that is being displayed in the active editor.
+  public var textDocument: TextDocumentIdentifier
+
+  public init(textDocument: TextDocumentIdentifier) {
+    self.textDocument = textDocument
+  }
+}

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -102,6 +102,17 @@ package final actor CapabilityRegistry {
     registration(for: [language], in: pullDiagnostics) != nil
   }
 
+  package nonisolated var clientSupportsActiveDocumentNotification: Bool {
+    return clientHasExperimentalCapability(DidChangeActiveDocumentNotification.method)
+  }
+
+  package nonisolated func clientHasExperimentalCapability(_ name: String) -> Bool {
+    guard case .dictionary(let experimentalCapabilities) = clientCapabilities.experimental else {
+      return false
+    }
+    return experimentalCapabilities[name] == .bool(true)
+  }
+
   // MARK: Initializer
 
   package init(clientCapabilities: ClientCapabilities) {

--- a/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
+++ b/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
@@ -100,6 +100,9 @@ package enum MessageHandlingDependencyTracker: QueueBasedMessageHandlerDependenc
       self = .freestanding
     case is CancelWorkDoneProgressNotification:
       self = .freestanding
+    case is DidChangeActiveDocumentNotification:
+      // The notification doesn't change behavior in an observable way, so we can treat it as freestanding.
+      self = .freestanding
     case is DidChangeConfigurationNotification:
       self = .globalConfigurationChange
     case let notification as DidChangeNotebookDocumentNotification:

--- a/Sources/SourceKitLSP/Swift/MacroExpansion.swift
+++ b/Sources/SourceKitLSP/Swift/MacroExpansion.swift
@@ -221,9 +221,8 @@ extension SwiftLanguageService {
       }
     }
 
-    if case .dictionary(let experimentalCapabilities) = self.capabilityRegistry.clientCapabilities.experimental,
-      case .bool(true) = experimentalCapabilities["workspace/peekDocuments"],
-      case .bool(true) = experimentalCapabilities["workspace/getReferenceDocument"]
+    if self.capabilityRegistry.clientHasExperimentalCapability(PeekDocumentsRequest.method),
+      self.capabilityRegistry.clientHasExperimentalCapability(GetReferenceDocumentRequest.method)
     {
       let expansionURIs = try macroExpansionReferenceDocumentURLs.map { try $0.uri }
 

--- a/Tests/SourceKitLSPTests/ExpandMacroTests.swift
+++ b/Tests/SourceKitLSPTests/ExpandMacroTests.swift
@@ -268,8 +268,8 @@ final class ExpandMacroTests: XCTestCase {
       files: files,
       manifest: SwiftPMTestProject.macroPackageManifest,
       capabilities: ClientCapabilities(experimental: [
-        "workspace/peekDocuments": .bool(peekDocuments),
-        "workspace/getReferenceDocument": .bool(getReferenceDocument),
+        PeekDocumentsRequest.method: .bool(peekDocuments),
+        GetReferenceDocumentRequest.method: .bool(getReferenceDocument),
       ]),
       options: SourceKitLSPOptions.testDefault(),
       enableBackgroundIndexing: true


### PR DESCRIPTION
SourceKit-LSP prepares the currently active file for editor functionality and currently infers the currently active document from whichever received the last `TextDocumentRequest`.

If an editor is capable of doing so, it should be able to report the document that the user currently has focused so that SourceKit-LSP does not have to infer this information from other requests.

Also clean up some handling code for experimental capabilities.