### PR TITLE
Add `CancelRequestNotification` to BSP notification types

### DIFF
--- a/Sources/BuildServerProtocol/Messages.swift
+++ b/Sources/BuildServerProtocol/Messages.swift
@@ -29,6 +29,7 @@ fileprivate let requestTypes: [_RequestType.Type] = [
 ]
 
 fileprivate let notificationTypes: [NotificationType.Type] = [
+  CancelRequestNotification.self,
   FileOptionsChangedNotification.self,
   OnBuildExitNotification.self,
   OnBuildInitializedNotification.self,


### PR DESCRIPTION
Otherwise a client that uses the `BuildServerProtocol` modules to implement a BSP server can’t deserialize the `$/cancelRequest` notification.