### PR TITLE
A couple refinements to the `window/didChangeActiveDocument` notification

### DIFF
--- a/Contributor Documentation/LSP Extensions.md
+++ b/Contributor Documentation/LSP Extensions.md
@@ -438,6 +438,8 @@ export interface DocumentTestsParams {
 
 New notification from the client to the server, telling SourceKit-LSP which document is the currently active primary document.
 
+This notification should only be called for documents that the editor has opened in SourceKit-LSP using the `textDocument/didOpen` notification.
+
 By default, SourceKit-LSP infers the currently active editor document from the last document that received a request.
 If the client supports active reporting of the currently active document, it should check for the
 `window/didChangeActiveDocument` experimental server capability. If that capability is present, it should respond with
@@ -449,9 +451,12 @@ active document changes.
 ```ts
 export interface DidChangeActiveDocumentParams {
   /**
-   * The document that is being displayed in the active editor.
+   * The document that is being displayed in the active editor or `null` to indicate that either no document is active
+   * or that the currently open document is not handled by SourceKit-LSP.
    */
-  textDocument: TextDocumentIdentifier;
+  textDocument?: TextDocumentIdentifier;
+}
+```
 
 ## `window/logMessage`
 

--- a/Sources/LanguageServerProtocol/Notifications/DidChangeActiveDocumentNotification.swift
+++ b/Sources/LanguageServerProtocol/Notifications/DidChangeActiveDocumentNotification.swift
@@ -13,10 +13,11 @@
 public struct DidChangeActiveDocumentNotification: NotificationType {
   public static let method: String = "window/didChangeActiveDocument"
 
-  /// The document that is being displayed in the active editor.
-  public var textDocument: TextDocumentIdentifier
+  /// The document that is being displayed in the active editor  or `null` to indicate that either no document is active
+  /// or that the currently open document is not handled by SourceKit-LSP.
+  public var textDocument: TextDocumentIdentifier?
 
-  public init(textDocument: TextDocumentIdentifier) {
+  public init(textDocument: TextDocumentIdentifier?) {
     self.textDocument = textDocument
   }
 }

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -471,21 +471,26 @@ package final actor SemanticIndexManager {
         }
       }
     }
-    if let inProgressPrepareForEditorTask {
-      // Cancel the in progress prepare for editor task to indicate that we are no longer interested in it.
-      // This will cancel the preparation of `inProgressPrepareForEditorTask`'s target if it hasn't started yet.
-      // (see comment at the end of `SemanticIndexManager.prepare`).
-      logger.debug(
-        "Marking preparation of \(inProgressPrepareForEditorTask.document) as no longer relevant because \(uri) was opened"
-      )
-      inProgressPrepareForEditorTask.task.cancel()
-    }
+
+    markPreparationForEditorFunctionalityTaskAsIrrelevant()
     inProgressPrepareForEditorTask = InProgressPrepareForEditorTask(
       id: id,
       document: uri,
       task: task
     )
     self.indexProgressStatusDidChange()
+  }
+
+  /// If there is an in-progress prepare for editor task, cancel it to indicate that we are no longer interested in it.
+  /// This will cancel the preparation of `inProgressPrepareForEditorTask`'s target if it hasn't started yet. If the
+  /// preparation has already started, we don't cancel it to guarantee forward progress (see comment at the end of
+  /// `SemanticIndexManager.prepare`).
+  package func markPreparationForEditorFunctionalityTaskAsIrrelevant() {
+    guard let inProgressPrepareForEditorTask else {
+      return
+    }
+    logger.debug("Marking preparation of \(inProgressPrepareForEditorTask.document) as no longer relevant")
+    inProgressPrepareForEditorTask.task.cancel()
   }
 
   /// Prepare the target that the given file is in, building all modules that the file depends on. Returns when


### PR DESCRIPTION
- Clarify that this must only be called with documents that are open in SourceKit-LSP and add a check for that.
- Allow sending `null` to indicate that no SourceKit-LSP document is currently active.
- Cancel preparation tasks for other workspaces that don’t contain the currently active document.