### PR TITLE
Change the build server injection logic to inject a `Connection` instead of `BuiltInBuildSystem`

### DIFF
--- a/Sources/BuildSystemIntegration/BuildSystemHooks.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemHooks.swift
@@ -31,12 +31,6 @@ package struct SwiftPMTestHooks: Sendable {
   }
 }
 
-/// When running SourceKit-LSP in-process, allows the creator of `SourceKitLSPServer` to create the build system instead
-/// of SourceKit-LSP creating build systems as needed.
-package protocol BuildSystemInjector: Sendable {
-  func createBuildSystem(projectRoot: URL, connectionToSourceKitLSP: any Connection) async -> BuiltInBuildSystem
-}
-
 package struct BuildSystemHooks: Sendable {
   package var swiftPMTestHooks: SwiftPMTestHooks
 
@@ -45,15 +39,20 @@ package struct BuildSystemHooks: Sendable {
   /// This allows requests to be artificially delayed.
   package var preHandleRequest: (@Sendable (any RequestType) async -> Void)?
 
-  package var buildSystemInjector: BuildSystemInjector?
+  /// When running SourceKit-LSP in-process, allows the creator of `SourceKitLSPServer` to create a message handler that
+  /// handles BSP requests instead of SourceKit-LSP creating build systems as needed.
+  package var injectBuildServer:
+    (@Sendable (_ projectRoot: URL, _ connectionToSourceKitLSP: any Connection) async -> any Connection)?
 
   package init(
     swiftPMTestHooks: SwiftPMTestHooks = SwiftPMTestHooks(),
     preHandleRequest: (@Sendable (any RequestType) async -> Void)? = nil,
-    buildSystemInjector: BuildSystemInjector? = nil
+    injectBuildServer: (
+      @Sendable (_ projectRoot: URL, _ connectionToSourceKitLSP: any Connection) async -> any Connection
+    )? = nil
   ) {
     self.swiftPMTestHooks = swiftPMTestHooks
     self.preHandleRequest = preHandleRequest
-    self.buildSystemInjector = buildSystemInjector
+    self.injectBuildServer = injectBuildServer
   }
 }

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 import BuildServerProtocol
-import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
 import SKOptions
@@ -20,8 +19,10 @@ import ToolchainRegistry
 
 #if compiler(>=6)
 package import Foundation
+package import LanguageServerProtocol
 #else
 import Foundation
+import LanguageServerProtocol
 #endif
 
 /// The details necessary to create a `BuildSystemAdapter`.
@@ -31,7 +32,9 @@ package struct BuildSystemSpec {
     case jsonCompilationDatabase
     case fixedCompilationDatabase
     case swiftPM
-    case injected(BuildSystemInjector)
+    case injected(
+      @Sendable (_ projectRoot: URL, _ connectionToSourceKitLSP: any Connection) async -> any Connection
+    )
   }
 
   package var kind: Kind

--- a/Sources/BuildSystemIntegration/DetermineBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/DetermineBuildSystem.swift
@@ -72,9 +72,9 @@ package func determineBuildSystem(
   options: SourceKitLSPOptions,
   hooks: BuildSystemHooks
 ) -> BuildSystemSpec? {
-  if let buildSystemInjector = hooks.buildSystemInjector {
+  if let injectBuildServer = hooks.injectBuildServer {
     return BuildSystemSpec(
-      kind: .injected(buildSystemInjector),
+      kind: .injected(injectBuildServer),
       projectRoot: workspaceFolder.arbitrarySchemeURL,
       configPath: workspaceFolder.arbitrarySchemeURL
     )


### PR DESCRIPTION
This gives the injected build system more flexibility by being able to respond to all BSP messages instead of only those methods defined in `BuiltInBuildSystem`.