### PR TITLE
Set `useNewAPI` when closing a code completion session

### DIFF
--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -374,6 +374,7 @@ class CodeCompletionSession {
         keys.column: sourcekitdPosition.utf8Column,
         keys.sourceFile: snapshot.uri.pseudoPath,
         keys.name: snapshot.uri.pseudoPath,
+        keys.codeCompleteOptions: [keys.useNewAPI: 1],
       ])
       logger.info("Closing code completion session: \(self.description)")
       _ = try? await sourcekitd.send(req, timeout: options.sourcekitdRequestTimeoutOrDefault, fileContents: nil)


### PR DESCRIPTION
Otherwise, the close does not get handled by the SourceKit plugin. In practice, it doesn’t matter too much because the SourceKit plugin will implicitly close the last completion session when a new one is opened but we should fix this.