### PR TITLE
If a build server doesn’t specify `-index-store-path` in the SourceKit options, add it during background indexing

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -37,8 +37,6 @@ The structure of the file is currently not guaranteed to be stable. Options may 
 - `buildSettingsTimeout: integer`: Number of milliseconds to wait for build settings from the build system before using fallback build settings.
 - `clangdOptions: string[]`: Extra command line arguments passed to `clangd` when launching it.
 - `index`: Options related to indexing.
-  - `indexStorePath: string`: Directory in which a separate compilation stores the index store. By default, inferred from the build system.
-  - `indexDatabasePath: string`: Directory in which the indexstore-db should be stored. By default, inferred from the build system.
   - `indexPrefixMap: [string: string]`: Path remappings for remapping index data for local use.
   - `updateIndexStoreTimeout: integer`: Number of seconds to wait for an update index store task to finish before killing it.
 - `logging`: Options related to logging, changing SourceKit-LSP’s logging behavior on non-Apple platforms. On Apple platforms, logging is done through the [system log](Diagnose%20Bundle.md#Enable%20Extended%20Logging). These options can only be set globally and not per workspace.

--- a/Sources/BuildSystemIntegration/FixedCompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/FixedCompilationDatabaseBuildSystem.swift
@@ -24,10 +24,10 @@ import LanguageServerProtocol
 #endif
 
 func lastIndexStorePathArgument(in compilerArgs: [String]) -> String? {
-  for i in compilerArgs.indices.reversed() {
-    if compilerArgs[i] == "-index-store-path" && i + 1 < compilerArgs.count {
-      return compilerArgs[i + 1]
-    }
+  if let indexStorePathIndex = compilerArgs.lastIndex(of: "-index-store-path"),
+    indexStorePathIndex + 1 < compilerArgs.count
+  {
+    return compilerArgs[indexStorePathIndex + 1]
   }
   return nil
 }

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -182,10 +182,6 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
   }
 
   public struct IndexOptions: Sendable, Codable, Equatable {
-    /// Directory in which a separate compilation stores the index store. By default, inferred from the build system.
-    public var indexStorePath: String?
-    /// Directory in which the indexstore-db should be stored. By default, inferred from the build system.
-    public var indexDatabasePath: String?
     /// Path remappings for remapping index data for local use.
     public var indexPrefixMap: [String: String]?
     /// A hint indicating how many cores background indexing should use at most (value between 0 and 1). Background indexing is not required to honor this setting.
@@ -208,14 +204,10 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     }
 
     public init(
-      indexStorePath: String? = nil,
-      indexDatabasePath: String? = nil,
       indexPrefixMap: [String: String]? = nil,
       maxCoresPercentageToUseForBackgroundIndexing: Double? = nil,
       updateIndexStoreTimeout: Int? = nil
     ) {
-      self.indexStorePath = indexStorePath
-      self.indexDatabasePath = indexDatabasePath
       self.indexPrefixMap = indexPrefixMap
       self.maxCoresPercentageToUseForBackgroundIndexing = maxCoresPercentageToUseForBackgroundIndexing
       self.updateIndexStoreTimeout = updateIndexStoreTimeout
@@ -223,8 +215,6 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
 
     static func merging(base: IndexOptions, override: IndexOptions?) -> IndexOptions {
       return IndexOptions(
-        indexStorePath: override?.indexStorePath ?? base.indexStorePath,
-        indexDatabasePath: override?.indexDatabasePath ?? base.indexDatabasePath,
         indexPrefixMap: override?.indexPrefixMap ?? base.indexPrefixMap,
         maxCoresPercentageToUseForBackgroundIndexing: override?.maxCoresPercentageToUseForBackgroundIndexing
           ?? base.maxCoresPercentageToUseForBackgroundIndexing,

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -147,13 +147,8 @@ package struct IndexedSingleSwiftFileTestProject {
     }
 
     // Create the test client
-    var options = try await SourceKitLSPOptions.testDefault()
-    options.indexOrDefault = SourceKitLSPOptions.IndexOptions(
-      indexStorePath: try indexURL.filePath,
-      indexDatabasePath: try indexDBURL.filePath
-    )
     self.testClient = try await TestSourceKitLSPClient(
-      options: options,
+      options: try await SourceKitLSPOptions.testDefault(),
       capabilities: capabilities,
       workspaceFolders: [
         WorkspaceFolder(uri: DocumentURI(testWorkspaceDirectory))

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -38,7 +38,6 @@ package struct IndexedSingleSwiftFileTestProject {
   package let testClient: TestSourceKitLSPClient
   package let fileURI: DocumentURI
   package let positions: DocumentPositions
-  package let indexDBURL: URL
 
   /// Writes a single file to a temporary directory on disk and compiles it to index it.
   ///
@@ -62,7 +61,6 @@ package struct IndexedSingleSwiftFileTestProject {
 
     let testFileURL = testWorkspaceDirectory.appendingPathComponent("test.swift")
     let indexURL = testWorkspaceDirectory.appendingPathComponent("index")
-    self.indexDBURL = testWorkspaceDirectory.appendingPathComponent("index-db")
     guard let swiftc = await ToolchainRegistry.forTesting.default?.swiftc else {
       throw Error.swiftcNotFound
     }

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -272,17 +272,13 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
 
     let indexOptions = options.indexOrDefault
     let indexStorePath: URL? =
-      if let indexStorePath = indexOptions.indexStorePath {
-        URL(fileURLWithPath: indexStorePath, relativeTo: rootUri?.fileURL)
-      } else if let indexStorePath = await buildSystemManager.initializationData?.indexStorePath {
+      if let indexStorePath = await buildSystemManager.initializationData?.indexStorePath {
         URL(fileURLWithPath: indexStorePath, relativeTo: rootUri?.fileURL)
       } else {
         nil
       }
     let indexDatabasePath: URL? =
-      if let indexDatabasePath = indexOptions.indexDatabasePath {
-        URL(fileURLWithPath: indexDatabasePath, relativeTo: rootUri?.fileURL)
-      } else if let indexDatabasePath = await buildSystemManager.initializationData?.indexDatabasePath {
+      if let indexDatabasePath = await buildSystemManager.initializationData?.indexDatabasePath {
         URL(fileURLWithPath: indexDatabasePath, relativeTo: rootUri?.fileURL)
       } else {
         nil

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -113,18 +113,6 @@ struct SourceKitLSP: AsyncParsableCommand {
   var clangdOptions = [String]()
 
   @Option(
-    name: .customLong("index-store-path", withSingleDash: true),
-    help: "Override index-store-path from the build system"
-  )
-  var indexStorePath: String?
-
-  @Option(
-    name: .customLong("index-db-path", withSingleDash: true),
-    help: "Override index-database-path from the build system"
-  )
-  var indexDatabasePath: String?
-
-  @Option(
     name: .customLong("index-prefix-map", withSingleDash: true),
     parsing: .unconditionalSingleValue,
     help: "Override the prefix map from the build system, values of form 'remote=local'"
@@ -177,8 +165,6 @@ struct SourceKitLSP: AsyncParsableCommand {
       compilationDatabase: SourceKitLSPOptions.CompilationDatabaseOptions(searchPaths: compilationDatabaseSearchPaths),
       clangdOptions: clangdOptions,
       index: SourceKitLSPOptions.IndexOptions(
-        indexStorePath: indexStorePath,
-        indexDatabasePath: indexDatabasePath,
         indexPrefixMap: [String: String](
           indexPrefixMappings.map { ($0.original, $0.replacement) },
           uniquingKeysWith: { lhs, rhs in rhs }

--- a/Tests/SourceKitLSPTests/IndexTests.swift
+++ b/Tests/SourceKitLSPTests/IndexTests.swift
@@ -128,7 +128,8 @@ final class IndexTests: XCTestCase {
       XCTAssertEqual(jump.first?.uri, project.fileURI)
       XCTAssertEqual(jump.first?.range.lowerBound, project.positions["1️⃣"])
 
-      let tmpContents = try listdir(project.indexDBURL)
+      let indexDBURL = project.fileURI.fileURL!.deletingLastPathComponent().appendingPathComponent("IndexDatabase")
+      let tmpContents = try listdir(indexDBURL)
       guard let versionedPath = tmpContents.filter({ $0.lastPathComponent.starts(with: "v") }).only else {
         XCTFail("expected one version path 'v[0-9]*', found \(tmpContents)")
         return nil

--- a/config.schema.json
+++ b/config.schema.json
@@ -126,11 +126,6 @@
       "description" : "Options related to indexing.",
       "markdownDescription" : "Options related to indexing.",
       "properties" : {
-        "indexDatabasePath" : {
-          "description" : "Directory in which the indexstore-db should be stored. By default, inferred from the build system.",
-          "markdownDescription" : "Directory in which the indexstore-db should be stored. By default, inferred from the build system.",
-          "type" : "string"
-        },
         "indexPrefixMap" : {
           "additionalProperties" : {
             "type" : "string"
@@ -138,11 +133,6 @@
           "description" : "Path remappings for remapping index data for local use.",
           "markdownDescription" : "Path remappings for remapping index data for local use.",
           "type" : "object"
-        },
-        "indexStorePath" : {
-          "description" : "Directory in which a separate compilation stores the index store. By default, inferred from the build system.",
-          "markdownDescription" : "Directory in which a separate compilation stores the index store. By default, inferred from the build system.",
-          "type" : "string"
         },
         "updateIndexStoreTimeout" : {
           "description" : "Number of seconds to wait for an update index store task to finish before killing it.",


### PR DESCRIPTION
Also, remove options to override the index store path and index database path. We should always infer these from the build system and I can’t think of a reason to override these settings.