### PR TITLE
Add calls with no defaulted arguments to code completion results

### DIFF
--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -353,6 +353,7 @@ class CodeCompletionSession {
       keys.hideByName: 0,
       keys.addInnerOperators: 0,
       keys.topNonLiteral: 0,
+      keys.addCallWithNoDefaultArgs: 1,
       // Filtering options.
       keys.filterText: filterText,
       keys.requestLimit: 200,

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -1125,6 +1125,27 @@ final class SwiftCompletionTests: XCTestCase {
       .markupContent(MarkupContent(kind: .markdown, value: "Creates a true value"))
     )
   }
+
+  func testCallDefaultedArguments() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+    let positions = testClient.openDocument(
+      """
+      struct Foo {
+        func makeBool(value: Bool = true) -> Bool { value }
+      }
+      func test(foo: Foo) {
+        foo.make1️⃣
+      }
+      """,
+      uri: uri
+    )
+
+    let completions = try await testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    XCTAssertEqual(completions.items.map(\.insertText), ["makeBool()", "makeBool(value: )"])
+  }
 }
 
 private func countFs(_ response: CompletionList) -> Int {


### PR DESCRIPTION
The completion items that don’t have any of the defaulted arguments disappeared when we switched to the SourceKit plugin.