### PR TITLE
Don’t poll the index for unit changes on every `filesDidChange` call

### DIFF
--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -190,6 +190,7 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
     if let semanticIndexManager {
       await semanticIndexManager.scheduleBuildGraphGenerationAndBackgroundIndexAllFiles(
         filesToIndex: nil,
+        ensureAllUnitsRegisteredInIndex: true,
         indexFilesWithUpToDateUnit: false
       )
     }


### PR DESCRIPTION
`pollForUnitChangesAndWait` is a costly operation since it iterates through all the unit files on the file system. We should only run it during initial indexing (where we might need to build the initial indexstore-db) but not for any subsequent indexing calls.