### PR TITLE
Make `testImplicitCancellationOnEdit` more robust

### DIFF
--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -897,8 +897,9 @@ final class SemanticTokensTests: XCTestCase {
     let testClient = try await TestSourceKitLSPClient(
       hooks: Hooks(preHandleRequest: { request in
         if request is DocumentSemanticTokensRequest {
-          // Sleep long enough for the edit to be handled
-          try? await Task.sleep(for: .seconds(10))
+          while !Task.isCancelled {
+            try? await Task.sleep(for: .seconds(1))
+          }
         }
       })
     )


### PR DESCRIPTION
Instead of adding an arbitrary `Task.sleep` that should give us enough time to send the `textDocument/didChange` notification, wait until we receive the cancellation from the document change.