### PR TITLE
When the build system sends an update for build targets, update the index for the files in those targets

### DIFF
--- a/Sources/BuildServerProtocol/Messages/InitializeBuildRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/InitializeBuildRequest.swift
@@ -283,11 +283,11 @@ public struct SourceKitInitializeBuildResponseData: LSPAnyCodable, Codable, Send
   public var sourceKitOptionsProvider: Bool?
 
   public init(
-    indexDatabasePath: String?,
-    indexStorePath: String?,
-    watchers: [FileSystemWatcher]?,
-    prepareProvider: Bool?,
-    sourceKitOptionsProvider: Bool?
+    indexDatabasePath: String? = nil,
+    indexStorePath: String? = nil,
+    watchers: [FileSystemWatcher]? = nil,
+    prepareProvider: Bool? = nil,
+    sourceKitOptionsProvider: Bool? = nil
   ) {
     self.indexDatabasePath = indexDatabasePath
     self.indexStorePath = indexStorePath

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -673,7 +673,7 @@ package final actor SemanticIndexManager {
   /// `indexFilesWithUpToDateUnit` is `true`.
   ///
   /// The returned task finishes when all files are indexed.
-  private func scheduleIndexing(
+  package func scheduleIndexing(
     of files: some Collection<DocumentURI> & Sendable,
     indexFilesWithUpToDateUnit: Bool,
     priority: TaskPriority?

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -42,7 +42,7 @@ import struct TSCBasic.ProcessResult
 
 private let updateIndexStoreIDForLogging = AtomicUInt32(initialValue: 1)
 
-package enum FileToIndex: CustomLogStringConvertible {
+package enum FileToIndex: CustomLogStringConvertible, Hashable {
   /// A non-header file
   case indexableFile(DocumentURI)
 

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -440,7 +440,7 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
       if let changes {
         let changedTargets = changes.map(\.target)
         sourceFiles = sourceFiles.filter {
-          !$0.value.targets.intersection(changedTargets).isEmpty
+          !$0.value.targets.isDisjoint(with: changedTargets)
         }
       }
       _ = await semanticIndexManager?.scheduleIndexing(

--- a/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceSymbolsTests.swift
@@ -76,20 +76,14 @@ class WorkspaceSymbolsTests: XCTestCase {
           SymbolInformation(
             name: "afuncFromA()",
             kind: .function,
-            location: Location(
-              uri: try project.uri(for: "PackageALib.swift"),
-              range: Range(try project.position(of: "1️⃣", in: "PackageALib.swift"))
-            )
+            location: try project.location(from: "1️⃣", to: "1️⃣", in: "PackageALib.swift")
           )
         ),
         .symbolInformation(
           SymbolInformation(
             name: "funcFromB()",
             kind: .function,
-            location: Location(
-              uri: try project.uri(for: "PackageBLib.swift"),
-              range: Range(try project.position(of: "2️⃣", in: "PackageBLib.swift"))
-            )
+            location: try project.location(from: "2️⃣", to: "2️⃣", in: "PackageBLib.swift")
           )
         ),
       ]


### PR DESCRIPTION
For each file in the changed targets, we still check whether it has an up-to-date unit based on timestamps. The important thing for this change is that we start indexing files for which we only receive build settings after an update from the build server.

While doing this, I found a couple ways in which we could clean up/improve `SemanticIndexManager`. These changes should be reviewable commit-by-commit.