### PR TITLE
Add BSP request to get the output file paths of a target

### DIFF
--- a/Contributor Documentation/BSP Extensions.md
+++ b/Contributor Documentation/BSP Extensions.md
@@ -14,13 +14,16 @@ Definition is the same as in LSP.
 
 ```ts
 export interface SourceKitInitializeBuildResponseData {
+  /** The path at which SourceKit-LSP can store its index database, aggregating data from `indexStorePath`.
+   * This should point to a directory that can be exclusively managed by SourceKit-LSP. Its exact location can be arbitrary. */
+  indexDatabasePath?: string;
+
   /** The directory to which the index store is written during compilation, ie. the path passed to `-index-store-path`
    * for `swiftc` or `clang` invocations **/
   indexStorePath?: string;
 
-  /** The path at which SourceKit-LSP can store its index database, aggregating data from `indexStorePath`.
-   * This should point to a directory that can be exclusively managed by SourceKit-LSP. Its exact location can be arbitrary. */
-  indexDatabasePath?: string;
+  /** Whether the server implements the `buildTarget/outputPaths` request. */
+  outputPathsProvider?: bool;
 
   /** Whether the build server supports the `buildTarget/prepare` request */
   prepareProvider?: bool;
@@ -43,6 +46,35 @@ If `data` contains a string value for the `workDoneProgressTitle` key, then the 
 
 `changes` can be `null` to indicate that all targets have changed.
 
+## `buildTarget/outputPaths`
+
+For all the source files in this target, the output paths that are used during indexing, ie. the `-index-unit-output-path` for the file, if it is specified in the compiler arguments or the file that is passed as `-o`, if `-index-unit-output-path` is not specified.
+
+ server communicates during the initialize handshake whether this method is supported or not by setting `outputPathsProvider: true` in `SourceKitInitializeBuildResponseData`.
+
+- method: `buildTarget/outputPaths`
+- params: `OutputPathsParams`
+- result: `OutputPathsResult`
+
+```ts
+export interface BuildTargetOutputPathsParams {
+  /** A list of build targets to get the output paths for. */
+  targets: BuildTargetIdentifier[];
+}
+
+export interface BuildTargetOutputPathsItem {
+  /** The target these output file paths are for. */
+  target: BuildTargetIdentifier;
+
+  /** The output paths for all source files in this target. */
+  outputPaths: string[];
+}
+
+export interface BuildTargetOutputPathsResult {
+  items: BuildTargetOutputPathsItem[];
+}
+```
+
 ## `buildTarget/prepare`
 
 The prepare build target request is sent from the client to the server to prepare the given list of build targets for editor functionality.
@@ -53,6 +85,7 @@ The server communicates during the initialize handshake whether this method is s
 
 - method: `buildTarget/prepare`
 - params: `PrepareParams`
+- result: `void`
 
 ```ts
 export interface PrepareParams {

--- a/Contributor Documentation/BSP Extensions.md
+++ b/Contributor Documentation/BSP Extensions.md
@@ -50,7 +50,9 @@ If `data` contains a string value for the `workDoneProgressTitle` key, then the 
 
 For all the source files in this target, the output paths that are used during indexing, ie. the `-index-unit-output-path` for the file, if it is specified in the compiler arguments or the file that is passed as `-o`, if `-index-unit-output-path` is not specified.
 
- server communicates during the initialize handshake whether this method is supported or not by setting `outputPathsProvider: true` in `SourceKitInitializeBuildResponseData`.
+This allows SourceKit-LSP to remove index entries for source files that are removed from a target but remain present on disk.
+
+The server communicates during the initialize handshake whether this method is supported or not by setting `outputPathsProvider: true` in `SourceKitInitializeBuildResponseData`.
 
 - method: `buildTarget/outputPaths`
 - params: `OutputPathsParams`

--- a/Sources/BuildServerProtocol/CMakeLists.txt
+++ b/Sources/BuildServerProtocol/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(BuildServerProtocol STATIC
   Messages.swift
 
   Messages/BuildShutdownRequest.swift
+  Messages/BuildTargetOutputPathsRequest.swift
   Messages/BuildTargetPrepareRequest.swift
   Messages/BuildTargetSourcesRequest.swift
   Messages/InitializeBuildRequest.swift

--- a/Sources/BuildServerProtocol/Messages.swift
+++ b/Sources/BuildServerProtocol/Messages.swift
@@ -18,6 +18,7 @@ import LanguageServerProtocol
 
 fileprivate let requestTypes: [_RequestType.Type] = [
   BuildShutdownRequest.self,
+  BuildTargetOutputPathsRequest.self,
   BuildTargetPrepareRequest.self,
   BuildTargetSourcesRequest.self,
   CreateWorkDoneProgressRequest.self,

--- a/Sources/BuildServerProtocol/Messages/BuildTargetOutputPathsRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/BuildTargetOutputPathsRequest.swift
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=6)
+public import LanguageServerProtocol
+#else
+import LanguageServerProtocol
+#endif
+
+/// For all the source files in this target, the output paths that are used during indexing, ie. the
+/// `-index-unit-output-path` for the file, if it is specified in the compiler arguments or the file that is passed as
+/// `-o`, if `-index-unit-output-path` is not specified.
+public struct BuildTargetOutputPathsRequest: RequestType, Equatable, Hashable {
+  public static let method: String = "buildTarget/outputPaths"
+
+  public typealias Response = BuildTargetOutputPathsResponse
+
+  /// A list of build targets to get the output paths for.
+  public var targets: [BuildTargetIdentifier]
+
+  public init(targets: [BuildTargetIdentifier]) {
+    self.targets = targets
+  }
+}
+
+public struct BuildTargetOutputPathsItem: Codable, Sendable {
+  /// The target these output file paths are for.
+  public var target: BuildTargetIdentifier
+
+  /// The output paths for all source files in this target.
+  public var outputPaths: [String]
+
+  public init(target: BuildTargetIdentifier, outputPaths: [String]) {
+    self.target = target
+    self.outputPaths = outputPaths
+  }
+}
+
+public struct BuildTargetOutputPathsResponse: ResponseType {
+  public var items: [BuildTargetOutputPathsItem]
+
+  public init(items: [BuildTargetOutputPathsItem]) {
+    self.items = items
+  }
+}

--- a/Sources/BuildServerProtocol/Messages/InitializeBuildRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/InitializeBuildRequest.swift
@@ -273,8 +273,8 @@ public struct SourceKitInitializeBuildResponseData: LSPAnyCodable, Codable, Send
   /// The path at which SourceKit-LSP can store its index database, aggregating data from `indexStorePath`
   public var indexStorePath: String?
 
-  /// The files to watch for changes.
-  public var watchers: [FileSystemWatcher]?
+  /// Whether the server implements the `buildTarget/outputPaths` request.
+  public var outputPathsProvider: Bool?
 
   /// Whether the build server supports the `buildTarget/prepare` request.
   public var prepareProvider: Bool?
@@ -282,6 +282,10 @@ public struct SourceKitInitializeBuildResponseData: LSPAnyCodable, Codable, Send
   /// Whether the server implements the `textDocument/sourceKitOptions` request.
   public var sourceKitOptionsProvider: Bool?
 
+  /// The files to watch for changes.
+  public var watchers: [FileSystemWatcher]?
+
+  @available(*, deprecated, message: "Use initializer with alphabetical order of parameters")
   public init(
     indexDatabasePath: String? = nil,
     indexStorePath: String? = nil,
@@ -294,6 +298,22 @@ public struct SourceKitInitializeBuildResponseData: LSPAnyCodable, Codable, Send
     self.watchers = watchers
     self.prepareProvider = prepareProvider
     self.sourceKitOptionsProvider = sourceKitOptionsProvider
+  }
+
+  public init(
+    indexDatabasePath: String? = nil,
+    indexStorePath: String? = nil,
+    outputPathsProvider: Bool? = nil,
+    prepareProvider: Bool? = nil,
+    sourceKitOptionsProvider: Bool? = nil,
+    watchers: [FileSystemWatcher]? = nil
+  ) {
+    self.indexDatabasePath = indexDatabasePath
+    self.indexStorePath = indexStorePath
+    self.outputPathsProvider = outputPathsProvider
+    self.prepareProvider = prepareProvider
+    self.sourceKitOptionsProvider = sourceKitOptionsProvider
+    self.watchers = watchers
   }
 
   public init?(fromLSPDictionary dictionary: [String: LanguageServerProtocol.LSPAny]) {

--- a/Sources/BuildServerProtocol/Messages/InitializeBuildRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/InitializeBuildRequest.swift
@@ -323,14 +323,17 @@ public struct SourceKitInitializeBuildResponseData: LSPAnyCodable, Codable, Send
     if case .string(let indexStorePath) = dictionary[CodingKeys.indexStorePath.stringValue] {
       self.indexStorePath = indexStorePath
     }
-    if let watchers = dictionary[CodingKeys.watchers.stringValue] {
-      self.watchers = [FileSystemWatcher](fromLSPArray: watchers)
+    if case .bool(let outputPathsProvider) = dictionary[CodingKeys.outputPathsProvider.stringValue] {
+      self.outputPathsProvider = outputPathsProvider
     }
     if case .bool(let prepareProvider) = dictionary[CodingKeys.prepareProvider.stringValue] {
       self.prepareProvider = prepareProvider
     }
     if case .bool(let sourceKitOptionsProvider) = dictionary[CodingKeys.sourceKitOptionsProvider.stringValue] {
       self.sourceKitOptionsProvider = sourceKitOptionsProvider
+    }
+    if let watchers = dictionary[CodingKeys.watchers.stringValue] {
+      self.watchers = [FileSystemWatcher](fromLSPArray: watchers)
     }
   }
 
@@ -342,14 +345,17 @@ public struct SourceKitInitializeBuildResponseData: LSPAnyCodable, Codable, Send
     if let indexStorePath {
       result[CodingKeys.indexStorePath.stringValue] = .string(indexStorePath)
     }
-    if let watchers {
-      result[CodingKeys.watchers.stringValue] = watchers.encodeToLSPAny()
+    if let outputPathsProvider {
+      result[CodingKeys.outputPathsProvider.stringValue] = .bool(outputPathsProvider)
     }
     if let prepareProvider {
       result[CodingKeys.prepareProvider.stringValue] = .bool(prepareProvider)
     }
     if let sourceKitOptionsProvider {
       result[CodingKeys.sourceKitOptionsProvider.stringValue] = .bool(sourceKitOptionsProvider)
+    }
+    if let watchers {
+      result[CodingKeys.watchers.stringValue] = watchers.encodeToLSPAny()
     }
     return .dictionary(result)
   }

--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -631,7 +631,7 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
         // All targets might have changed
         return true
       }
-      return !updatedTargets.intersection(cacheKey.targets).isEmpty
+      return !updatedTargets.isDisjoint(with: cacheKey.targets)
     }
     self.cachedSourceFilesAndDirectories.clearAll(isolation: self)
 
@@ -1167,7 +1167,17 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
     return response.items
   }
 
-  package func outputPath(from targets: Set<BuildTargetIdentifier>) async throws -> [String] {
+  /// Return the output paths for all source files known to the build server.
+  ///
+  /// See `BuildTargetOutputPathsRequest` for details.
+  package func outputPathInAllTargets() async throws -> [String] {
+    return try await outputPaths(in: Set(buildTargets().map(\.key)))
+  }
+
+  /// For all source files in the given targets, return their output file paths.
+  ///
+  /// See `BuildTargetOutputPathsRequest` for details.
+  package func outputPaths(in targets: Set<BuildTargetIdentifier>) async throws -> [String] {
     guard let buildSystemAdapter = await buildSystemAdapterAfterInitialized, !targets.isEmpty else {
       return []
     }

--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -379,6 +379,8 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
 
   private var cachedTargetSources = RequestCache<BuildTargetSourcesRequest>()
 
+  private var cachedTargetOutputPaths = RequestCache<BuildTargetOutputPathsRequest>()
+
   /// `SourceFilesAndDirectories` is a global property that only gets reset when the build targets change and thus
   /// has no real key.
   private struct SourceFilesAndDirectoriesKey: Hashable {}
@@ -618,6 +620,13 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
     }
     self.cachedBuildTargets.clearAll(isolation: self)
     self.cachedTargetSources.clear(isolation: self) { cacheKey in
+      guard let updatedTargets else {
+        // All targets might have changed
+        return true
+      }
+      return !updatedTargets.intersection(cacheKey.targets).isEmpty
+    }
+    self.cachedTargetOutputPaths.clear(isolation: self) { cacheKey in
       guard let updatedTargets else {
         // All targets might have changed
         return true
@@ -1156,6 +1165,32 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
       try await buildSystemAdapter.send(request)
     }
     return response.items
+  }
+
+  package func outputPath(from targets: Set<BuildTargetIdentifier>) async throws -> [String] {
+    guard let buildSystemAdapter = await buildSystemAdapterAfterInitialized, !targets.isEmpty else {
+      return []
+    }
+
+    let request = BuildTargetOutputPathsRequest(targets: targets.sorted { $0.uri.stringValue < $1.uri.stringValue })
+
+    // If we have a cached request for a superset of the targets, serve the result from that cache entry.
+    let fromSuperset = await orLog("Getting output paths from superset request") {
+      try await cachedTargetOutputPaths.getDerived(
+        isolation: self,
+        request,
+        canReuseKey: { targets.isSubset(of: $0.targets) },
+        transform: { BuildTargetOutputPathsResponse(items: $0.items.filter { targets.contains($0.target) }) }
+      )
+    }
+    if let fromSuperset {
+      return fromSuperset.items.flatMap(\.outputPaths)
+    }
+
+    let response = try await cachedTargetOutputPaths.get(request, isolation: self) { request in
+      try await buildSystemAdapter.send(request)
+    }
+    return response.items.flatMap(\.outputPaths)
   }
 
   /// Returns all source files in the project.

--- a/Sources/BuildSystemIntegration/BuildSystemMessageDependencyTracker.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemMessageDependencyTracker.swift
@@ -90,6 +90,8 @@ package enum BuildSystemMessageDependencyTracker: QueueBasedMessageHandlerDepend
     switch request {
     case is BuildShutdownRequest:
       self = .stateChange
+    case is BuildTargetOutputPathsRequest:
+      self = .stateRead
     case is BuildTargetPrepareRequest:
       self = .stateRead
     case is BuildTargetSourcesRequest:

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
@@ -44,15 +44,18 @@ package protocol BuiltInBuildSystem: AnyObject, Sendable {
   /// The path to put the index database, if any.
   var indexDatabasePath: URL? { get async }
 
-  /// Whether the build system is capable of preparing a target for indexing, ie. if the `prepare` methods has been
-  /// implemented.
-  var supportsPreparation: Bool { get }
+  /// Whether the build system is capable of preparing a target for indexing and determining the output paths for the
+  /// target, ie. whether the `prepare` and `buildTargetOutputPaths` methods have been implemented.
+  var supportsPreparationAndOutputPaths: Bool { get }
 
   /// Returns all targets in the build system
   func buildTargets(request: WorkspaceBuildTargetsRequest) async throws -> WorkspaceBuildTargetsResponse
 
   /// Returns all the source files in the given targets
   func buildTargetSources(request: BuildTargetSourcesRequest) async throws -> BuildTargetSourcesResponse
+
+  /// Returns all the output paths for the source files in the given targets.
+  func buildTargetOutputPaths(request: BuildTargetOutputPathsRequest) async throws -> BuildTargetOutputPathsResponse
 
   /// Called when files in the project change.
   func didChangeWatchedFiles(notification: OnWatchedFilesDidChangeNotification) async

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
@@ -100,9 +100,10 @@ actor BuiltInBuildSystemAdapter: QueueBasedMessageHandler {
         indexStorePath: await orLog("getting index store file path") {
           try await underlyingBuildSystem.indexStorePath?.filePath
         },
-        watchers: await underlyingBuildSystem.fileWatchers,
-        prepareProvider: underlyingBuildSystem.supportsPreparation,
-        sourceKitOptionsProvider: true
+        outputPathsProvider: underlyingBuildSystem.supportsPreparationAndOutputPaths,
+        prepareProvider: underlyingBuildSystem.supportsPreparationAndOutputPaths,
+        sourceKitOptionsProvider: true,
+        watchers: await underlyingBuildSystem.fileWatchers
       ).encodeToLSPAny()
     )
   }
@@ -130,6 +131,8 @@ actor BuiltInBuildSystemAdapter: QueueBasedMessageHandler {
     switch request {
     case let request as RequestAndReply<BuildShutdownRequest>:
       await request.reply { VoidResponse() }
+    case let request as RequestAndReply<BuildTargetOutputPathsRequest>:
+      await request.reply { try await underlyingBuildSystem.buildTargetOutputPaths(request: request.params) }
     case let request as RequestAndReply<BuildTargetPrepareRequest>:
       await request.reply { try await underlyingBuildSystem.prepare(request: request.params) }
     case let request as RequestAndReply<BuildTargetSourcesRequest>:

--- a/Sources/BuildSystemIntegration/FixedCompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/FixedCompilationDatabaseBuildSystem.swift
@@ -66,7 +66,7 @@ package actor FixedCompilationDatabaseBuildSystem: BuiltInBuildSystem {
     indexStorePath?.deletingLastPathComponent().appendingPathComponent("IndexDatabase")
   }
 
-  package nonisolated var supportsPreparation: Bool { false }
+  package nonisolated var supportsPreparationAndOutputPaths: Bool { false }
 
   private static func parseCompileFlags(at configPath: URL) throws -> [String] {
     let fileContents: String = try String(contentsOf: configPath, encoding: .utf8)
@@ -121,7 +121,13 @@ package actor FixedCompilationDatabaseBuildSystem: BuiltInBuildSystem {
   }
 
   package func prepare(request: BuildTargetPrepareRequest) async throws -> VoidResponse {
-    throw PrepareNotSupportedError()
+    throw ResponseError.methodNotFound(BuildTargetPrepareRequest.method)
+  }
+
+  package func buildTargetOutputPaths(
+    request: BuildTargetOutputPathsRequest
+  ) async throws -> BuildTargetOutputPathsResponse {
+    throw ResponseError.methodNotFound(BuildTargetOutputPathsRequest.method)
   }
 
   package func sourceKitOptions(

--- a/Sources/BuildSystemIntegration/JSONCompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/JSONCompilationDatabaseBuildSystem.swift
@@ -86,7 +86,7 @@ package actor JSONCompilationDatabaseBuildSystem: BuiltInBuildSystem {
     indexStorePath?.deletingLastPathComponent().appendingPathComponent("IndexDatabase")
   }
 
-  package nonisolated var supportsPreparation: Bool { false }
+  package nonisolated var supportsPreparationAndOutputPaths: Bool { false }
 
   package init(
     configPath: URL,
@@ -148,7 +148,13 @@ package actor JSONCompilationDatabaseBuildSystem: BuiltInBuildSystem {
   }
 
   package func prepare(request: BuildTargetPrepareRequest) async throws -> VoidResponse {
-    throw PrepareNotSupportedError()
+    throw ResponseError.methodNotFound(BuildTargetPrepareRequest.method)
+  }
+
+  package func buildTargetOutputPaths(
+    request: BuildTargetOutputPathsRequest
+  ) async throws -> BuildTargetOutputPathsResponse {
+    throw ResponseError.methodNotFound(BuildTargetOutputPathsRequest.method)
   }
 
   package func sourceKitOptions(

--- a/Sources/BuildSystemIntegration/LegacyBuildServerBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/LegacyBuildServerBuildSystem.swift
@@ -136,7 +136,7 @@ actor LegacyBuildServerBuildSystem: MessageHandler, BuiltInBuildSystem {
     connectionToSourceKitLSP.send(OnBuildTargetDidChangeNotification(changes: nil))
   }
 
-  package nonisolated var supportsPreparation: Bool { false }
+  package nonisolated var supportsPreparationAndOutputPaths: Bool { false }
 
   package func buildTargets(request: WorkspaceBuildTargetsRequest) async throws -> WorkspaceBuildTargetsResponse {
     return WorkspaceBuildTargetsResponse(targets: [
@@ -168,7 +168,13 @@ actor LegacyBuildServerBuildSystem: MessageHandler, BuiltInBuildSystem {
   package func didChangeWatchedFiles(notification: OnWatchedFilesDidChangeNotification) {}
 
   package func prepare(request: BuildTargetPrepareRequest) async throws -> VoidResponse {
-    throw PrepareNotSupportedError()
+    throw ResponseError.methodNotFound(BuildTargetPrepareRequest.method)
+  }
+
+  package func buildTargetOutputPaths(
+    request: BuildTargetOutputPathsRequest
+  ) async throws -> BuildTargetOutputPathsResponse {
+    throw ResponseError.methodNotFound(BuildTargetOutputPathsRequest.method)
   }
 
   package func sourceKitOptions(

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -466,7 +466,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
     signposter.endInterval("Reloading package", state)
   }
 
-  package nonisolated var supportsPreparationAndOutputPaths: Bool { true }
+  package nonisolated var supportsPreparationAndOutputPaths: Bool { options.backgroundIndexingOrDefault }
 
   package var buildPath: URL {
     return destinationBuildParameters.buildPath.asURL
@@ -489,11 +489,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
 
   /// Return the compiler arguments for the given source file within a target, making any necessary adjustments to
   /// account for differences in the SwiftPM versions being linked into SwiftPM and being installed in the toolchain.
-  private func compilerArguments(
-    for file: DocumentURI,
-    in buildTarget: any SwiftBuildTarget,
-    language: Language
-  ) async throws -> [String] {
+  private func compilerArguments(for file: DocumentURI, in buildTarget: any SwiftBuildTarget) async throws -> [String] {
     guard let fileURL = file.fileURL else {
       struct NonFileURIError: Swift.Error, CustomStringConvertible {
         let uri: DocumentURI
@@ -638,11 +634,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
       // getting its compiler arguments and then patching up the compiler arguments by replacing the substitute file
       // with the `.cpp` file.
       let buildSettings = FileBuildSettings(
-        compilerArguments: try await compilerArguments(
-          for: DocumentURI(substituteFile),
-          in: swiftPMTarget,
-          language: request.language
-        ),
+        compilerArguments: try await compilerArguments(for: DocumentURI(substituteFile), in: swiftPMTarget),
         workingDirectory: try projectRoot.filePath,
         language: request.language
       ).patching(newFile: DocumentURI(try path.asURL.realpath), originalFile: DocumentURI(substituteFile))
@@ -653,11 +645,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
     }
 
     return TextDocumentSourceKitOptionsResponse(
-      compilerArguments: try await compilerArguments(
-        for: request.textDocument.uri,
-        in: swiftPMTarget,
-        language: request.language
-      ),
+      compilerArguments: try await compilerArguments(for: request.textDocument.uri, in: swiftPMTarget),
       workingDirectory: try projectRoot.filePath
     )
   }

--- a/Sources/SemanticIndex/IndexHooks.swift
+++ b/Sources/SemanticIndex/IndexHooks.swift
@@ -28,6 +28,10 @@ package protocol IndexInjector: Sendable {
     delegate: IndexDelegate,
     prefixMappings: [PathMapping]
   ) async throws -> IndexStoreDB
+
+  /// Whether the injected index uses explicit output paths and whether SourceKit-LSP should thus set the unit output
+  /// paths on the index as they change.
+  var usesExplicitOutputPaths: Bool { get async }
 }
 
 /// Callbacks that allow inspection of internal state modifications during testing.

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -347,8 +347,6 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
         "-index-file-path", uri.pseudoPath,
         // batch mode is not compatible with -index-file
         "-disable-batch-mode",
-        // Fake an output path so that we get a different unit file for every Swift file we background index
-        "-index-unit-output-path", uri.pseudoPath + ".o",
       ]
     args = try await addOrReplaceIndexStorePath(in: args, for: uri)
 


### PR DESCRIPTION
We can then use this request to exclude units from the index that are no longer part of any targets.