### PR TITLE
Small improvements to `workspace/_sourceKitOptions` request

### DIFF
--- a/Sources/LanguageServerProtocol/Requests/SourceKitOptionsRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/SourceKitOptionsRequest.swift
@@ -19,7 +19,7 @@
 /// **(LSP Extension)**.
 public struct SourceKitOptionsRequest: RequestType, Hashable {
   public static let method: String = "workspace/_sourceKitOptions"
-  public typealias Response = SourceKitOptionsResponse?
+  public typealias Response = SourceKitOptionsResponse
 
   /// The document to get options for
   public var textDocument: TextDocumentIdentifier

--- a/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
+++ b/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
@@ -223,7 +223,7 @@ package enum MessageHandlingDependencyTracker: QueueBasedMessageHandlerDependenc
     case is ShutdownRequest:
       self = .globalConfigurationChange
     case is SourceKitOptionsRequest:
-      self = .workspaceRequest
+      self = .freestanding
     case is TriggerReindexRequest:
       self = .globalConfigurationChange
     case is TypeHierarchySubtypesRequest:

--- a/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
@@ -421,7 +421,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
         allowFallbackSettings: false
       )
     )
-    XCTAssertEqual(options?.data, LSPAny.dictionary(["custom": .string("value")]))
+    XCTAssertEqual(options.data, LSPAny.dictionary(["custom": .string("value")]))
   }
 
   func testBuildSettingsForFilePartOfMultipleTargets() async throws {


### PR DESCRIPTION
- Make response of `workspace/_sourceKitOptions` request non-optional
  - The response was not specified as being optional and shouldn’t be.
- Mark `workspace/_sourceKitOptions` as freestanding
  - The request doesn’t depend on any document state, so it should be freestanding instead of `workspaceRequest`.