### PR TITLE
Add logging for requests handled by the SourceKit plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -334,6 +334,7 @@ var targets: [Target] = [
     swiftSettings: globalSwiftSettings + lspLoggingSwiftSettings + [
       // We can't depend on swift-crypto in the plugin because we can't module-alias it due to https://github.com/swiftlang/swift-package-manager/issues/8119
       .define("NO_CRYPTO_DEPENDENCY"),
+      .define("SKLOGGING_FOR_PLUGIN"),
       .unsafeFlags([
         "-module-alias", "SwiftExtensions=SwiftExtensionsForPlugin",
       ]),

--- a/Sources/SKLogging/LoggingScope.swift
+++ b/Sources/SKLogging/LoggingScope.swift
@@ -21,7 +21,11 @@ package final class LoggingScope {
 
   /// The name of the current logging subsystem.
   package static var subsystem: String {
+    #if SKLOGGING_FOR_PLUGIN
+    return _subsystem ?? "org.swift.sourcekit-lsp.plugin"
+    #else
     return _subsystem ?? "org.swift.sourcekit-lsp"
+    #endif
   }
 
   /// The name of the current logging scope.

--- a/Sources/SwiftSourceKitPlugin/SKDRequestDictionaryReader.swift
+++ b/Sources/SwiftSourceKitPlugin/SKDRequestDictionaryReader.swift
@@ -13,13 +13,33 @@
 import Csourcekitd
 import SourceKitD
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(CRT)
+import CRT
+#elseif canImport(Bionic)
+import Bionic
+#endif
+
 /// Provide getters to get values of a sourcekitd request dictionary.
 ///
 /// This is not part of the `SourceKitD` module because it uses `SourceKitD.servicePluginAPI` which must not be accessed
 /// outside of the service plugin.
-final class SKDRequestDictionaryReader: Sendable {
+final class SKDRequestDictionaryReader: Sendable, CustomStringConvertible {
   private nonisolated(unsafe) let dict: sourcekitd_api_object_t
   let sourcekitd: SourceKitD
+
+  var description: String {
+    guard let description = sourcekitd.api.request_description_copy(dict) else {
+      return "getting request description failed"
+    }
+    defer { free(description) }
+    return String(cString: description)
+  }
 
   /// Creates an `SKDRequestDictionary` that essentially provides a view into the given opaque
   /// `sourcekitd_api_object_t`.

--- a/Sources/SwiftSourceKitPlugin/SKDResponse.swift
+++ b/Sources/SwiftSourceKitPlugin/SKDResponse.swift
@@ -74,7 +74,7 @@ final class SKDResponse: CustomStringConvertible, Sendable {
   }
 
   public var description: String {
-    let cstr = sourcekitd.api.request_description_copy(value)!
+    let cstr = sourcekitd.api.response_description_copy(value)!
     defer { free(cstr) }
     return String(cString: cstr)
   }

--- a/Sources/SwiftSourceKitPlugin/SourceKitDWrappers.swift
+++ b/Sources/SwiftSourceKitPlugin/SourceKitDWrappers.swift
@@ -31,4 +31,8 @@ struct RequestHandle: Sendable {
     }
     self.handle = handle
   }
+
+  var numericValue: Int {
+    Int(bitPattern: handle)
+  }
 }

--- a/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
+++ b/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
@@ -272,7 +272,6 @@ final class SwiftSourceKitPluginTests: XCTestCase {
   }
 
   func testCancellation() async throws {
-    try XCTSkipIf(true, "rdar://145905708")
     try await SkipUnless.sourcekitdSupportsPlugin()
     let sourcekitd = try await getSourceKitD()
     let path = scratchFilePath()


### PR DESCRIPTION
I couldn’t figure out what might be causing `SwiftSourceKitPluginTests.testCancellation` to start failing late last week. But this logging should be able to tell us whether cancellation is getting lost in the plugin handling or whether it isn’t getting handled properly inside sourcekitd to steer further investigation.