### PR TITLE
Allow a build system to use standardized paths while indexstore-db return realpaths

### DIFF
--- a/Sources/BuildSystemIntegration/MainFilesProvider.swift
+++ b/Sources/BuildSystemIntegration/MainFilesProvider.swift
@@ -18,13 +18,15 @@ import LanguageServerProtocol
 
 /// A type that can provide the set of main files that include a particular file.
 package protocol MainFilesProvider: Sendable {
-  /// Returns the set of main files that contain the given file.
+  /// Returns all the files that (transitively) include the header file at the given path.
   ///
-  /// For example,
+  /// If `crossLanguage` is set to `true`, Swift files that import a header through a module will also be reported.
+  ///
+  /// ### Examples
   ///
   /// ```
   /// mainFilesContainingFile("foo.cpp") == Set(["foo.cpp"])
   /// mainFilesContainingFile("foo.h") == Set(["foo.cpp", "bar.cpp"])
   /// ```
-  func mainFilesContainingFile(_: DocumentURI) async -> Set<DocumentURI>
+  func mainFiles(containing uri: DocumentURI, crossLanguage: Bool) async -> Set<DocumentURI>
 }

--- a/Sources/SemanticIndex/CheckedIndex.swift
+++ b/Sources/SemanticIndex/CheckedIndex.swift
@@ -151,19 +151,6 @@ package final class CheckedIndex {
     return index.unitTests(referencedByMainFiles: mainFilePaths).filter { checker.isUpToDate($0.location) }
   }
 
-  /// Returns all the files that (transitively) include the header file at the given path.
-  ///
-  /// If `crossLanguage` is set to `true`, Swift files that import a header through a module will also be reported.
-  package func mainFilesContainingFile(uri: DocumentURI, crossLanguage: Bool = false) -> [DocumentURI] {
-    return index.mainFilesContainingFile(path: uri.pseudoPath, crossLanguage: crossLanguage).compactMap {
-      let uri = DocumentURI(filePath: $0, isDirectory: false)
-      guard checker.indexHasUpToDateUnit(for: uri, mainFile: nil, index: self.index) else {
-        return nil
-      }
-      return uri
-    }
-  }
-
   /// Returns all unit test symbols in the index.
   package func unitTests() -> [SymbolOccurrence] {
     return index.unitTests().filter { checker.isUpToDate($0.location) }

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -327,7 +327,7 @@ private final actor ManualMainFilesProvider: MainFilesProvider {
     self.mainFiles[file] = mainFiles
   }
 
-  func mainFilesContainingFile(_ file: DocumentURI) -> Set<DocumentURI> {
+  func mainFiles(containing file: DocumentURI, crossLanguage: Bool) -> Set<DocumentURI> {
     if let result = mainFiles[file] {
       return result
     }


### PR DESCRIPTION
On Darwin platforms, this fixes the following problem: indexstore-db by itself returns realpaths but the build system might be using standardized Darwin paths (eg. realpath is `/private/tmp` but the standardized path is `/tmp`). Because of this, when inferring the main file for a file, we might get a URI that the build system doesn’t know about. To fix this, if the realpath that indexstore-db returns could not be found in the build system's source files but the standardized path is part of the source files, use the standardized path instead.