### PR TITLE
Add log message if we can’t infer the language server type for a document that was opened

### DIFF
--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -494,6 +494,7 @@ package actor SourceKitLSPServer {
     in workspace: Workspace
   ) async -> LanguageService? {
     guard let serverType = LanguageServerType(language: language) else {
+      logger.error("Unable to infer language server type for language '\(language)'")
       return nil
     }
     // Pick the first language service that can handle this workspace.


### PR DESCRIPTION
Motivated by https://github.com/swiftlang/sourcekit-lsp/issues/2028#issuecomment-2702162160.