### PR TITLE
Poll index in `testBuildSystemUsesStandardizedFileUrlsInsteadOfRealpath`

### DIFF
--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -1368,6 +1368,7 @@ final class WorkspaceTests: XCTestCase {
       options: .testDefault(experimentalFeatures: [.sourceKitOptionsRequest]),
       workspaceFolders: [WorkspaceFolder(uri: DocumentURI(scratchDirectory), name: nil)]
     )
+    try await testClient.send(PollIndexRequest())
 
     // Check that we can infer build settings for the header from its main file. indexstore-db stores this main file
     // path as `/private/tmp` while the build system only knows about it as `/tmp`.


### PR DESCRIPTION
We need to make sure that all unit files are read into indexstore-db so that we know about the unit file that allows us to map from header to main file.

Fixes rdar://146392120