### PR TITLE
Require Swift 6 to build SourceKit-LSP

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 
 import Foundation
 import PackageDescription
@@ -699,9 +699,10 @@ let package = Package(
   products: products,
   dependencies: dependencies,
   targets: targets,
-  swiftLanguageVersions: [.v5, .version("6")]
+  swiftLanguageModes: [.v6]
 )
 
+@MainActor
 func swiftSyntaxDependencies(_ names: [String]) -> [Target.Dependency] {
   if buildDynamicSwiftSyntaxLibrary {
     return [.product(name: "_SwiftSyntaxDynamic", package: "swift-syntax")]
@@ -710,6 +711,7 @@ func swiftSyntaxDependencies(_ names: [String]) -> [Target.Dependency] {
   }
 }
 
+@MainActor
 func swiftPMDependency<T>(_ values: [T]) -> [T] {
   if noSwiftPMDependency {
     return []

--- a/Sources/BuildServerProtocol/Messages.swift
+++ b/Sources/BuildServerProtocol/Messages.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 fileprivate let requestTypes: [_RequestType.Type] = [
   BuildShutdownRequest.self,

--- a/Sources/BuildServerProtocol/Messages/BuildShutdownRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/BuildShutdownRequest.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// Like the language server protocol, the shutdown build request is
 /// sent from the client to the server. It asks the server to shut down,

--- a/Sources/BuildServerProtocol/Messages/BuildTargetOutputPathsRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/BuildTargetOutputPathsRequest.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// For all the source files in this target, the output paths that are used during indexing, ie. the
 /// `-index-unit-output-path` for the file, if it is specified in the compiler arguments or the file that is passed as

--- a/Sources/BuildServerProtocol/Messages/BuildTargetPrepareRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/BuildTargetPrepareRequest.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 public typealias OriginId = String
 

--- a/Sources/BuildServerProtocol/Messages/BuildTargetSourcesRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/BuildTargetSourcesRequest.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// The build target sources request is sent from the client to the server to
 /// query for the list of text documents and directories that belong to a

--- a/Sources/BuildServerProtocol/Messages/InitializeBuildRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/InitializeBuildRequest.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// Like the language server protocol, the initialize request is sent
 /// as the first request from the client to the server. If the server

--- a/Sources/BuildServerProtocol/Messages/OnBuildExitNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/OnBuildExitNotification.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// Like the language server protocol, a notification to ask the
 /// server to exit its process. The server should exit with success

--- a/Sources/BuildServerProtocol/Messages/OnBuildInitializedNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/OnBuildInitializedNotification.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// Like the language server protocol, the initialized notification is sent from the client to the server after the client received the result of the initialize request but before the client is sending any other request or notification to the server. The server can use the initialized notification for example to initialize intensive computation such as dependency resolution or compilation. The initialized notification may only be sent once.
 public struct OnBuildInitializedNotification: NotificationType {

--- a/Sources/BuildServerProtocol/Messages/OnBuildLogMessageNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/OnBuildLogMessageNotification.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// The log message notification is sent from a server to a client to ask the client to log a particular message in its console.
 ///

--- a/Sources/BuildServerProtocol/Messages/OnBuildTargetDidChangeNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/OnBuildTargetDidChangeNotification.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// The build target changed notification is sent from the server to the client
 /// to signal a change in a build target. The server communicates during the

--- a/Sources/BuildServerProtocol/Messages/OnWatchedFilesDidChangeNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/OnWatchedFilesDidChangeNotification.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// Notification sent from SourceKit-LSP to the build system to indicate that files within the project have been modified.
 public typealias OnWatchedFilesDidChangeNotification = LanguageServerProtocol.DidChangeWatchedFilesNotification

--- a/Sources/BuildServerProtocol/Messages/RegisterForChangeNotifications.swift
+++ b/Sources/BuildServerProtocol/Messages/RegisterForChangeNotifications.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// The register for changes request is sent from the language
 /// server to the build server to register or unregister for

--- a/Sources/BuildServerProtocol/Messages/TaskFinishNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/TaskFinishNotification.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
-public import LanguageServerProtocol
 public import Foundation
-#else
-import LanguageServerProtocol
-import Foundation
-#endif
+public import LanguageServerProtocol
 
 /// A `build/taskFinish` notification must always be sent after a `build/taskStart`` with the same `taskId` was sent.
 public struct TaskFinishNotification: NotificationType {

--- a/Sources/BuildServerProtocol/Messages/TaskProgressNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/TaskProgressNotification.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
-public import LanguageServerProtocol
 public import Foundation
-#else
-import LanguageServerProtocol
-import Foundation
-#endif
+public import LanguageServerProtocol
 
 /// After a `taskStart` and before `taskFinish` for a `taskId`, the server may send any number of progress
 /// notifications.

--- a/Sources/BuildServerProtocol/Messages/TaskStartNotification.swift
+++ b/Sources/BuildServerProtocol/Messages/TaskStartNotification.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
-public import LanguageServerProtocol
 public import Foundation
-#else
-import LanguageServerProtocol
-import Foundation
-#endif
+public import LanguageServerProtocol
 
 /// The BSP server can inform the client on the execution state of any task in the build tool.
 /// The execution of some tasks, such as compilation or tests, must always be reported by the server.

--- a/Sources/BuildServerProtocol/Messages/TextDocumentSourceKitOptionsRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/TextDocumentSourceKitOptionsRequest.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// The `TextDocumentSourceKitOptionsRequest` request is sent from the client to the server to query for the list of
 /// compiler options necessary to compile this file in the given target.

--- a/Sources/BuildServerProtocol/Messages/WorkspaceBuildTargetsRequest.swift
+++ b/Sources/BuildServerProtocol/Messages/WorkspaceBuildTargetsRequest.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// The workspace build targets request is sent from the client to the server to
 /// ask for the list of all available build targets in the workspace.

--- a/Sources/BuildServerProtocol/Messages/WorkspaceWaitForBuildSystemUpdates.swift
+++ b/Sources/BuildServerProtocol/Messages/WorkspaceWaitForBuildSystemUpdates.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// This request is a no-op and doesn't have any effects.
 ///

--- a/Sources/BuildServerProtocol/SupportTypes/BuildTarget.swift
+++ b/Sources/BuildServerProtocol/SupportTypes/BuildTarget.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// Build target contains metadata about an artifact (for example library, test, or binary artifact).
 /// Using vocabulary of other build tools:

--- a/Sources/BuildServerProtocol/SupportTypes/MillisecondsSince1970Date.swift
+++ b/Sources/BuildServerProtocol/SupportTypes/MillisecondsSince1970Date.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
-public import LanguageServerProtocol
 public import Foundation
-#else
-import LanguageServerProtocol
-import Foundation
-#endif
+public import LanguageServerProtocol
 
 public struct MillisecondsSince1970Date: CustomCodableWrapper {
   public var wrappedValue: Date

--- a/Sources/BuildSystemIntegration/BuildSettingsLogger.swift
+++ b/Sources/BuildSystemIntegration/BuildSettingsLogger.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
 package import SKLogging
-#else
-import LanguageServerProtocol
-import SKLogging
-#endif
 
 // MARK: - Build settings logger
 

--- a/Sources/BuildSystemIntegration/BuildSystemHooks.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemHooks.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
-package import LanguageServerProtocol
 package import Foundation
-#else
-import LanguageServerProtocol
-import Foundation
-#endif
+package import LanguageServerProtocol
 
 package struct SwiftPMTestHooks: Sendable {
   package var reloadPackageDidStart: (@Sendable () async -> Void)?

--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import BuildServerProtocol
 import Dispatch
 package import Foundation
@@ -20,25 +19,10 @@ import SKLogging
 package import SKOptions
 import SKUtilities
 package import SwiftExtensions
+import TSCExtensions
 package import ToolchainRegistry
-import TSCExtensions
 
 import struct TSCBasic.RelativePath
-#else
-import BuildServerProtocol
-import Dispatch
-import Foundation
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-import SKOptions
-import SKUtilities
-import SwiftExtensions
-import ToolchainRegistry
-import TSCExtensions
-
-import struct TSCBasic.RelativePath
-#endif
 
 fileprivate typealias RequestCache<Request: RequestType & Hashable> = Cache<Request, Request.Response>
 

--- a/Sources/BuildSystemIntegration/BuildSystemManagerDelegate.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManagerDelegate.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import BuildServerProtocol
 package import LanguageServerProtocol
-#else
-import BuildServerProtocol
-import LanguageServerProtocol
-#endif
 
 /// Handles build system events, such as file build settings changes.
 package protocol BuildSystemManagerDelegate: AnyObject, Sendable {

--- a/Sources/BuildSystemIntegration/BuildSystemMessageDependencyTracker.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemMessageDependencyTracker.swift
@@ -10,19 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import BuildServerProtocol
 package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
 package import SwiftExtensions
-#else
-import BuildServerProtocol
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-import SwiftExtensions
-#endif
 
 /// A lightweight way of describing tasks that are created from handling BSP
 /// requests or notifications for the purpose of dependency tracking.

--- a/Sources/BuildSystemIntegration/BuildTargetIdentifierExtensions.swift
+++ b/Sources/BuildSystemIntegration/BuildTargetIdentifierExtensions.swift
@@ -10,15 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+package import BuildServerProtocol
 import Foundation
 import LanguageServerProtocol
 import SKLogging
-
-#if compiler(>=6)
-package import BuildServerProtocol
-#else
-import BuildServerProtocol
-#endif
 
 extension BuildTargetIdentifier {
   package static let dummy: BuildTargetIdentifier = BuildTargetIdentifier(uri: try! URI(string: "dummy://dummy"))
@@ -152,7 +147,6 @@ extension BuildTargetIdentifier {
   }
 }
 
-#if compiler(>=6)
 extension BuildTargetIdentifier: CustomLogStringConvertible {
   package var description: String {
     return uri.stringValue
@@ -162,14 +156,3 @@ extension BuildTargetIdentifier: CustomLogStringConvertible {
     return uri.stringValue.hashForLogging
   }
 }
-#else
-extension BuildTargetIdentifier: CustomLogStringConvertible {
-  public var description: String {
-    return uri.stringValue
-  }
-
-  public var redactedDescription: String {
-    return uri.stringValue.hashForLogging
-  }
-}
-#endif

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystem.swift
@@ -10,21 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import BuildServerProtocol
 package import Foundation
 package import LanguageServerProtocol
 import SKLogging
 import SKOptions
 import ToolchainRegistry
-#else
-import BuildServerProtocol
-import Foundation
-import LanguageServerProtocol
-import SKLogging
-import SKOptions
-import ToolchainRegistry
-#endif
 
 /// An error build systems can throw from `prepare` if they don't support preparation of targets.
 package struct PrepareNotSupportedError: Error, CustomStringConvertible {

--- a/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
+++ b/Sources/BuildSystemIntegration/BuiltInBuildSystemAdapter.swift
@@ -11,19 +11,13 @@
 //===----------------------------------------------------------------------===//
 
 import BuildServerProtocol
+package import Foundation
+package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
 import SKOptions
 import SwiftExtensions
 import ToolchainRegistry
-
-#if compiler(>=6)
-package import Foundation
-package import LanguageServerProtocol
-#else
-import Foundation
-import LanguageServerProtocol
-#endif
 
 /// The details necessary to create a `BuildSystemAdapter`.
 package struct BuildSystemSpec {

--- a/Sources/BuildSystemIntegration/CompilationDatabase.swift
+++ b/Sources/BuildSystemIntegration/CompilationDatabase.swift
@@ -10,21 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
 import SwiftExtensions
 import TSCExtensions
-#else
-import Foundation
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-import SwiftExtensions
-import TSCExtensions
-#endif
 
 #if os(Windows)
 import WinSDK

--- a/Sources/BuildSystemIntegration/DetermineBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/DetermineBuildSystem.swift
@@ -11,21 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+package import LanguageServerProtocol
 import SKLogging
+package import SKOptions
 import SwiftExtensions
 import TSCExtensions
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
-
-#if compiler(>=6)
-package import LanguageServerProtocol
-package import SKOptions
-#else
-import LanguageServerProtocol
-import SKOptions
-#endif
 
 private func searchForCompilationDatabaseConfig(
   in workspaceFolder: URL,

--- a/Sources/BuildSystemIntegration/FallbackBuildSettings.swift
+++ b/Sources/BuildSystemIntegration/FallbackBuildSettings.swift
@@ -11,20 +11,14 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
+package import SKOptions
 import SwiftExtensions
 import TSCExtensions
 
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
-
-#if compiler(>=6)
-package import LanguageServerProtocol
-package import SKOptions
-#else
-import LanguageServerProtocol
-import SKOptions
-#endif
 
 /// The path to the SDK.
 private let sdkpath: AbsolutePath? = {

--- a/Sources/BuildSystemIntegration/FileBuildSettings.swift
+++ b/Sources/BuildSystemIntegration/FileBuildSettings.swift
@@ -11,13 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import LanguageServerProtocolExtensions
-
-#if compiler(>=6)
 package import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
+import LanguageServerProtocolExtensions
 
 /// Build settings for a single file.
 ///

--- a/Sources/BuildSystemIntegration/FixedCompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/FixedCompilationDatabaseBuildSystem.swift
@@ -10,18 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SKLogging
-import SwiftExtensions
-
-#if compiler(>=6)
 package import BuildServerProtocol
 package import Foundation
 package import LanguageServerProtocol
-#else
-import BuildServerProtocol
-import Foundation
-import LanguageServerProtocol
-#endif
+import SKLogging
+import SwiftExtensions
 
 func lastIndexStorePathArgument(in compilerArgs: [String]) -> String? {
   if let indexStorePathIndex = compilerArgs.lastIndex(of: "-index-store-path"),

--- a/Sources/BuildSystemIntegration/JSONCompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/JSONCompilationDatabaseBuildSystem.swift
@@ -10,20 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SKLogging
-import SwiftExtensions
-
-#if compiler(>=6)
 package import BuildServerProtocol
 package import Foundation
 package import LanguageServerProtocol
+import SKLogging
+import SwiftExtensions
 package import ToolchainRegistry
-#else
-import BuildServerProtocol
-import Foundation
-import LanguageServerProtocol
-import ToolchainRegistry
-#endif
 
 fileprivate extension CompilationDatabaseCompileCommand {
   /// The first entry in the command line identifies the compiler that should be used to compile the file and can thus

--- a/Sources/BuildSystemIntegration/MainFilesProvider.swift
+++ b/Sources/BuildSystemIntegration/MainFilesProvider.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// A type that can provide the set of main files that include a particular file.
 package protocol MainFilesProvider: Sendable {

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -13,38 +13,27 @@
 #if !NO_SWIFTPM_DEPENDENCY
 import Basics
 @preconcurrency import Build
+package import BuildServerProtocol
 import Dispatch
+package import Foundation
+package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 @preconcurrency import PackageGraph
 import PackageLoading
 import PackageModel
 import SKLogging
+package import SKOptions
 @preconcurrency package import SPMBuildCore
 import SourceControl
+@preconcurrency package import SourceKitLSPAPI
 import SwiftExtensions
 import TSCExtensions
+package import ToolchainRegistry
 @preconcurrency import Workspace
 
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
-
-#if compiler(>=6)
-package import BuildServerProtocol
-package import Foundation
-package import LanguageServerProtocol
-package import SKOptions
-@preconcurrency package import SourceKitLSPAPI
-package import ToolchainRegistry
 package import class ToolchainRegistry.Toolchain
-#else
-import BuildServerProtocol
-import Foundation
-import LanguageServerProtocol
-import SKOptions
-@preconcurrency import SourceKitLSPAPI
-import ToolchainRegistry
-import class ToolchainRegistry.Toolchain
-#endif
 
 fileprivate typealias AbsolutePath = Basics.AbsolutePath
 

--- a/Sources/CompletionScoringTestSupport/TestExtensions.swift
+++ b/Sources/CompletionScoringTestSupport/TestExtensions.swift
@@ -10,15 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+package import CompletionScoring
 import Foundation
 import SwiftExtensions
 import XCTest
-
-#if compiler(>=6)
-package import CompletionScoring
-#else
-import CompletionScoring
-#endif
 
 @inline(never)
 package func drain<T>(_ value: T) {}

--- a/Sources/Diagnose/DebugCommand.swift
+++ b/Sources/Diagnose/DebugCommand.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import ArgumentParser
-#else
-import ArgumentParser
-#endif
 
 package struct DebugCommand: ParsableCommand {
   package static let configuration = CommandConfiguration(

--- a/Sources/Diagnose/DiagnoseCommand.swift
+++ b/Sources/Diagnose/DiagnoseCommand.swift
@@ -10,29 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import ArgumentParser
 import Foundation
 import LanguageServerProtocolExtensions
-import ToolchainRegistry
 import SwiftExtensions
 import TSCExtensions
+import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import class TSCUtility.PercentProgressAnimation
-#else
-import ArgumentParser
-import Foundation
-import LanguageServerProtocolExtensions
-import ToolchainRegistry
-import SwiftExtensions
-import TSCExtensions
-
-import struct TSCBasic.AbsolutePath
-import class TSCBasic.Process
-import class TSCUtility.PercentProgressAnimation
-#endif
 
 /// When diagnosis is started, a progress bar displayed on the terminal that shows how far the diagnose command has
 /// progressed.

--- a/Sources/Diagnose/IndexCommand.swift
+++ b/Sources/Diagnose/IndexCommand.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import ArgumentParser
 import Foundation
 import InProcessClient
@@ -24,21 +23,6 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import class TSCUtility.PercentProgressAnimation
-#else
-import ArgumentParser
-import Foundation
-import InProcessClient
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKOptions
-import SourceKitLSP
-import SwiftExtensions
-import ToolchainRegistry
-
-import struct TSCBasic.AbsolutePath
-import class TSCBasic.Process
-import class TSCUtility.PercentProgressAnimation
-#endif
 
 private actor IndexLogMessageHandler: MessageHandler {
   var hasSeenError: Bool = false

--- a/Sources/Diagnose/ReduceCommand.swift
+++ b/Sources/Diagnose/ReduceCommand.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import ArgumentParser
 import Foundation
 import ToolchainRegistry
@@ -18,15 +17,6 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import class TSCUtility.PercentProgressAnimation
-#else
-import ArgumentParser
-import Foundation
-import ToolchainRegistry
-
-import struct TSCBasic.AbsolutePath
-import class TSCBasic.Process
-import class TSCUtility.PercentProgressAnimation
-#endif
 
 package struct ReduceCommand: AsyncParsableCommand {
   package static let configuration: CommandConfiguration = CommandConfiguration(

--- a/Sources/Diagnose/ReduceFrontendCommand.swift
+++ b/Sources/Diagnose/ReduceFrontendCommand.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import ArgumentParser
 import Foundation
 import ToolchainRegistry
@@ -18,15 +17,6 @@ import ToolchainRegistry
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import class TSCUtility.PercentProgressAnimation
-#else
-import ArgumentParser
-import Foundation
-import ToolchainRegistry
-
-import struct TSCBasic.AbsolutePath
-import class TSCBasic.Process
-import class TSCUtility.PercentProgressAnimation
-#endif
 
 package struct ReduceFrontendCommand: AsyncParsableCommand {
   package static let configuration: CommandConfiguration = CommandConfiguration(

--- a/Sources/Diagnose/RequestInfo.swift
+++ b/Sources/Diagnose/RequestInfo.swift
@@ -10,15 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 import RegexBuilder
 import SwiftExtensions
-#else
-import Foundation
-import RegexBuilder
-import SwiftExtensions
-#endif
 
 /// All the information necessary to replay a sourcektid request.
 package struct RequestInfo: Sendable {

--- a/Sources/Diagnose/RunSourcekitdRequestCommand.swift
+++ b/Sources/Diagnose/RunSourcekitdRequestCommand.swift
@@ -10,27 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import ArgumentParser
 import Csourcekitd
 import Foundation
 import SKUtilities
-import SwiftExtensions
-import SourceKitD
-import ToolchainRegistry
-
-import struct TSCBasic.AbsolutePath
-#else
-import ArgumentParser
-import Csourcekitd
-import Foundation
-import SKUtilities
 import SourceKitD
 import SwiftExtensions
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
-#endif
 
 package struct RunSourceKitdRequestCommand: AsyncParsableCommand {
   package static let configuration = CommandConfiguration(

--- a/Sources/Diagnose/SourceKitD+RunWithYaml.swift
+++ b/Sources/Diagnose/SourceKitD+RunWithYaml.swift
@@ -10,15 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Csourcekitd
 import Foundation
 package import SourceKitD
-#else
-import Csourcekitd
-import Foundation
-import SourceKitD
-#endif
 
 extension SourceKitD {
   /// Parse the request from YAML and execute it.

--- a/Sources/Diagnose/SourceKitDRequestExecutor.swift
+++ b/Sources/Diagnose/SourceKitDRequestExecutor.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 import SourceKitD
 import SwiftExtensions
@@ -18,15 +17,6 @@ import SwiftExtensions
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import struct TSCBasic.ProcessResult
-#else
-import Foundation
-import SourceKitD
-import SwiftExtensions
-
-import struct TSCBasic.AbsolutePath
-import class TSCBasic.Process
-import struct TSCBasic.ProcessResult
-#endif
 
 /// The different states in which a sourcekitd request can finish.
 package enum SourceKitDRequestResult: Sendable {

--- a/Sources/Diagnose/Toolchain+SwiftFrontend.swift
+++ b/Sources/Diagnose/Toolchain+SwiftFrontend.swift
@@ -10,17 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
-#else
-import Foundation
-import ToolchainRegistry
-
-import struct TSCBasic.AbsolutePath
-#endif
 
 extension Toolchain {
   /// The path to `swift-frontend` in the toolchain, found relative to `swift`.

--- a/Sources/Diagnose/TraceFromSignpostsCommand.swift
+++ b/Sources/Diagnose/TraceFromSignpostsCommand.swift
@@ -10,21 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import ArgumentParser
 import Foundation
 import RegexBuilder
 import SwiftExtensions
 
 import class TSCBasic.Process
-#else
-import ArgumentParser
-import Foundation
-import RegexBuilder
-import SwiftExtensions
-
-import class TSCBasic.Process
-#endif
 
 /// Shared instance of the regex that is used to extract Signpost lines from `log stream --signpost`.
 fileprivate struct LogParseRegex {

--- a/Sources/InProcessClient/InProcessSourceKitLSPClient.swift
+++ b/Sources/InProcessClient/InProcessSourceKitLSPClient.swift
@@ -15,20 +15,13 @@ public import Foundation
 public import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
-import SwiftExtensions
-import TSCExtensions
-
-import struct TSCBasic.AbsolutePath
-
-#if compiler(>=6)
 package import SKOptions
 package import SourceKitLSP
+import SwiftExtensions
+import TSCExtensions
 package import ToolchainRegistry
-#else
-import SKOptions
-import SourceKitLSP
-import ToolchainRegistry
-#endif
+
+import struct TSCBasic.AbsolutePath
 
 /// Launches a `SourceKitLSPServer` in-process and allows sending messages to it.
 public final class InProcessSourceKitLSPClient: Sendable {

--- a/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/DocumentURI.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import Foundation
-#else
-import Foundation
-#endif
 
 struct FailedToConstructDocumentURIFromStringError: Error, CustomStringConvertible {
   let string: String

--- a/Sources/LanguageServerProtocolExtensions/Connection+Send.swift
+++ b/Sources/LanguageServerProtocolExtensions/Connection+Send.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
 import SwiftExtensions
-#else
-import LanguageServerProtocol
-import SwiftExtensions
-#endif
 
 extension Connection {
   /// Send the given request to the connection and await its result.

--- a/Sources/LanguageServerProtocolExtensions/DocumentURI+symlinkTarget.swift
+++ b/Sources/LanguageServerProtocolExtensions/DocumentURI+symlinkTarget.swift
@@ -10,15 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 package import LanguageServerProtocol
 import SwiftExtensions
-#else
-import Foundation
-import LanguageServerProtocol
-import SwiftExtensions
-#endif
 
 extension DocumentURI {
   /// If this is a file URI pointing to a symlink, return the realpath of the URI, otherwise return `nil`.

--- a/Sources/LanguageServerProtocolExtensions/Language+Inference.swift
+++ b/Sources/LanguageServerProtocolExtensions/Language+Inference.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 package import LanguageServerProtocol
-#else
-import Foundation
-import LanguageServerProtocol
-#endif
 
 extension Language {
   package enum SemanticKind {

--- a/Sources/LanguageServerProtocolExtensions/LocalConnection.swift
+++ b/Sources/LanguageServerProtocolExtensions/LocalConnection.swift
@@ -11,15 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
+package import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
 import SKLogging
 import SwiftExtensions
-
-#if compiler(>=6)
-package import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// A connection between two message handlers in the same process.
 ///

--- a/Sources/LanguageServerProtocolExtensions/QueueBasedMessageHandler.swift
+++ b/Sources/LanguageServerProtocolExtensions/QueueBasedMessageHandler.swift
@@ -11,16 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+package import LanguageServerProtocol
 import LanguageServerProtocolJSONRPC
 import SKLogging
-
-#if compiler(>=6)
-package import LanguageServerProtocol
 package import SwiftExtensions
-#else
-import LanguageServerProtocol
-import SwiftExtensions
-#endif
 
 /// Side structure in which `QueueBasedMessageHandler` can keep track of active requests etc.
 ///

--- a/Sources/LanguageServerProtocolExtensions/RequestAndReply.swift
+++ b/Sources/LanguageServerProtocolExtensions/RequestAndReply.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
 import SwiftExtensions
-#else
-import LanguageServerProtocol
-import SwiftExtensions
-#endif
 
 /// A request and a callback that returns the request's reply
 package final class RequestAndReply<Params: RequestType>: Sendable {

--- a/Sources/LanguageServerProtocolExtensions/WorkDoneProgressManager.swift
+++ b/Sources/LanguageServerProtocolExtensions/WorkDoneProgressManager.swift
@@ -10,17 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 package import LanguageServerProtocol
 import SKLogging
 import SwiftExtensions
-#else
-import Foundation
-import LanguageServerProtocol
-import SKLogging
-import SwiftExtensions
-#endif
 
 /// Represents a single `WorkDoneProgress` task that gets communicated with the client.
 ///

--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -10,21 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import Dispatch
 public import Foundation
 public import LanguageServerProtocol
 import SKLogging
 import SwiftExtensions
+
 #if canImport(Android)
 import Android
-#endif
-#else
-import Dispatch
-import Foundation
-import LanguageServerProtocol
-import SKLogging
-import SwiftExtensions
 #endif
 
 #if canImport(CDispatch)

--- a/Sources/LanguageServerProtocolJSONRPC/LoggableMessageTypes.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/LoggableMessageTypes.swift
@@ -10,15 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 package import LanguageServerProtocol
 package import SKLogging
-#else
-import Foundation
-import LanguageServerProtocol
-import SKLogging
-#endif
 
 // MARK: - RequestType
 

--- a/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/MessageCoding.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 public import LanguageServerProtocol
-#else
-import Foundation
-import LanguageServerProtocol
-#endif
 
 @_spi(Testing) public enum JSONRPCMessage {
   case notification(NotificationType)

--- a/Sources/SKLogging/CustomLogStringConvertible.swift
+++ b/Sources/SKLogging/CustomLogStringConvertible.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
-#else
-import Foundation
-#endif
 
 #if !NO_CRYPTO_DEPENDENCY
 import Crypto

--- a/Sources/SKLogging/Logging.swift
+++ b/Sources/SKLogging/Logging.swift
@@ -13,11 +13,7 @@
 import Foundation
 
 #if canImport(os) && !SOURCEKIT_LSP_FORCE_NON_DARWIN_LOGGER
-#if compiler(>=6)
 @_exported public import os  // os_log
-#else
-@_exported import os  // os_log
-#endif
 
 package typealias LogLevel = os.OSLogType
 package typealias Logger = os.Logger

--- a/Sources/SKLogging/NonDarwinLogging.swift
+++ b/Sources/SKLogging/NonDarwinLogging.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import SwiftExtensions
-#else
-import SwiftExtensions
-#endif
 
 #if canImport(Darwin)
 import Foundation

--- a/Sources/SKLogging/SetGlobalLogFileHandler.swift
+++ b/Sources/SKLogging/SetGlobalLogFileHandler.swift
@@ -14,18 +14,10 @@ import RegexBuilder
 import SwiftExtensions
 
 #if canImport(Darwin)
-#if compiler(>=6)
 package import Foundation
 #else
-import Foundation
-#endif
-#else
 // TODO: @preconcurrency needed because stderr is not sendable on Linux https://github.com/swiftlang/swift/issues/75601
-#if compiler(>=6)
 @preconcurrency package import Foundation
-#else
-@preconcurrency import Foundation
-#endif
 #endif
 
 #if os(Windows)

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -10,21 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import Foundation
 public import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
 
 import struct TSCBasic.AbsolutePath
-#else
-import Foundation
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-
-import struct TSCBasic.AbsolutePath
-#endif
 
 /// Options that can be used to modify SourceKit-LSP's behavior.
 ///

--- a/Sources/SKTestSupport/Assertions.swift
+++ b/Sources/SKTestSupport/Assertions.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import XCTest
-#else
-import XCTest
-#endif
 
 /// Same as `XCTAssertNoThrow` but executes the trailing closure.
 package func assertNoThrow<T>(

--- a/Sources/SKTestSupport/CompletionItem+clearingUnstableValues.swift
+++ b/Sources/SKTestSupport/CompletionItem+clearingUnstableValues.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 extension Array<CompletionItem> {
   /// Remove `sortText` and `data` from all completion items as these are not stable across runs. Instead, sort items

--- a/Sources/SKTestSupport/CustomBuildServerTestProject.swift
+++ b/Sources/SKTestSupport/CustomBuildServerTestProject.swift
@@ -10,25 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+package import BuildServerProtocol
 import BuildSystemIntegration
+package import Foundation
+package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
+package import SKOptions
 import SourceKitLSP
 import SwiftExtensions
 import ToolchainRegistry
 import XCTest
-
-#if compiler(>=6)
-package import BuildServerProtocol
-package import Foundation
-package import LanguageServerProtocol
-package import SKOptions
-#else
-import BuildServerProtocol
-import Foundation
-import LanguageServerProtocol
-import SKOptions
-#endif
 
 // MARK: - CustomBuildServer
 

--- a/Sources/SKTestSupport/DocumentDiagnosticReport+full.swift
+++ b/Sources/SKTestSupport/DocumentDiagnosticReport+full.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 extension DocumentDiagnosticReport {
   /// If this is a full diagnostic report, return it. Otherwise return `nil`.

--- a/Sources/SKTestSupport/DummyBuildSystemManagerConnectionToClient.swift
+++ b/Sources/SKTestSupport/DummyBuildSystemManagerConnectionToClient.swift
@@ -10,15 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import BuildSystemIntegration
 import Foundation
 package import LanguageServerProtocol
-#else
-import BuildSystemIntegration
-import Foundation
-import LanguageServerProtocol
-#endif
 
 package struct DummyBuildSystemManagerConnectionToClient: BuildSystemManagerConnectionToClient {
   package var clientSupportsWorkDoneProgress: Bool = false

--- a/Sources/SKTestSupport/ExternalBuildServerTestProject.swift
+++ b/Sources/SKTestSupport/ExternalBuildServerTestProject.swift
@@ -11,14 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+package import SKOptions
 import SwiftExtensions
 import XCTest
-
-#if compiler(>=6)
-package import SKOptions
-#else
-import SKOptions
-#endif
 
 fileprivate let sdkArgs =
   if let defaultSDKPath {

--- a/Sources/SKTestSupport/FileManager+createFiles.swift
+++ b/Sources/SKTestSupport/FileManager+createFiles.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
-#else
-import Foundation
-#endif
 
 extension FileManager {
   /// Creates files from a dictionary of path to contents.

--- a/Sources/SKTestSupport/FileManager+findFiles.swift
+++ b/Sources/SKTestSupport/FileManager+findFiles.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
-#else
-import Foundation
-#endif
 
 extension FileManager {
   /// Returns the URLs of all files with the given file extension in the given directory (recursively).

--- a/Sources/SKTestSupport/FindTool.swift
+++ b/Sources/SKTestSupport/FindTool.swift
@@ -10,19 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 import LanguageServerProtocolExtensions
 import TSCExtensions
 
 import class TSCBasic.Process
-#else
-import Foundation
-import LanguageServerProtocolExtensions
-import TSCExtensions
-
-import class TSCBasic.Process
-#endif
 
 #if os(Windows)
 import WinSDK

--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 @_spi(Testing) import BuildSystemIntegration
 package import Foundation
 package import LanguageServerProtocol
@@ -19,16 +18,6 @@ import SourceKitLSP
 import SwiftExtensions
 import TSCBasic
 import ToolchainRegistry
-#else
-@_spi(Testing) import BuildSystemIntegration
-import Foundation
-import LanguageServerProtocol
-import SKOptions
-import SourceKitLSP
-import SwiftExtensions
-import TSCBasic
-import ToolchainRegistry
-#endif
 
 package struct IndexedSingleSwiftFileTestProject {
   enum Error: Swift.Error {

--- a/Sources/SKTestSupport/LocationsOrLocationLinksResponse+Locations.swift
+++ b/Sources/SKTestSupport/LocationsOrLocationLinksResponse+Locations.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 extension LocationsOrLocationLinksResponse {
   /// If this is the `locations` case, return the locations, otherwise return `nil`.

--- a/Sources/SKTestSupport/MultiFileTestProject.swift
+++ b/Sources/SKTestSupport/MultiFileTestProject.swift
@@ -10,21 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftExtensions
-
-#if compiler(>=6)
 package import Foundation
 package import LanguageServerProtocol
 package import SKOptions
 package import SourceKitLSP
+import SwiftExtensions
 package import ToolchainRegistry
-#else
-import Foundation
-import LanguageServerProtocol
-import SKOptions
-import SourceKitLSP
-import ToolchainRegistry
-#endif
 
 /// The location of a test file within test workspace.
 package struct RelativeFileLocation: Hashable, ExpressibleByStringLiteral {

--- a/Sources/SKTestSupport/PerfTestCase.swift
+++ b/Sources/SKTestSupport/PerfTestCase.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 public import XCTest
-#else
-import XCTest
-#endif
 
 /// Base class for a performance test case in SourceKit-LSP.
 ///

--- a/Sources/SKTestSupport/PluginPaths.swift
+++ b/Sources/SKTestSupport/PluginPaths.swift
@@ -11,13 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import ToolchainRegistry
-
-#if compiler(>=6)
 package import SourceKitD
-#else
-import SourceKitD
-#endif
+import ToolchainRegistry
 
 /// The path to the `SwiftSourceKitPluginTests` test bundle. This gives us a hook into the the build directory.
 private let xctestBundle: URL = {

--- a/Sources/SKTestSupport/String+writeWithRetry.swift
+++ b/Sources/SKTestSupport/String+writeWithRetry.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SKLogging
-
-#if compiler(>=6)
 package import Foundation
-#else
-import Foundation
-#endif
+import SKLogging
 
 extension String {
   /// Write this string to the given URL using UTF-8 encoding.

--- a/Sources/SKTestSupport/SwiftPMDependencyProject.swift
+++ b/Sources/SKTestSupport/SwiftPMDependencyProject.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 import LanguageServerProtocolExtensions
 import SwiftExtensions
@@ -20,17 +19,6 @@ import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import enum TSCBasic.ProcessEnv
 import struct TSCBasic.ProcessResult
-#else
-import Foundation
-import LanguageServerProtocolExtensions
-import SwiftExtensions
-import XCTest
-
-import struct TSCBasic.AbsolutePath
-import class TSCBasic.Process
-import enum TSCBasic.ProcessEnv
-import struct TSCBasic.ProcessResult
-#endif
 
 /// A SwiftPM package that gets written to disk and for which a Git repository is initialized with a commit tagged
 /// `1.0.0`. This repository can then be used as a dependency for another package, usually a `SwiftPMTestProject`.

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 package import LanguageServerProtocol
 package import SKOptions
@@ -19,16 +18,6 @@ import SwiftExtensions
 import TSCBasic
 import ToolchainRegistry
 import XCTest
-#else
-import Foundation
-import LanguageServerProtocol
-import SKOptions
-import SourceKitLSP
-import SwiftExtensions
-import TSCBasic
-import ToolchainRegistry
-import XCTest
-#endif
 
 package class SwiftPMTestProject: MultiFileTestProject {
   enum Error: Swift.Error {

--- a/Sources/SKTestSupport/TestBundle.swift
+++ b/Sources/SKTestSupport/TestBundle.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
-#else
-import Foundation
-#endif
 
 /// The bundle of the currently executing test.
 package let testBundle: Bundle = {

--- a/Sources/SKTestSupport/TestJSONRPCConnection.swift
+++ b/Sources/SKTestSupport/TestJSONRPCConnection.swift
@@ -10,25 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import InProcessClient
 public import LanguageServerProtocol
-package import LanguageServerProtocolJSONRPC
 package import LanguageServerProtocolExtensions
+package import LanguageServerProtocolJSONRPC
 import SwiftExtensions
 import XCTest
 
 package import class Foundation.Pipe
-#else
-import InProcessClient
-import LanguageServerProtocol
-import LanguageServerProtocolJSONRPC
-import LanguageServerProtocolExtensions
-import SwiftExtensions
-import XCTest
-
-import class Foundation.Pipe
-#endif
 
 package final class TestJSONRPCConnection: Sendable {
   package let clientToServer: Pipe = Pipe()

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -12,25 +12,17 @@
 
 import Foundation
 import InProcessClient
+package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import LanguageServerProtocolJSONRPC
+package import SKOptions
 import SKUtilities
 import SourceKitD
+package import SourceKitLSP
 import SwiftExtensions
 import SwiftSyntax
-import XCTest
-
-#if compiler(>=6)
-package import LanguageServerProtocol
-package import SKOptions
-package import SourceKitLSP
 package import ToolchainRegistry
-#else
-import LanguageServerProtocol
-import SKOptions
-import SourceKitLSP
-import ToolchainRegistry
-#endif
+import XCTest
 
 extension SourceKitLSPOptions {
   package static func testDefault(

--- a/Sources/SKTestSupport/TextDocumentIdentifier+URI.swift
+++ b/Sources/SKTestSupport/TextDocumentIdentifier+URI.swift
@@ -10,17 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 package import LanguageServerProtocol
 
 import struct TSCBasic.AbsolutePath
-#else
-import Foundation
-import LanguageServerProtocol
-
-import struct TSCBasic.AbsolutePath
-#endif
 
 package extension TextDocumentIdentifier {
   init(_ url: URL) {

--- a/Sources/SKTestSupport/Timeouts.swift
+++ b/Sources/SKTestSupport/Timeouts.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
-#else
-import Foundation
-#endif
 
 /// The default duration how long tests should wait for responses from
 /// SourceKit-LSP / sourcekitd / clangd.

--- a/Sources/SKTestSupport/Utils.swift
+++ b/Sources/SKTestSupport/Utils.swift
@@ -10,17 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 package import LanguageServerProtocol
 import SwiftExtensions
+
 import struct TSCBasic.AbsolutePath
-#else
-import Foundation
-import LanguageServerProtocol
-import SwiftExtensions
-import struct TSCBasic.AbsolutePath
-#endif
 
 extension Language {
   var fileExtension: String {

--- a/Sources/SKTestSupport/WrappedSemaphore.swift
+++ b/Sources/SKTestSupport/WrappedSemaphore.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Dispatch
 import XCTest
-#else
-import Dispatch
-import XCTest
-#endif
 
 /// Wrapper around `DispatchSemaphore` so that Swift Concurrency doesn't complain about the usage of semaphores in the
 /// tests.

--- a/Sources/SemanticIndex/CheckedIndex.swift
+++ b/Sources/SemanticIndex/CheckedIndex.swift
@@ -10,19 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 @preconcurrency package import IndexStoreDB
 package import LanguageServerProtocol
 import SKLogging
 import SwiftExtensions
-#else
-import Foundation
-@preconcurrency import IndexStoreDB
-import LanguageServerProtocol
-import SKLogging
-import SwiftExtensions
-#endif
 
 /// Essentially a `DocumentManager` from the `SourceKitLSP` module.
 ///

--- a/Sources/SemanticIndex/IndexHooks.swift
+++ b/Sources/SemanticIndex/IndexHooks.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
-package import IndexStoreDB
 package import Foundation
-#else
-import IndexStoreDB
-import Foundation
-#endif
+package import IndexStoreDB
 
 /// When running SourceKit-LSP in-process, allows the creator of `SourceKitLSPServer` to provide the `IndexStoreDB`
 /// instead of SourceKit-LSP creating the instance when needed.

--- a/Sources/SemanticIndex/PreparationTaskDescription.swift
+++ b/Sources/SemanticIndex/PreparationTaskDescription.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import BuildServerProtocol
 import BuildSystemIntegration
 import Foundation
@@ -21,18 +20,6 @@ import SwiftExtensions
 
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
-#else
-import BuildServerProtocol
-import BuildSystemIntegration
-import Foundation
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-import SwiftExtensions
-
-import struct TSCBasic.AbsolutePath
-import class TSCBasic.Process
-#endif
 
 private let preparationIDForLogging = AtomicUInt32(initialValue: 1)
 

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -10,23 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import LanguageServerProtocolExtensions
-
-#if compiler(>=6)
 package import BuildServerProtocol
 package import BuildSystemIntegration
 import Foundation
 package import LanguageServerProtocol
+import LanguageServerProtocolExtensions
 import SKLogging
 import SwiftExtensions
-#else
-import BuildServerProtocol
-import BuildSystemIntegration
-import Foundation
-import LanguageServerProtocol
-import SKLogging
-import SwiftExtensions
-#endif
 
 /// The logging subsystem that should be used for all index-related logging.
 let indexLoggingSubsystem = "org.swift.sourcekit-lsp.indexing"

--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -10,17 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 import LanguageServerProtocolExtensions
 package import SKLogging
 import SwiftExtensions
-#else
-import Foundation
-import LanguageServerProtocolExtensions
-import SKLogging
-import SwiftExtensions
-#endif
 
 /// See comment on ``TaskDescriptionProtocol/dependencies(to:taskPriority:)``
 package enum TaskDependencyAction<TaskDescription: TaskDescriptionProtocol> {

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import BuildServerProtocol
 import BuildSystemIntegration
 import Foundation
@@ -18,29 +17,13 @@ package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
 import SwiftExtensions
-import ToolchainRegistry
 import TSCExtensions
+import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
 import struct TSCBasic.ProcessResult
 import enum TSCBasic.SystemError
-#else
-import BuildServerProtocol
-import BuildSystemIntegration
-import Foundation
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-import SwiftExtensions
-import ToolchainRegistry
-import TSCExtensions
-
-import struct TSCBasic.AbsolutePath
-import class TSCBasic.Process
-import struct TSCBasic.ProcessResult
-import enum TSCBasic.SystemError
-#endif
 
 #if os(Windows)
 import WinSDK

--- a/Sources/SourceKitD/DynamicallyLoadedSourceKitD.swift
+++ b/Sources/SourceKitD/DynamicallyLoadedSourceKitD.swift
@@ -10,17 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Csourcekitd
 package import Foundation
 import SKLogging
 import SwiftExtensions
-#else
-import Csourcekitd
-import Foundation
-import SKLogging
-import SwiftExtensions
-#endif
 
 extension sourcekitd_api_keys: @unchecked Sendable {}
 extension sourcekitd_api_requests: @unchecked Sendable {}

--- a/Sources/SourceKitD/SKDRequestArray.swift
+++ b/Sources/SourceKitD/SKDRequestArray.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Csourcekitd
-#else
-import Csourcekitd
-#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/SourceKitD/SKDRequestDictionary.swift
+++ b/Sources/SourceKitD/SKDRequestDictionary.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Csourcekitd
 import SKLogging
-#else
-import Csourcekitd
-import SKLogging
-#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/SourceKitD/SKDResponse.swift
+++ b/Sources/SourceKitD/SKDResponse.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Csourcekitd
 import SKLogging
-#else
-import Csourcekitd
-import SKLogging
-#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/SourceKitD/SKDResponseArray.swift
+++ b/Sources/SourceKitD/SKDResponseArray.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Csourcekitd
-#else
-import Csourcekitd
-#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/SourceKitD/SKDResponseDictionary.swift
+++ b/Sources/SourceKitD/SKDResponseDictionary.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Csourcekitd
-#else
-import Csourcekitd
-#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -10,19 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SKLogging
-
-#if compiler(>=6)
 package import Csourcekitd
 import Dispatch
 package import Foundation
+import SKLogging
 import SwiftExtensions
-#else
-import Csourcekitd
-import Dispatch
-import Foundation
-import SwiftExtensions
-#endif
 
 fileprivate struct SourceKitDRequestHandle: Sendable {
   /// `nonisolated(unsafe)` is fine because we just use the handle as an opaque value.

--- a/Sources/SourceKitD/SourceKitDRegistry.swift
+++ b/Sources/SourceKitD/SourceKitDRegistry.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SKLogging
-
-#if compiler(>=6)
 package import Foundation
-#else
-import Foundation
-#endif
+import SKLogging
 
 /// The set of known SourceKitD instances, uniqued by path.
 ///

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -12,11 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Csourcekitd
-#else
-import Csourcekitd
-#endif
 
 package struct sourcekitd_api_keys {
   /// `key.version_major`

--- a/Sources/SourceKitD/sourcekitd_uids.swift.gyb
+++ b/Sources/SourceKitD/sourcekitd_uids.swift.gyb
@@ -122,11 +122,7 @@
   ]
 }%
 
-#if compiler(>=6)
 package import Csourcekitd
-#else
-import Csourcekitd
-#endif
 % for (struct_type, uids) in TYPES_AND_KEYS:
 
 package struct ${struct_type} {

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -10,17 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
 import SwiftExtensions
-#else
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-import SwiftExtensions
-#endif
 
 /// A class which tracks the client's capabilities as well as our dynamic
 /// capability registrations in order to avoid registering conflicting

--- a/Sources/SourceKitLSP/DocumentManager.swift
+++ b/Sources/SourceKitLSP/DocumentManager.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Dispatch
 import Foundation
 package import LanguageServerProtocol
@@ -18,15 +17,6 @@ import SKLogging
 package import SKUtilities
 import SemanticIndex
 package import SwiftSyntax
-#else
-import Dispatch
-import Foundation
-import LanguageServerProtocol
-import SKLogging
-import SKUtilities
-import SemanticIndex
-import SwiftSyntax
-#endif
 
 /// An immutable snapshot of a document at a given time.
 ///

--- a/Sources/SourceKitLSP/DocumentSnapshot+FromFileContents.swift
+++ b/Sources/SourceKitLSP/DocumentSnapshot+FromFileContents.swift
@@ -10,15 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 package import LanguageServerProtocol
 import SKUtilities
-#else
-import Foundation
-import LanguageServerProtocol
-import SKUtilities
-#endif
 
 package extension DocumentSnapshot {
   /// Creates a `DocumentSnapshot` with the file contents from disk.

--- a/Sources/SourceKitLSP/Documentation/DocumentationLanguageService.swift
+++ b/Sources/SourceKitLSP/Documentation/DocumentationLanguageService.swift
@@ -11,18 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-
-#if compiler(>=6)
 package import LanguageServerProtocol
 package import SKOptions
 package import SwiftSyntax
 package import ToolchainRegistry
-#else
-import LanguageServerProtocol
-import SKOptions
-import SwiftSyntax
-import ToolchainRegistry
-#endif
 
 package actor DocumentationLanguageService: LanguageService, Sendable {
   package init?(

--- a/Sources/SourceKitLSP/Hooks.swift
+++ b/Sources/SourceKitLSP/Hooks.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import BuildSystemIntegration
 import Foundation
 package import LanguageServerProtocol
@@ -19,16 +18,6 @@ package import SemanticIndex
 
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
-#else
-import BuildSystemIntegration
-import Foundation
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SemanticIndex
-
-import struct TSCBasic.AbsolutePath
-import struct TSCBasic.RelativePath
-#endif
 
 /// Closures can be used to inspect or modify internal behavior in SourceKit-LSP.
 public struct Hooks: Sendable {

--- a/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
+++ b/Sources/SourceKitLSP/IndexStoreDB+MainFilesProvider.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import BuildSystemIntegration
 import Foundation
 import IndexStoreDB
@@ -18,15 +17,6 @@ package import LanguageServerProtocol
 import SKLogging
 import SemanticIndex
 import SwiftExtensions
-#else
-import BuildSystemIntegration
-import Foundation
-import IndexStoreDB
-import LanguageServerProtocol
-import SKLogging
-import SemanticIndex
-import SwiftExtensions
-#endif
 
 extension UncheckedIndex: BuildSystemIntegration.MainFilesProvider {
   /// - Important: This may return realpaths when the build system might not be using realpaths. Use

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -10,19 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 package import LanguageServerProtocol
 package import SKOptions
 package import SwiftSyntax
 package import ToolchainRegistry
-#else
-import Foundation
-import LanguageServerProtocol
-import SKOptions
-import SwiftSyntax
-import ToolchainRegistry
-#endif
 
 /// The state of a `ToolchainLanguageServer`
 package enum LanguageServerState {

--- a/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
+++ b/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
@@ -10,17 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
 package import SwiftExtensions
-#else
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-import SwiftExtensions
-#endif
 
 /// A lightweight way of describing tasks that are created from handling LSP
 /// requests or notifications for the purpose of dependency tracking.

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Csourcekitd
 import Foundation
 import IndexStoreDB
@@ -21,18 +20,6 @@ import SemanticIndex
 import SourceKitD
 import SwiftExtensions
 import SwiftSyntax
-#else
-import Csourcekitd
-import Foundation
-import IndexStoreDB
-import LanguageServerProtocol
-import SKLogging
-import SKUtilities
-import SemanticIndex
-import SourceKitD
-import SwiftExtensions
-import SwiftSyntax
-#endif
 
 // MARK: - Helper types
 

--- a/Sources/SourceKitLSP/SemanticTokensLegend+SourceKitLSPLegend.swift
+++ b/Sources/SourceKitLSP/SemanticTokensLegend+SourceKitLSPLegend.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 extension SemanticTokenTypes {
   // LSP doesn’t know about actors. Display actors as classes.

--- a/Sources/SourceKitLSP/SourceKitLSPCommandMetadata.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPCommandMetadata.swift
@@ -10,17 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 import SKLogging
-#else
-import Foundation
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-#endif
 
 /// Represents metadata that SourceKit-LSP injects at every command returned by code actions.
 /// The ExecuteCommand is not a TextDocumentRequest, so metadata is injected to allow SourceKit-LSP

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import BuildServerProtocol
 import BuildSystemIntegration
 import Dispatch
@@ -28,25 +27,6 @@ package import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
 import protocol TSCBasic.FileSystem
-#else
-import BuildServerProtocol
-import BuildSystemIntegration
-import Dispatch
-import Foundation
-import IndexStoreDB
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import LanguageServerProtocolJSONRPC
-import SKLogging
-import SKOptions
-import SemanticIndex
-import SourceKitD
-import SwiftExtensions
-import ToolchainRegistry
-
-import struct TSCBasic.AbsolutePath
-import protocol TSCBasic.FileSystem
-#endif
 
 /// Disambiguate LanguageServerProtocol.Language and IndexstoreDB.Language
 package typealias Language = LanguageServerProtocol.Language

--- a/Sources/SourceKitLSP/Swift/ClosureCompletionFormat.swift
+++ b/Sources/SourceKitLSP/Swift/ClosureCompletionFormat.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.0)
 public import SwiftBasicFormat
 public import SwiftSyntax
-#else
-import SwiftBasicFormat
-import SwiftSyntax
-#endif
 
 /// A specialization of `BasicFormat` for closure literals in a code completion
 /// context.

--- a/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/AddDocumentation.swift
@@ -10,19 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import SwiftBasicFormat
 import SwiftExtensions
 import SwiftParser
 import SwiftRefactor
 package import SwiftSyntax
-#else
-import SwiftBasicFormat
-import SwiftExtensions
-import SwiftParser
-import SwiftRefactor
-import SwiftSyntax
-#endif
 
 /// Insert a documentation template associated with a function or macro.
 ///

--- a/Sources/SourceKitLSP/Swift/CodeActions/ConvertJSONToCodableStruct.swift
+++ b/Sources/SourceKitLSP/Swift/CodeActions/ConvertJSONToCodableStruct.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 import LanguageServerProtocol
 import SwiftBasicFormat
@@ -18,15 +17,6 @@ import SwiftParser
 import SwiftRefactor
 package import SwiftSyntax
 import SwiftSyntaxBuilder
-#else
-import Foundation
-import LanguageServerProtocol
-import SwiftBasicFormat
-import SwiftParser
-import SwiftRefactor
-import SwiftSyntax
-import SwiftSyntaxBuilder
-#endif
 
 /// Convert JSON literals into corresponding Swift structs that conform to the
 /// `Codable` protocol.

--- a/Sources/SourceKitLSP/Swift/CodeCompletion.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletion.swift
@@ -10,19 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 package import LanguageServerProtocol
 import SKLogging
 import SourceKitD
 import SwiftBasicFormat
-#else
-import Foundation
-import LanguageServerProtocol
-import SKLogging
-import SourceKitD
-import SwiftBasicFormat
-#endif
 
 extension SwiftLanguageService {
   package func completion(_ req: CompletionRequest) async throws -> CompletionList {

--- a/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentFormatting.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
@@ -23,20 +22,6 @@ import TSCExtensions
 
 import struct TSCBasic.AbsolutePath
 import class TSCBasic.Process
-#else
-import Foundation
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-import SKUtilities
-import SwiftExtensions
-import SwiftParser
-import SwiftSyntax
-import TSCExtensions
-
-import struct TSCBasic.AbsolutePath
-import class TSCBasic.Process
-#endif
 
 fileprivate extension String {
   init?(bytes: [UInt8], encoding: Encoding) {

--- a/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
+++ b/Sources/SourceKitLSP/Swift/DocumentSymbols.swift
@@ -10,17 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Foundation
 package import LanguageServerProtocol
 import SKLogging
 import SwiftSyntax
-#else
-import Foundation
-import LanguageServerProtocol
-import SKLogging
-import SwiftSyntax
-#endif
 
 extension SwiftLanguageService {
   package func documentSymbol(_ req: DocumentSymbolRequest) async throws -> DocumentSymbolResponse? {

--- a/Sources/SourceKitLSP/Swift/ExpandMacroCommand.swift
+++ b/Sources/SourceKitLSP/Swift/ExpandMacroCommand.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
 import SourceKitD
-#else
-import LanguageServerProtocol
-import SourceKitD
-#endif
 
 package struct ExpandMacroCommand: SwiftCommand {
   package static let identifier: String = "expand.macro.command"

--- a/Sources/SourceKitLSP/Swift/FoldingRange.swift
+++ b/Sources/SourceKitLSP/Swift/FoldingRange.swift
@@ -10,17 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
 import SKLogging
 import SKUtilities
 import SwiftSyntax
-#else
-import LanguageServerProtocol
-import SKLogging
-import SKUtilities
-import SwiftSyntax
-#endif
 
 fileprivate final class FoldingRangeFinder: SyntaxAnyVisitor {
   private let snapshot: DocumentSnapshot

--- a/Sources/SourceKitLSP/Swift/MacroExpansionReferenceDocumentURLData.swift
+++ b/Sources/SourceKitLSP/Swift/MacroExpansionReferenceDocumentURLData.swift
@@ -10,15 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 package import LanguageServerProtocol
 import RegexBuilder
-#else
-import Foundation
-import LanguageServerProtocol
-import RegexBuilder
-#endif
 
 /// Represents url of macro expansion reference document as follows:
 /// `sourcekit-lsp://swift-macro-expansion/LaCb-LcCd.swift?fromLine=&fromColumn=&toLine=&toColumn=&bufferName=&parent=`

--- a/Sources/SourceKitLSP/Swift/OpenInterface.swift
+++ b/Sources/SourceKitLSP/Swift/OpenInterface.swift
@@ -11,13 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import SKLogging
-
-#if compiler(>=6)
 package import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
+import SKLogging
 
 extension SwiftLanguageService {
   package func openGeneratedInterface(

--- a/Sources/SourceKitLSP/Swift/RefactoringEdit.swift
+++ b/Sources/SourceKitLSP/Swift/RefactoringEdit.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
 import SourceKitD
-#else
-import LanguageServerProtocol
-import SourceKitD
-#endif
 
 /// Represents an edit from semantic refactor response. Notionally, a subclass of `TextEdit`
 package struct RefactoringEdit: Hashable, Sendable, Codable {

--- a/Sources/SourceKitLSP/Swift/SemanticRefactorCommand.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticRefactorCommand.swift
@@ -10,15 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import Csourcekitd
 package import LanguageServerProtocol
 import SourceKitD
-#else
-import Csourcekitd
-import LanguageServerProtocol
-import SourceKitD
-#endif
 
 package struct SemanticRefactorCommand: SwiftCommand {
   typealias Response = SemanticRefactoring

--- a/Sources/SourceKitLSP/Swift/SemanticTokens.swift
+++ b/Sources/SourceKitLSP/Swift/SemanticTokens.swift
@@ -10,21 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
 import SKLogging
 import SourceKitD
 import SwiftIDEUtils
 import SwiftParser
 import SwiftSyntax
-#else
-import LanguageServerProtocol
-import SKLogging
-import SourceKitD
-import SwiftIDEUtils
-import SwiftParser
-import SwiftSyntax
-#endif
 
 extension SwiftLanguageService {
   /// Requests the semantic highlighting tokens for the given snapshot from sourcekitd.

--- a/Sources/SourceKitLSP/Swift/SwiftCommand.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftCommand.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 /// The set of known Swift commands.
 ///

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -10,9 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
-package import BuildSystemIntegration
 import BuildServerProtocol
+package import BuildSystemIntegration
 import Csourcekitd
 import Dispatch
 import Foundation
@@ -29,26 +28,6 @@ import SwiftParser
 import SwiftParserDiagnostics
 package import SwiftSyntax
 package import ToolchainRegistry
-#else
-import BuildSystemIntegration
-import BuildServerProtocol
-import Csourcekitd
-import Dispatch
-import Foundation
-import IndexStoreDB
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-import SKOptions
-import SKUtilities
-import SemanticIndex
-import SourceKitD
-import SwiftExtensions
-import SwiftParser
-import SwiftParserDiagnostics
-import SwiftSyntax
-import ToolchainRegistry
-#endif
 
 #if os(Windows)
 import WinSDK

--- a/Sources/SourceKitLSP/Swift/SymbolInfo.swift
+++ b/Sources/SourceKitLSP/Swift/SymbolInfo.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
-#else
-import LanguageServerProtocol
-#endif
 
 extension SwiftLanguageService {
   package func symbolInfo(_ req: SymbolInfoRequest) async throws -> [SymbolDetails] {

--- a/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxHighlightingToken.swift
@@ -10,15 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import LanguageServerProtocol
 import SKLogging
 import SourceKitD
-#else
-import LanguageServerProtocol
-import SKLogging
-import SourceKitD
-#endif
 
 /// A ranged token in the document used for syntax highlighting.
 package struct SyntaxHighlightingToken: Hashable, Sendable {

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 import BuildServerProtocol
 import BuildSystemIntegration
 import Foundation
@@ -20,17 +19,6 @@ import SKLogging
 import SemanticIndex
 import SwiftExtensions
 import SwiftSyntax
-#else
-import BuildServerProtocol
-import BuildSystemIntegration
-import Foundation
-import IndexStoreDB
-import LanguageServerProtocol
-import SKLogging
-import SemanticIndex
-import SwiftExtensions
-import SwiftSyntax
-#endif
 
 package enum TestStyle {
   package static let xcTest = "XCTest"

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import BuildServerProtocol
 package import BuildSystemIntegration
 import Foundation
@@ -21,28 +20,11 @@ import SKLogging
 package import SKOptions
 package import SemanticIndex
 import SwiftExtensions
-import ToolchainRegistry
 import TSCExtensions
+import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
 import struct TSCBasic.RelativePath
-#else
-import BuildServerProtocol
-import BuildSystemIntegration
-import Foundation
-import IndexStoreDB
-import LanguageServerProtocol
-import LanguageServerProtocolExtensions
-import SKLogging
-import SKOptions
-import SemanticIndex
-import SwiftExtensions
-import ToolchainRegistry
-import TSCExtensions
-
-import struct TSCBasic.AbsolutePath
-import struct TSCBasic.RelativePath
-#endif
 
 /// Actor that caches realpaths for `sourceFilesWithSameRealpath`.
 fileprivate actor SourceFilesWithSameRealpathInferrer {

--- a/Sources/SwiftExtensions/FileManagerExtensions.swift
+++ b/Sources/SwiftExtensions/FileManagerExtensions.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
-#else
-import Foundation
-#endif
 
 extension FileManager {
   /// Same as `fileExists(atPath:)` but takes a `URL` instead of a `String`.

--- a/Sources/SwiftExtensions/PipeAsStringHandler.swift
+++ b/Sources/SwiftExtensions/PipeAsStringHandler.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
-#else
-import Foundation
-#endif
 
 /// Gathers data from a stdout or stderr pipe. When it has accumulated a full line, calls the handler to handle the
 /// string.

--- a/Sources/SwiftExtensions/URLExtensions.swift
+++ b/Sources/SwiftExtensions/URLExtensions.swift
@@ -10,11 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
-#else
-import Foundation
-#endif
 
 enum FilePathError: Error, CustomStringConvertible {
   case noFileSystemRepresentation(URL)

--- a/Sources/SwiftSourceKitClientPlugin/ClientPlugin.swift
+++ b/Sources/SwiftSourceKitClientPlugin/ClientPlugin.swift
@@ -10,16 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+public import Csourcekitd
 import Foundation
 import SourceKitD
 import SwiftExtensions
 import SwiftSourceKitPluginCommon
-
-#if compiler(>=6)
-public import Csourcekitd
-#else
-import Csourcekitd
-#endif
 
 #if compiler(>=6.3)
 #warning("Remove sourcekitd_plugin_initialize when we no longer support toolchains that call it")

--- a/Sources/SwiftSourceKitPlugin/Plugin.swift
+++ b/Sources/SwiftSourceKitPlugin/Plugin.swift
@@ -10,17 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+public import Csourcekitd
 import Foundation
 import SKLogging
 import SourceKitD
 import SwiftExtensions
 import SwiftSourceKitPluginCommon
-
-#if compiler(>=6)
-public import Csourcekitd
-#else
-import Csourcekitd
-#endif
 
 private func useNewAPI(for dict: SKDRequestDictionaryReader) -> Bool {
   guard let opts: SKDRequestDictionaryReader = dict[dict.sourcekitd.keys.codeCompleteOptions],

--- a/Sources/SwiftSourceKitPluginCommon/CompletionResultsArray.swift
+++ b/Sources/SwiftSourceKitPluginCommon/CompletionResultsArray.swift
@@ -10,13 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SourceKitD
-
-#if compiler(>=6)
 package import Csourcekitd
-#else
-import Csourcekitd
-#endif
+import SourceKitD
 
 package struct CompletionResult {
   package struct StringEntry {

--- a/Sources/SwiftSourceKitPluginCommon/DynamicallyLoadedSourceKitdD+forPlugin.swift
+++ b/Sources/SwiftSourceKitPluginCommon/DynamicallyLoadedSourceKitdD+forPlugin.swift
@@ -12,13 +12,8 @@
 
 import Foundation
 import SKLogging
-import SwiftExtensions
-
-#if compiler(>=6)
 package import SourceKitD
-#else
-import SourceKitD
-#endif
+import SwiftExtensions
 
 extension DynamicallyLoadedSourceKitD {
   private static nonisolated(unsafe) var _forPlugin: SourceKitD?

--- a/Sources/TSCExtensions/ByteString.swift
+++ b/Sources/TSCExtensions/ByteString.swift
@@ -10,15 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6)
 package import Foundation
 
 package import struct TSCBasic.ByteString
-#else
-import Foundation
-
-import struct TSCBasic.ByteString
-#endif
 
 extension ByteString {
   /// Access the contents of `self` as `Data`. The contents are not copied, so it is not safe to

--- a/Sources/TSCExtensions/Process+Run.swift
+++ b/Sources/TSCExtensions/Process+Run.swift
@@ -14,19 +14,11 @@ import Foundation
 import SKLogging
 import SwiftExtensions
 
-#if compiler(>=6)
 package import struct TSCBasic.AbsolutePath
 package import class TSCBasic.Process
 package import enum TSCBasic.ProcessEnv
 package import struct TSCBasic.ProcessEnvironmentBlock
 package import struct TSCBasic.ProcessResult
-#else
-import struct TSCBasic.AbsolutePath
-import class TSCBasic.Process
-import enum TSCBasic.ProcessEnv
-import struct TSCBasic.ProcessEnvironmentBlock
-import struct TSCBasic.ProcessResult
-#endif
 
 #if os(Windows)
 import WinSDK

--- a/Sources/TSCExtensions/URL+appendingRelativePath.swift
+++ b/Sources/TSCExtensions/URL+appendingRelativePath.swift
@@ -10,17 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+package import Foundation
 import SwiftExtensions
 
-#if compiler(>=6)
 package import struct TSCBasic.AbsolutePath
 package import struct TSCBasic.RelativePath
-package import Foundation
-#else
-import struct TSCBasic.AbsolutePath
-import struct TSCBasic.RelativePath
-import Foundation
-#endif
 
 extension URL {
   package func appending(_ relativePath: RelativePath) -> URL {

--- a/Sources/ToolchainRegistry/Toolchain.swift
+++ b/Sources/ToolchainRegistry/Toolchain.swift
@@ -10,17 +10,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+package import Foundation
 import RegexBuilder
 import SKLogging
 import SwiftExtensions
 
 import class TSCBasic.Process
-
-#if compiler(>=6)
-package import Foundation
-#else
-import Foundation
-#endif
 
 /// A Swift version consisting of the major and minor component.
 package struct SwiftVersion: Sendable, Comparable, CustomStringConvertible {

--- a/Sources/ToolchainRegistry/ToolchainRegistry.swift
+++ b/Sources/ToolchainRegistry/ToolchainRegistry.swift
@@ -11,24 +11,15 @@
 //===----------------------------------------------------------------------===//
 
 import Dispatch
+package import Foundation
 import SKLogging
 import SwiftExtensions
 import TSCExtensions
 
-#if compiler(>=6)
-package import Foundation
 package import class TSCBasic.Process
 package import enum TSCBasic.ProcessEnv
 package import struct TSCBasic.ProcessEnvironmentKey
 package import func TSCBasic.getEnvSearchPaths
-#else
-import Foundation
-import struct TSCBasic.AbsolutePath
-import class TSCBasic.Process
-import enum TSCBasic.ProcessEnv
-import struct TSCBasic.ProcessEnvironmentKey
-import func TSCBasic.getEnvSearchPaths
-#endif
 
 /// Set of known toolchains.
 ///

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+public import ArgumentParser
 import BuildSystemIntegration
 import Csourcekitd  // Not needed here, but fixes debugging...
 import Diagnose
@@ -25,12 +26,6 @@ import SwiftExtensions
 import ToolchainRegistry
 
 import struct TSCBasic.AbsolutePath
-
-#if compiler(>=6)
-public import ArgumentParser
-#else
-import ArgumentParser
-#endif
 
 #if canImport(Android)
 import Android


### PR DESCRIPTION
This significantly cleans up our `import` statements