### PR TITLE
Vend InProcessClient as a package library product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,7 @@ var products: [Product] = [
   .executable(name: "sourcekit-lsp", targets: ["sourcekit-lsp"]),
   .library(name: "_SourceKitLSP", targets: ["SourceKitLSP"]),
   .library(name: "LSPBindings", targets: ["LanguageServerProtocol", "LanguageServerProtocolJSONRPC"]),
+  .library(name: "InProcessClient", targets: ["InProcessClient"]),
   .library(name: "SwiftSourceKitPlugin", type: .dynamic, targets: ["SwiftSourceKitPlugin"]),
   .library(name: "SwiftSourceKitClientPlugin", type: .dynamic, targets: ["SwiftSourceKitClientPlugin"]),
 ]


### PR DESCRIPTION
This allows people writing tools on top of SourceKit-LSP to be able to directly use the `InProcessSourceKitLSPClient` to directly send requests within their applications.

This addresses #2040