### PR TITLE
Do not send `DiagnosticsRefreshRequest` to the client if it doesn't support it

### DIFF
--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -365,12 +365,6 @@ package final class TestSourceKitLSPClient: MessageHandler, Sendable {
         return (handler, index, handlerAndIsOneShot.isOneShot)
       }.first
       guard let (requestHandler, index, isOneShot) = requestHandlerIndexAndIsOneShot else {
-        if Request.self == DiagnosticsRefreshRequest.self {
-          // Ignore diagnostic refresh requests. This keeps the log a little cleaner than if we return
-          // methodNotFound.
-          reply(.success(VoidResponse() as! Request.Response))
-          return
-        }
         reply(.failure(.methodNotFound(Request.method)))
         return
       }

--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -237,6 +237,12 @@ package actor SwiftLanguageService: LanguageService, Sendable {
         logger.fault("Not sending DiagnosticRefreshRequest to client because sourceKitLSPServer has been deallocated")
         return
       }
+      guard
+        await sourceKitLSPServer.capabilityRegistry?.clientCapabilities.workspace?.diagnostics?.refreshSupport ?? false
+      else {
+        logger.debug("Not sending DiagnosticRefreshRequest because the client doesn't support it")
+        return
+      }
       _ = await orLog("Sending DiagnosticRefreshRequest to client after document dependencies updated") {
         try await sourceKitLSPServer.sendRequestToClient(DiagnosticsRefreshRequest())
       }

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -572,7 +572,10 @@ final class BackgroundIndexingTests: XCTestCase {
           ]
         )
         """,
-      capabilities: ClientCapabilities(window: WindowClientCapabilities(workDoneProgress: true)),
+      capabilities: ClientCapabilities(
+        workspace: WorkspaceClientCapabilities(diagnostics: RefreshRegistrationCapability(refreshSupport: true)),
+        window: WindowClientCapabilities(workDoneProgress: true)
+      ),
       hooks: testHooks,
       enableBackgroundIndexing: true,
       cleanUp: { expectedPreparationTracker.keepAlive() }

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -342,6 +342,9 @@ class DefinitionTests: XCTestCase {
         }
         """,
       ],
+      capabilities: ClientCapabilities(
+        workspace: WorkspaceClientCapabilities(diagnostics: RefreshRegistrationCapability(refreshSupport: true))
+      ),
       enableBackgroundIndexing: true
     )
 
@@ -408,7 +411,10 @@ class DefinitionTests: XCTestCase {
             .target(name: "LibB", dependencies: ["LibA"]),
           ]
         )
-        """
+        """,
+      capabilities: ClientCapabilities(
+        workspace: WorkspaceClientCapabilities(diagnostics: RefreshRegistrationCapability(refreshSupport: true))
+      )
     )
 
     let (bUri, bPositions) = try project.openDocument("LibB.swift")

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -179,7 +179,10 @@ final class PullDiagnosticsTests: XCTestCase {
           sayHello()
         }
         """,
-      ]
+      ],
+      capabilities: ClientCapabilities(
+        workspace: WorkspaceClientCapabilities(diagnostics: RefreshRegistrationCapability(refreshSupport: true))
+      )
     )
 
     let (bUri, _) = try project.openDocument("FileB.swift")
@@ -235,7 +238,10 @@ final class PullDiagnosticsTests: XCTestCase {
             .target(name: "LibB", dependencies: ["LibA"]),
           ]
         )
-        """
+        """,
+      capabilities: ClientCapabilities(
+        workspace: WorkspaceClientCapabilities(diagnostics: RefreshRegistrationCapability(refreshSupport: true))
+      )
     )
 
     let (bUri, _) = try project.openDocument("LibB.swift")

--- a/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
@@ -328,6 +328,9 @@ final class SwiftPMIntegrationTests: XCTestCase {
         let x: String = 1
         """
       ],
+      capabilities: ClientCapabilities(
+        workspace: WorkspaceClientCapabilities(diagnostics: RefreshRegistrationCapability(refreshSupport: true))
+      ),
       hooks: Hooks(
         buildSystemHooks: BuildSystemHooks(
           swiftPMTestHooks: SwiftPMTestHooks(reloadPackageDidStart: {


### PR DESCRIPTION
Check if the client's capabilities to see if it supports `workspace/diagnostic/refresh`.