### PR TITLE
Support cancellation in `CustomBuildServer`

### DIFF
--- a/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
@@ -527,6 +527,8 @@ final class BuildServerBuildSystemTests: XCTestCase {
   func testDontBlockBuildServerInitializationIfBuildSystemIsUnresponsive() async throws {
     // A build server that responds to the initialize request but not to any other requests.
     final class UnresponsiveBuildServer: CustomBuildServer {
+      let inProgressRequestsTracker = CustomBuildServerInProgressRequestTracker()
+
       init(projectRoot: URL, connectionToSourceKitLSP: any Connection) {}
 
       func buildTargetSourcesRequest(_ request: BuildTargetSourcesRequest) async throws -> BuildTargetSourcesResponse {

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -23,6 +23,7 @@ import ToolchainRegistry
 import XCTest
 
 fileprivate actor TestBuildSystem: CustomBuildServer {
+  let inProgressRequestsTracker = CustomBuildServerInProgressRequestTracker()
   private let connectionToSourceKitLSP: any Connection
   private var buildSettingsByFile: [DocumentURI: TextDocumentSourceKitOptionsResponse] = [:]
 

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1955,6 +1955,7 @@ final class BackgroundIndexingTests: XCTestCase {
 
   func testIndexFileIfBuildTargetsChange() async throws {
     actor BuildServer: CustomBuildServer {
+      let inProgressRequestsTracker = CustomBuildServerInProgressRequestTracker()
       private let projectRoot: URL
       private let connectionToSourceKitLSP: any Connection
       private var buildSettingsByFile: [DocumentURI: TextDocumentSourceKitOptionsResponse] = [:]
@@ -2106,6 +2107,7 @@ final class BackgroundIndexingTests: XCTestCase {
     // response file to invoke the indexer.
 
     final class BuildServer: CustomBuildServer {
+      let inProgressRequestsTracker = CustomBuildServerInProgressRequestTracker()
       private let projectRoot: URL
       private var testFileURL: URL { projectRoot.appendingPathComponent("Test File.swift") }
 

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -24,6 +24,7 @@ import ToolchainRegistry
 import XCTest
 
 fileprivate actor TestBuildSystem: CustomBuildServer {
+  let inProgressRequestsTracker = CustomBuildServerInProgressRequestTracker()
   private let connectionToSourceKitLSP: any Connection
   private var buildSettingsByFile: [DocumentURI: TextDocumentSourceKitOptionsResponse] = [:]
 


### PR DESCRIPTION
I developed this for a test case that didn’t end up being useful. But supporting request cancellation here might come in useful in the future.