### PR TITLE
Log sourcekitd requests inside `withCancellableCheckedThrowingContinuation`

### DIFF
--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -139,10 +139,9 @@ extension SourceKitD {
     timeout: Duration,
     fileContents: String?
   ) async throws -> SKDResponseDictionary {
-    log(request: request)
-
     let sourcekitdResponse = try await withTimeout(timeout) {
       return try await withCancellableCheckedThrowingContinuation { (continuation) -> SourceKitDRequestHandle? in
+        self.log(request: request)
         var handle: sourcekitd_api_request_handle_t? = nil
         self.api.send_request(request.dict, &handle) { response in
           continuation.resume(returning: SKDResponse(response!, sourcekitd: self))


### PR DESCRIPTION
Otherwise, we would log sending the sourcekitd request even if the task was already cancelled and we thus took an early exit in `withCancellableCheckedThrowingContinuation`.