### PR TITLE
Only show the `Scheduling Indexing` progress if no indexing tasks are currently happening

### DIFF
--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -215,9 +215,6 @@ package final actor SemanticIndexManager {
     if inProgressPreparationTasks.values.contains(where: { $0.purpose == .forEditorFunctionality }) {
       return .preparingFileForEditorFunctionality
     }
-    if !scheduleIndexingTasks.isEmpty {
-      return .schedulingIndexing
-    }
     let preparationTasks = inProgressPreparationTasks.mapValues { inProgressTask in
       return inProgressTask.task.isExecuting ? IndexTaskStatus.executing : IndexTaskStatus.scheduled
     }
@@ -230,6 +227,9 @@ package final actor SemanticIndexManager {
       }
     }
     if preparationTasks.isEmpty && indexTasks.isEmpty {
+      if !scheduleIndexingTasks.isEmpty {
+        return .schedulingIndexing
+      }
       return .upToDate
     }
     return .indexing(preparationTasks: preparationTasks, indexTasks: indexTasks)


### PR DESCRIPTION
- **Issue**: Since https://github.com/swiftlang/sourcekit-lsp/pull/1973, we are watching for all changes in SourceKit-LSP. This means that we get notified every time the index database is changed. Each of these modifications triggers a new task that waits for build system updates to determine if the modified file needs to be re-indexed. While this task finishes very quickly, it still causes `Scheduling indexing` to replace the `Indexing x / y` in the index status during initial indexing, which looks very noisy.
- **Explanation**: To avoid this flickering, only show `Scheduling indexing` in the index status if we aren’t already indexing any files
- **Scope**: Index progress status
- **Original PR**: This is a significantly reduced version of https://github.com/swiftlang/sourcekit-lsp/pull/2051
- **Risk**: Low, this only changes the precedence of status messages in the indexing status
- **Testing**: Manually verified that we don’t see `Scheduling indexing` appear during initial indexing of a package
- **Reviewer**: @bnbarham