### PR TITLE
Handle file did change notifications as freestanding messages

### DIFF
--- a/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
+++ b/Sources/SourceKitLSP/MessageHandlingDependencyTracker.swift
@@ -103,7 +103,12 @@ package enum MessageHandlingDependencyTracker: QueueBasedMessageHandlerDependenc
     case let notification as DidChangeTextDocumentNotification:
       self = .documentUpdate(notification.textDocument.uri)
     case is DidChangeWatchedFilesNotification:
-      self = .globalConfigurationChange
+      // Technically, the watched files notification can change the response of any other request (eg. because a target
+      // needs to be re-prepared). But treating it as a `globalConfiguration` inserts a lot of barriers in request
+      // handling and significantly prevents parallelism. Since many editors batch file change notifications already,
+      // they might have delayed the file change notification even more, which is equivalent to handling the
+      // notification a little later inside SourceKit-LSP. Thus, treating it as `freestanding` should be acceptable.
+      self = .freestanding
     case is DidChangeWorkspaceFoldersNotification:
       self = .globalConfigurationChange
     case let notification as DidCloseNotebookDocumentNotification:

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1482,9 +1482,7 @@ extension SourceKitLSPServer {
     // a file doesn't mean a file can't affect the build system's build settings
     // (e.g. Package.swift doesn't have build settings but affects build
     // settings). Inform the build system about all file changes.
-    for workspace in workspaces {
-      await workspace.filesDidChange(notification.changes)
-    }
+    await workspaces.concurrentForEach { await $0.filesDidChange(notification.changes) }
   }
 
   func setBackgroundIndexingPaused(_ request: SetOptionsRequest) async throws -> VoidResponse {

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -382,8 +382,10 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
 
     // Notify all clients about the reported and inferred edits.
     await buildSystemManager.filesDidChange(events)
-    await syntacticTestIndex.filesDidChange(events)
-    await semanticIndexManager?.filesDidChange(events)
+
+    async let updateSyntacticIndex: Void = await syntacticTestIndex.filesDidChange(events)
+    async let updateSemanticIndex: Void? = await semanticIndexManager?.filesDidChange(events)
+    _ = await (updateSyntacticIndex, updateSemanticIndex)
   }
 
   func documentService(for uri: DocumentURI) -> LanguageService? {

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -56,17 +56,7 @@ final class CompilationDatabaseTests: XCTestCase {
 
     // Remove -DFOO from the compile commands.
 
-    let compileFlagsUri = try project.uri(for: FixedCompilationDatabaseBuildSystem.dbName)
-    try await "".writeWithRetry(to: XCTUnwrap(compileFlagsUri.fileURL))
-
-    project.testClient.send(
-      DidChangeWatchedFilesNotification(changes: [
-        FileEvent(uri: compileFlagsUri, type: .changed)
-      ])
-    )
-
-    // Ensure that the DidChangeWatchedFilesNotification is handled before we continue.
-    try await project.testClient.send(PollIndexRequest())
+    try await project.changeFileOnDisk(FixedCompilationDatabaseBuildSystem.dbName, newMarkedContents: "")
 
     // DocumentHighlight should now point to the definition in the `#else` block.
 

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -351,12 +351,9 @@ class DefinitionTests: XCTestCase {
     )
     XCTAssertNil(beforeChangingFileA)
 
-    let (updatedAPositions, updatedACode) = DocumentPositions.extract(from: "func 2️⃣sayHello() {}")
-
-    let aUri = try project.uri(for: "FileA.swift")
-    try await updatedACode.writeWithRetry(to: XCTUnwrap(aUri.fileURL))
-    project.testClient.send(
-      DidChangeWatchedFilesNotification(changes: [FileEvent(uri: aUri, type: .changed)])
+    let (aUri, updatedAPositions) = try await project.changeFileOnDisk(
+      "FileA.swift",
+      newMarkedContents: "func 2️⃣sayHello() {}"
     )
 
     // Wait until SourceKit-LSP has handled the `DidChangeWatchedFilesNotification` (which it only does after a delay

--- a/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
+++ b/Tests/SourceKitLSPTests/MainFilesProviderTests.swift
@@ -188,13 +188,11 @@ final class MainFilesProviderTests: XCTestCase {
     let preEditDiag = try XCTUnwrap(preEditDiags.diagnostics.first)
     XCTAssertEqual(preEditDiag.message, "Unused variable 'fromMyLibrary'")
 
-    let newFancyLibraryContents = """
-      #include "\(try project.scratchDirectory.filePath)/Sources/shared.h"
-      """
-    let fancyLibraryUri = try project.uri(for: "MyFancyLibrary.c")
-    try await newFancyLibraryContents.writeWithRetry(to: XCTUnwrap(fancyLibraryUri.fileURL))
-    project.testClient.send(
-      DidChangeWatchedFilesNotification(changes: [FileEvent(uri: fancyLibraryUri, type: .changed)])
+    try await project.changeFileOnDisk(
+      "MyFancyLibrary.c",
+      newMarkedContents: """
+        #include "\(try project.scratchDirectory.filePath)/Sources/shared.h"
+        """
     )
 
     // 'MyFancyLibrary.c' now also includes 'shared.h'. Since it lexicographically precedes MyLibrary, we should use its

--- a/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PublishDiagnosticsTests.swift
@@ -146,12 +146,7 @@ final class PublishDiagnosticsTests: XCTestCase {
       return false
     }
 
-    let updatedACode = "func sayHello() {}"
-    let aUri = try project.uri(for: "FileA.swift")
-    try await updatedACode.writeWithRetry(to: XCTUnwrap(aUri.fileURL))
-    project.testClient.send(
-      DidChangeWatchedFilesNotification(changes: [FileEvent(uri: aUri, type: .changed)])
-    )
+    try await project.changeFileOnDisk("FileA.swift", newMarkedContents: "func sayHello() {}")
 
     let diagnosticsAfterChangingFileA = try await project.testClient.nextDiagnosticsNotification()
     XCTAssertEqual(diagnosticsAfterChangingFileA.diagnostics, [])

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -196,13 +196,7 @@ final class PullDiagnosticsTests: XCTestCase {
       return VoidResponse()
     }
 
-    let updatedACode = "func sayHello() {}"
-    let aUri = try project.uri(for: "FileA.swift")
-    try await updatedACode.writeWithRetry(to: XCTUnwrap(aUri.fileURL))
-    project.testClient.send(
-      DidChangeWatchedFilesNotification(changes: [FileEvent(uri: aUri, type: .changed)])
-    )
-
+    try await project.changeFileOnDisk("FileA.swift", newMarkedContents: "func sayHello() {}")
     try await fulfillmentOfOrThrow([diagnosticsRefreshRequestReceived])
 
     let afterChangingFileA = try await project.testClient.send(

--- a/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
@@ -521,14 +521,13 @@ final class SwiftPMIntegrationTests: XCTestCase {
     }
 
     // Make a change to the top level input file of the plugin command
-    let topDepUri = try project.uri(for: "topDep.txt")
-    let topDepUrl = try XCTUnwrap(topDepUri.fileURL)
-    try "// some change\nlet topGenerated = 2".write(
-      to: topDepUrl,
-      atomically: true,
-      encoding: .utf8
+    try await project.changeFileOnDisk(
+      "topDep.txt",
+      newMarkedContents: """
+        // some change
+        let topGenerated = 2
+        """
     )
-    project.testClient.send(DidChangeWatchedFilesNotification(changes: [FileEvent(uri: topDepUri, type: .changed)]))
     try await project.testClient.send(PollIndexRequest())
 
     // Expect that the position has been updated in the dependency
@@ -541,14 +540,13 @@ final class SwiftPMIntegrationTests: XCTestCase {
     }
 
     // Make a change to the target level input file of the plugin command
-    let targetDepUri = try project.uri(for: "targetDep.txt")
-    let targetDepUrl = try XCTUnwrap(targetDepUri.fileURL)
-    try "// some change\nlet targetGenerated = 2".write(
-      to: targetDepUrl,
-      atomically: true,
-      encoding: .utf8
+    try await project.changeFileOnDisk(
+      "targetDep.txt",
+      newMarkedContents: """
+        // some change
+        let targetGenerated = 2
+        """
     )
-    project.testClient.send(DidChangeWatchedFilesNotification(changes: [FileEvent(uri: targetDepUri, type: .changed)]))
     try await project.testClient.send(PollIndexRequest())
 
     // Expect that the position has been updated in the dependency


### PR DESCRIPTION
Technically, the watched files notification can change the response of any other request (eg. because a target needs to be re-prepared). But treating it as a `globalConfiguration` inserts a lot of barriers in request  handling and significantly prevents parallelism. Since many editors batch file change notifications already, they might have delayed the file change notification even more, which is equivalent to handling the  notification a little later inside SourceKit-LSP. Thus, treating it as `freestanding` should be acceptable.

Also, simplify the logic needed in tests to write modified files to disk because we now need to run a barrier request in tests to ensure that the watched file notification has been handled.