### PR TITLE
Allow specifying toolsets for SwiftPM projects

### DIFF
--- a/Documentation/Configuration File.md
+++ b/Documentation/Configuration File.md
@@ -20,6 +20,7 @@ The structure of the file is currently not guaranteed to be stable. Options may 
   - `swiftSDKsDirectory: string`: Equivalent to SwiftPM's `--swift-sdks-path` option.
   - `swiftSDK: string`: Equivalent to SwiftPM's `--swift-sdk` option.
   - `triple: string`: Equivalent to SwiftPM's `--triple` option.
+  - `toolsets: string[]`: Equivalent to SwiftPM's `--toolset` option.
   - `traits: string[]`: Traits to enable for the package. Equivalent to SwiftPM's `--traits` option.
   - `cCompilerFlags: string[]`: Extra arguments passed to the compiler for C files. Equivalent to SwiftPM's `-Xcc` option.
   - `cxxCompilerFlags: string[]`: Extra arguments passed to the compiler for C++ files. Equivalent to SwiftPM's `-Xcxx` option.

--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -208,6 +208,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
     let destinationSDK = try SwiftSDK.deriveTargetSwiftSDK(
       hostSwiftSDK: hostSDK,
       hostTriple: hostSwiftPMToolchain.targetTriple,
+      customToolsets: options.swiftPMOrDefault.toolsets?.map { try AbsolutePath(validating: $0) } ?? [],
       customCompileTriple: options.swiftPMOrDefault.triple.map { try Triple($0) },
       swiftSDKSelector: options.swiftPMOrDefault.swiftSDK,
       store: SwiftSDKBundleStore(

--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -44,6 +44,9 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     /// Equivalent to SwiftPM's `--triple` option.
     public var triple: String?
 
+    /// Equivalent to SwiftPM's `--toolset` option.
+    public var toolsets: [String]?
+
     /// Traits to enable for the package. Equivalent to SwiftPM's `--traits` option.
     public var traits: [String]?
 
@@ -79,6 +82,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
       swiftSDKsDirectory: String? = nil,
       swiftSDK: String? = nil,
       triple: String? = nil,
+      toolsets: [String]? = nil,
       traits: [String]? = nil,
       cCompilerFlags: [String]? = nil,
       cxxCompilerFlags: [String]? = nil,
@@ -93,6 +97,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
       self.swiftSDKsDirectory = swiftSDKsDirectory
       self.swiftSDK = swiftSDK
       self.triple = triple
+      self.toolsets = toolsets
       self.traits = traits
       self.cCompilerFlags = cCompilerFlags
       self.cxxCompilerFlags = cxxCompilerFlags
@@ -109,6 +114,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
         swiftSDKsDirectory: override?.swiftSDKsDirectory ?? base.swiftSDKsDirectory,
         swiftSDK: override?.swiftSDK ?? base.swiftSDK,
         triple: override?.triple ?? base.triple,
+        toolsets: override?.toolsets ?? base.toolsets,
         traits: override?.traits ?? base.traits,
         cCompilerFlags: override?.cCompilerFlags ?? base.cCompilerFlags,
         cxxCompilerFlags: override?.cxxCompilerFlags ?? base.cxxCompilerFlags,

--- a/config.schema.json
+++ b/config.schema.json
@@ -272,6 +272,14 @@
           "markdownDescription" : "Equivalent to SwiftPM's `--swift-sdks-path` option.",
           "type" : "string"
         },
+        "toolsets" : {
+          "description" : "Equivalent to SwiftPM's `--toolset` option.",
+          "items" : {
+            "type" : "string"
+          },
+          "markdownDescription" : "Equivalent to SwiftPM's `--toolset` option.",
+          "type" : "array"
+        },
         "traits" : {
           "description" : "Traits to enable for the package. Equivalent to SwiftPM's `--traits` option.",
           "items" : {


### PR DESCRIPTION
Equivalent to SwiftPM’s `--toolset` option, implemented in https://github.com/swiftlang/swift-package-manager/pull/8051.

Fixes #2047
rdar://146557424