### PR TITLE
Do not apply file path normalization in `mainFiles(containing:)` to the file itself

### DIFF
--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -1312,6 +1312,19 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
     #if canImport(Darwin)
     if let buildableSourceFiles = try? await self.buildableSourceFiles() {
       return mainFiles.map { mainFile in
+        if mainFile == uri {
+          // Do not apply the standardized file normalization to the source file itself. Otherwise we would get the
+          // following behavior:
+          //  - We have a build system that uses standardized file paths and index a file as /tmp/test.c
+          //  - We are asking for the main files of /private/tmp/test.c
+          //  - Since indexstore-db uses realpath for everything, we find the unit for /tmp/test.c as a unit containg
+          //    /private/tmp/test.c, which has /private/tmp/test.c as the main file.
+          //  - If we applied the path normalization, we would normalize /private/tmp/test.c to /tmp/test.c, thus
+          //    reporting that /tmp/test.c is a main file containing /private/tmp/test.c,
+          // But that doesn't make sense (it would, in fact cause us to treat /private/tmp/test.c as a header file that
+          // we should index using /tmp/test.c as a main file.
+          return mainFile
+        }
         if buildableSourceFiles.contains(mainFile) {
           return mainFile
         }

--- a/Sources/SKTestSupport/MultiFileTestProject.swift
+++ b/Sources/SKTestSupport/MultiFileTestProject.swift
@@ -139,10 +139,11 @@ package class MultiFileTestProject {
     enableBackgroundIndexing: Bool = false,
     usePullDiagnostics: Bool = true,
     preInitialization: ((TestSourceKitLSPClient) -> Void)? = nil,
+    testScratchDir overrideTestScratchDir: URL? = nil,
     cleanUp: (@Sendable () -> Void)? = nil,
     testName: String = #function
   ) async throws {
-    scratchDirectory = try testScratchDir(testName: testName)
+    scratchDirectory = try overrideTestScratchDir ?? testScratchDir(testName: testName)
     self.fileData = try Self.writeFilesToDisk(files: files, scratchDirectory: scratchDirectory)
 
     self.testClient = try await TestSourceKitLSPClient(

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -481,6 +481,7 @@ package final actor SemanticIndexManager {
         // if we request the same header to be indexed twice, we'll pick the same unit file the second time around,
         // realize that its timestamp is later than the modification date of the header and we don't need to re-index.
         let mainFile = await buildSystemManager.mainFiles(containing: uri)
+          .filter { sourceFiles.contains($0) }
           .sorted(by: { $0.stringValue < $1.stringValue }).first
         guard let mainFile else {
           logger.log("Not indexing \(uri) because its main file could not be inferred")

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -1309,7 +1309,8 @@ final class WorkspaceTests: XCTestCase {
     try SkipUnless.platformIsDarwin("The realpath vs standardized path difference only exists on macOS")
 
     // Explicitly create a directory at /tmp (which is a standardized path but whose realpath is /private/tmp)
-    let scratchDirectory = URL(fileURLWithPath: "/tmp").appendingPathComponent("sourcekitlsp-test-\(UUID())")
+    let scratchDirectory = URL(fileURLWithPath: "/tmp")
+      .appendingPathComponent(testScratchName())
     try FileManager.default.createDirectory(at: scratchDirectory, withIntermediateDirectories: true)
 
     defer {


### PR DESCRIPTION
Do not apply the standardized file normalization to the source file itself. Otherwise we would get the following behavior:
 - We have a build system that uses standardized file paths and index a file as /tmp/test.c
 - We are asking for the main files of /private/tmp/test.c
 - Since indexstore-db uses realpath for everything, we find the unit for /tmp/test.c as a unit containing /private/tmp/test.c, which has /private/tmp/test.c as the main file.
 - If we applied the path normalization, we would normalize /private/tmp/test.c to /tmp/test.c, thus reporting that /tmp/test.c is a main file containing /private/tmp/test.c, But that doesn't make sense (it would, in fact cause us to treat /private/tmp/test.c as a header file that we should index using /tmp/test.c as a main file.