### PR TITLE
Skip formatting tests if the `swift-format` executable in the host toolchain doesn’t support `-` to indicate that it’s reading the source file from stdin

### DIFF
--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -218,8 +218,7 @@ package actor SkipUnless {
       return try await withTestScratchDir { scratchDirectory in
         let input = scratchDirectory.appendingPathComponent("Input.swift")
         guard FileManager.default.createFile(atPath: input.path, contents: nil) else {
-          struct FailedToCrateInputFileError: Error {}
-          throw FailedToCrateInputFileError()
+          throw GenericError("Failed to create input file")
         }
         // If we can't compile for wasm, this fails complaining that it can't find the stdlib for wasm.
         let process = Process(
@@ -249,10 +248,7 @@ package actor SkipUnless {
   ) async throws {
     return try await shared.skipUnlessSupportedByToolchain(swiftVersion: SwiftVersion(6, 2), file: file, line: line) {
       guard let sourcekitdPath = await ToolchainRegistry.forTesting.default?.sourcekitd else {
-        struct NoSourceKitdFound: Error, CustomStringConvertible {
-          var description: String = "Could not find SourceKitD"
-        }
-        throw NoSourceKitdFound()
+        throw GenericError("Could not find SourceKitD")
       }
       let sourcekitd = try await DynamicallyLoadedSourceKitD.getOrCreate(
         dylibPath: sourcekitdPath,
@@ -354,6 +350,30 @@ package actor SkipUnless {
       return .featureSupported
     }
   }
+
+  /// Checks that swift-format supports running as `swift-format format -` to indicate that the source file should be
+  /// read from stdin, ie. that swift-format contains https://github.com/swiftlang/swift-format/pull/914.
+  package static func swiftFormatSupportsDashToIndicateReadingFromStdin(
+    file: StaticString = #filePath,
+    line: UInt = #line
+  ) async throws {
+    return try await shared.skipUnlessSupportedByToolchain(swiftVersion: SwiftVersion(6, 1), file: file, line: line) {
+      guard let swiftFormatPath = await ToolchainRegistry.forTesting.default?.swiftFormat else {
+        throw GenericError("Could not find swift-format")
+      }
+      let process = TSCBasic.Process(arguments: [try swiftFormatPath.filePath, "format", "-"])
+      let writeStream = try process.launch()
+      writeStream.send("let x = 1")
+      try writeStream.close()
+      let result = try await process.waitUntilExitStoppingProcessOnTaskCancellation()
+      let output = try result.utf8Output()
+      switch output {
+      case "": return false
+      case "let x = 1": return true
+      default: throw GenericError("Received unexpected formatting output: \(output)")
+      }
+    }
+  }
 }
 
 // MARK: - Parsing Swift compiler version
@@ -367,5 +387,13 @@ fileprivate extension String {
       let data = Data(bytes: baseAddress, count: buffer.count)
       return String(data: data, encoding: encoding)!
     }
+  }
+}
+
+private struct GenericError: Error, CustomStringConvertible {
+  var description: String
+
+  init(_ message: String) {
+    self.description = message
   }
 }

--- a/Tests/SourceKitLSPTests/FormattingTests.swift
+++ b/Tests/SourceKitLSPTests/FormattingTests.swift
@@ -18,6 +18,8 @@ import XCTest
 
 final class FormattingTests: XCTestCase {
   func testFormatting() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -51,6 +53,8 @@ final class FormattingTests: XCTestCase {
   }
 
   func testFormattingNoEdits() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -76,6 +80,8 @@ final class FormattingTests: XCTestCase {
   }
 
   func testConfigFileOnDisk() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
     let project = try await MultiFileTestProject(files: [
       ".swift-format": """
@@ -110,6 +116,8 @@ final class FormattingTests: XCTestCase {
   }
 
   func testConfigFileInParentDirectory() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
     let project = try await MultiFileTestProject(files: [
       ".swift-format": """
@@ -144,6 +152,8 @@ final class FormattingTests: XCTestCase {
   }
 
   func testConfigFileInNestedDirectory() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
     let project = try await MultiFileTestProject(files: [
       ".swift-format": """
@@ -186,6 +196,8 @@ final class FormattingTests: XCTestCase {
   }
 
   func testInvalidConfigurationFile() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
     // The swift-format default is 2 spaces.
     let project = try await MultiFileTestProject(files: [
@@ -210,6 +222,8 @@ final class FormattingTests: XCTestCase {
   }
 
   func testInsertAndRemove() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -241,6 +255,8 @@ final class FormattingTests: XCTestCase {
   }
 
   func testMultiLineStringInsertion() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 

--- a/Tests/SourceKitLSPTests/OnTypeFormattingTests.swift
+++ b/Tests/SourceKitLSPTests/OnTypeFormattingTests.swift
@@ -18,6 +18,8 @@ import XCTest
 
 final class OnTypeFormattingTests: XCTestCase {
   func testOnlyFormatsSpecifiedLine() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -51,6 +53,8 @@ final class OnTypeFormattingTests: XCTestCase {
   }
 
   func testFormatsFullLineAndDoesNotFormatNextLine() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -88,6 +92,8 @@ final class OnTypeFormattingTests: XCTestCase {
   /// Otherwise could mess up writing code. You'd write {} and try to go into the braces to write more code,
   /// only for on-type formatting to immediately close the braces again.
   func testDoesNothingWhenInAnEmptyLine() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 

--- a/Tests/SourceKitLSPTests/RangeFormattingTests.swift
+++ b/Tests/SourceKitLSPTests/RangeFormattingTests.swift
@@ -18,6 +18,8 @@ import XCTest
 
 final class RangeFormattingTests: XCTestCase {
   func testOnlyFormatsSpecifiedLines() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -50,6 +52,8 @@ final class RangeFormattingTests: XCTestCase {
   }
 
   func testOnlyFormatsSpecifiedColumns() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -82,6 +86,8 @@ final class RangeFormattingTests: XCTestCase {
   }
 
   func testFormatsMultipleLines() async throws {
+    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 


### PR DESCRIPTION
Ie if SourceKit-LSP is being tested with a Swift 6.0 toolchain