### PR TITLE
Fix issue that caused code completion to fail using compile_flags.txt

### DIFF
--- a/Sources/BuildSystemIntegration/FixedCompilationDatabaseBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/FixedCompilationDatabaseBuildSystem.swift
@@ -126,14 +126,8 @@ package actor FixedCompilationDatabaseBuildSystem: BuiltInBuildSystem {
   package func sourceKitOptions(
     request: TextDocumentSourceKitOptionsRequest
   ) async throws -> TextDocumentSourceKitOptionsResponse? {
-    let compilerName: String
-    switch request.language {
-    case .swift: compilerName = "swiftc"
-    case .c, .cpp, .objective_c, .objective_cpp: compilerName = "clang"
-    default: return nil
-    }
     return TextDocumentSourceKitOptionsResponse(
-      compilerArguments: [compilerName] + compilerArgs + [request.textDocument.uri.pseudoPath],
+      compilerArguments: compilerArgs + [request.textDocument.uri.pseudoPath],
       workingDirectory: try? configPath.deletingLastPathComponent().filePath
     )
   }

--- a/Tests/BuildSystemIntegrationTests/CompilationDatabaseTests.swift
+++ b/Tests/BuildSystemIntegrationTests/CompilationDatabaseTests.swift
@@ -239,7 +239,7 @@ final class CompilationDatabaseTests: XCTestCase {
       XCTAssertEqual(
         buildSettings,
         TextDocumentSourceKitOptionsResponse(
-          compilerArguments: ["clang", "-xc++", "-I", "libwidget/include/", try dummyFile.filePath],
+          compilerArguments: ["-xc++", "-I", "libwidget/include/", try dummyFile.filePath],
           workingDirectory: try tempDir.filePath
         )
       )

--- a/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftCompletionTests.swift
@@ -1146,6 +1146,29 @@ final class SwiftCompletionTests: XCTestCase {
     )
     XCTAssertEqual(completions.items.map(\.insertText), ["makeBool()", "makeBool(value: )"])
   }
+
+  func testCompletionUsingCompileFlagsTxt() async throws {
+    let project = try await MultiFileTestProject(
+      files: [
+        "test.swift": """
+        func test() {
+          #if FOO
+          let myVar: String
+          #else
+          let myVar: Int
+          #endif
+          print(myVar1️⃣)
+        }
+        """,
+        "compile_flags.txt": "-DFOO",
+      ]
+    )
+    let (uri, positions) = try project.openDocument("test.swift")
+    let completions = try await project.testClient.send(
+      CompletionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    XCTAssertEqual(completions.items.only?.detail, "String")
+  }
 }
 
 private func countFs(_ response: CompletionList) -> Int {


### PR DESCRIPTION
The compiler name shouldn’t be part of the build settings.