### PR TITLE
Fix expected output in swift-format `SkipUnless` check

### DIFF
--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -372,8 +372,8 @@ package actor SkipUnless {
       let output = try result.utf8Output()
       switch output {
       case "": return false
-      case "let x = 1": return true
-      default: throw GenericError("Received unexpected formatting output: \(output)")
+      case "let x = 1\n": return true
+      default: throw GenericError("Received unexpected formatting output: '\(output)'")
       }
     }
   }


### PR DESCRIPTION
We weren’t hitting this in Swift CI because we only test against Swift 6.2 toolchains, which take an earlier exit based on the Swift version.