### PR TITLE
Remove trailing comma

### DIFF
--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -27,7 +27,7 @@ import XCTest
 extension SourceKitLSPOptions {
   package static func testDefault(
     backgroundIndexing: Bool = true,
-    experimentalFeatures: Set<ExperimentalFeature> = [],
+    experimentalFeatures: Set<ExperimentalFeature> = []
   ) async throws -> SourceKitLSPOptions {
     let pluginPaths = try await sourceKitPluginPaths
     return SourceKitLSPOptions(


### PR DESCRIPTION
This restores the ability to build SourceKit-LSP using a Swift 6.0 compiler