### PR TITLE
Ensure that unit file generated by background indexing are immediately loaded into indextore-db

### DIFF
--- a/Sources/SemanticIndex/CheckedIndex.swift
+++ b/Sources/SemanticIndex/CheckedIndex.swift
@@ -336,6 +336,11 @@ package final actor UncheckedIndex: Sendable {
   package nonisolated func pollForUnitChangesAndWait() {
     self.underlyingIndexStoreDB.pollForUnitChangesAndWait()
   }
+
+  /// Import the units for the given output paths into indexstore-db. Returns after the import has finished.
+  package nonisolated func processUnitsForOutputPathsAndWait(_ outputPaths: some Collection<String>) {
+    self.underlyingIndexStoreDB.processUnitsForOutputPathsAndWait(outputPaths)
+  }
 }
 
 /// Helper class to check if symbols from the index are up-to-date or if the source file has been modified after it was

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -188,6 +188,17 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
           outputPath: fileIndexInfo.outputPath
         )
       }
+      // If we know the output paths, make sure that we load their units into indexstore-db. We would eventually also
+      // pick the units up through file watching but that would leave a short time period in which we think that
+      // indexing has finished (because the index process has terminated) but when the new symbols aren't present in
+      // indexstore-db.
+      let outputPaths = filesToIndex.compactMap { fileToIndex in
+        switch fileToIndex.outputPath {
+        case .path(let string): return string
+        case .notSupported: return nil
+        }
+      }
+      index.processUnitsForOutputPathsAndWait(outputPaths)
       await hooks.updateIndexStoreTaskDidFinish?(self)
       logger.log(
         "Finished updating index store in \(Date().timeIntervalSince(startDate) * 1000, privacy: .public)ms: \(filesToIndexDescription)"


### PR DESCRIPTION
Otherwise, we can end up in a situation where we declare indexing as done but haven’t loaded the new units into indexstore-db yet.