### PR TITLE
If the compiler arguments only contain `-o`, add the output path as `-index-unit-output-path` to the adjusted options

### DIFF
--- a/Sources/SKTestSupport/CustomBuildServerTestProject.swift
+++ b/Sources/SKTestSupport/CustomBuildServerTestProject.swift
@@ -277,6 +277,7 @@ package final class CustomBuildServerTestProject<BuildServer: CustomBuildServer>
     options: SourceKitLSPOptions? = nil,
     hooks: Hooks = Hooks(),
     enableBackgroundIndexing: Bool = false,
+    pollIndex: Bool = true,
     testScratchDir: URL? = nil,
     testName: String = #function
   ) async throws {
@@ -295,6 +296,11 @@ package final class CustomBuildServerTestProject<BuildServer: CustomBuildServer>
       testScratchDir: testScratchDir,
       testName: testName
     )
+
+    if pollIndex {
+      // Wait for the indexstore-db to finish indexing
+      try await testClient.send(SynchronizeRequest(index: true))
+    }
   }
 
   package func buildServer(file: StaticString = #filePath, line: UInt = #line) throws -> BuildServer {


### PR DESCRIPTION
Otherwise, we would strip away the `-o`, leaving the command line without any output path option and thus not able to generate a unit file (which requires an output path).