### PR TITLE
Do not re-index deleted files

### DIFF
--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -379,7 +379,7 @@ package final actor SemanticIndexManager {
   package func filesDidChange(_ events: [FileEvent]) async {
     // We only re-index the files that were changed and don't re-index any of their dependencies. See the
     // `Documentation/Files_To_Reindex.md` file.
-    let changedFiles = events.map(\.uri)
+    let changedFiles = events.filter { $0.type != .deleted }.map(\.uri)
     await indexStoreUpToDateTracker.markOutOfDate(changedFiles)
 
     // Preparation tracking should be per file. For now consider any non-known-language change as having to re-prepare


### PR DESCRIPTION
This wasn’t an issue when we were always waiting for an up-to-date build graph before indexing files but now we could still have an old build graph that contains the deleted files and thus start an indexing process for a file that doesn’t exist anymore on disk. And it’s cleaner anyway.