### PR TITLE
Terminate pending background indexing and preparation tasks when shutting down SourceKit-LSP

### DIFF
--- a/Sources/SKTestSupport/CustomBuildServerTestProject.swift
+++ b/Sources/SKTestSupport/CustomBuildServerTestProject.swift
@@ -208,7 +208,7 @@ package extension CustomBuildServer {
     )
   }
 
-  func dummyTargetSourcesResponse(_ files: some Sequence<DocumentURI>) -> BuildTargetSourcesResponse {
+  func dummyTargetSourcesResponse(files: some Sequence<DocumentURI>) -> BuildTargetSourcesResponse {
     return BuildTargetSourcesResponse(items: [
       SourcesItem(target: .dummy, sources: files.map { SourceItem(uri: $0, kind: .file, generated: false) })
     ])

--- a/Sources/SwiftExtensions/CMakeLists.txt
+++ b/Sources/SwiftExtensions/CMakeLists.txt
@@ -13,6 +13,7 @@ set(sources
   NSLock+WithLock.swift
   PipeAsStringHandler.swift
   Platform.swift
+  Process+terminate.swift
   ResultExtensions.swift
   Sequence+AsyncMap.swift
   Sequence+ContainsAnyIn.swift

--- a/Sources/SwiftExtensions/Process+terminate.swift
+++ b/Sources/SwiftExtensions/Process+terminate.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+package import Foundation
+
+extension Foundation.Process {
+  /// If the process has not exited after `duration`, terminate it.
+  package func terminateIfRunning(after duration: Duration, pollInterval: Duration = .milliseconds(5)) async throws {
+    for _ in 0..<Int(duration.seconds / pollInterval.seconds) {
+      if !self.isRunning {
+        break
+      }
+      try await Task.sleep(for: pollInterval)
+    }
+    if self.isRunning {
+      self.terminate()
+    }
+  }
+
+  /// On Posix platforms, send a SIGKILL to the process. On Windows, terminate the process.
+  package func terminateImmediately() {
+    // TODO: We should also terminate all child processes (https://github.com/swiftlang/sourcekit-lsp/issues/2080)
+    #if os(Windows)
+    self.terminate()
+    #else
+    Foundation.kill(processIdentifier, SIGKILL)  // ignore-unacceptable-language
+    #endif
+  }
+}

--- a/Sources/TSCExtensions/Process+Run.swift
+++ b/Sources/TSCExtensions/Process+Run.swift
@@ -43,6 +43,7 @@ extension Process {
         // Give the process 2 seconds to react to a SIGINT. If that doesn't work, terminate the process.
         try await Task.sleep(for: .seconds(2))
         if !hasExited.value {
+          // TODO: We should also terminate all child processes (https://github.com/swiftlang/sourcekit-lsp/issues/2080)
           #if os(Windows)
           // Windows does not define SIGKILL. Process.signal sends a `terminate` to the underlying Foundation process
           // for any signal that is not SIGINT. Use `SIGABRT` to terminate the process.

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -37,7 +37,7 @@ fileprivate actor TestBuildSystem: CustomBuildServer {
   }
 
   func buildTargetSourcesRequest(_ request: BuildTargetSourcesRequest) -> BuildTargetSourcesResponse {
-    return dummyTargetSourcesResponse(buildSettingsByFile.keys)
+    return dummyTargetSourcesResponse(files: buildSettingsByFile.keys)
   }
 
   func textDocumentSourceKitOptionsRequest(

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -1961,7 +1961,7 @@ final class BackgroundIndexingTests: XCTestCase {
       }
 
       func buildTargetSourcesRequest(_ request: BuildTargetSourcesRequest) -> BuildTargetSourcesResponse {
-        return dummyTargetSourcesResponse(buildSettingsByFile.keys)
+        return dummyTargetSourcesResponse(files: buildSettingsByFile.keys)
       }
 
       func textDocumentSourceKitOptionsRequest(

--- a/Tests/SourceKitLSPTests/BuildSystemTests.swift
+++ b/Tests/SourceKitLSPTests/BuildSystemTests.swift
@@ -38,7 +38,7 @@ fileprivate actor TestBuildSystem: CustomBuildServer {
   }
 
   func buildTargetSourcesRequest(_ request: BuildTargetSourcesRequest) -> BuildTargetSourcesResponse {
-    return dummyTargetSourcesResponse(buildSettingsByFile.keys)
+    return dummyTargetSourcesResponse(files: buildSettingsByFile.keys)
   }
 
   func textDocumentSourceKitOptionsRequest(


### PR DESCRIPTION
When SourceKit-LSP is shut down, we should make sure that we don’t leave behind child processes, which will become orphans after SourceKit-LSP has terminated. What’s worse, when SourceKit-LSP has exited, these processes might not have any process to read their stdout/stderr, which can lead to them running indefinitely.

This change does not cover the termination of subprocess trees. For example, if we launch `swift build` and need to kill it because it doesn’t honor SIGINT, its child processes will still live on. Similarly, if we kill a BSP server, its child processes might live on. Fixing this is a drastically bigger endeavor, likely requiring changes to Foundation and/or TSC. I filed https://github.com/swiftlang/sourcekit-lsp/issues/2080 for it.