### PR TITLE
Make `fulfillmentOfOrThrow` take a variadic list of expectations

### DIFF
--- a/Sources/SKTestSupport/Assertions.swift
+++ b/Sources/SKTestSupport/Assertions.swift
@@ -144,7 +144,7 @@ package struct ExpectationNotFulfilledError: Error, CustomStringConvertible {
 /// Wait for the given expectations to be fulfilled. If the expectations aren't
 /// fulfilled within `timeout`, throw an error, aborting the test execution.
 package nonisolated func fulfillmentOfOrThrow(
-  _ expectations: [XCTestExpectation],
+  _ expectations: XCTestExpectation...,
   timeout: TimeInterval = defaultTimeout,
   enforceOrder enforceOrderOfFulfillment: Bool = false
 ) async throws {

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -173,7 +173,7 @@ final class BuildSystemManagerTests: XCTestCase {
       (a, .swift, fallbackBuildSettings(for: a, language: .swift, options: .init()), changed)
     ])
     await buildSystem.setBuildSettings(for: a, to: nil)
-    try await fulfillmentOfOrThrow([changed])
+    try await fulfillmentOfOrThrow(changed)
   }
 
   func testSettingsMainFileInitialNil() async throws {
@@ -187,7 +187,7 @@ final class BuildSystemManagerTests: XCTestCase {
     let changed = expectation(description: "changed settings")
     await del.setExpected([(a, .swift, FileBuildSettings(compilerArguments: ["x"], language: .swift), changed)])
     await buildSystem.setBuildSettings(for: a, to: TextDocumentSourceKitOptionsResponse(compilerArguments: ["x"]))
-    try await fulfillmentOfOrThrow([changed])
+    try await fulfillmentOfOrThrow(changed)
   }
 
   func testSettingsMainFileWithFallback() async throws {
@@ -211,12 +211,12 @@ final class BuildSystemManagerTests: XCTestCase {
       for: a,
       to: TextDocumentSourceKitOptionsResponse(compilerArguments: ["non-fallback", "args"])
     )
-    try await fulfillmentOfOrThrow([changed])
+    try await fulfillmentOfOrThrow(changed)
 
     let revert = expectation(description: "revert to fallback settings")
     await del.setExpected([(a, .swift, fallbackSettings, revert)])
     await buildSystem.setBuildSettings(for: a, to: nil)
-    try await fulfillmentOfOrThrow([revert])
+    try await fulfillmentOfOrThrow(revert)
   }
 
   func testSettingsHeaderChangeMainFile() async throws {
@@ -257,20 +257,20 @@ final class BuildSystemManagerTests: XCTestCase {
     let changed = expectation(description: "changed settings to cpp2")
     await del.setExpected([(h, .c, FileBuildSettings(compilerArguments: ["C++ 2"], language: .c), changed)])
     await manager.mainFilesChanged()
-    try await fulfillmentOfOrThrow([changed])
+    try await fulfillmentOfOrThrow(changed)
 
     let changed2 = expectation(description: "still cpp2, no update")
     changed2.isInverted = true
     await del.setExpected([(h, .c, nil, changed2)])
     await manager.mainFilesChanged()
-    try await fulfillmentOfOrThrow([changed2], timeout: 1)
+    try await fulfillmentOfOrThrow(changed2, timeout: 1)
 
     await mainFiles.updateMainFiles(for: h, to: [cpp1, cpp2])
 
     let changed3 = expectation(description: "added lexicographically earlier main file")
     await del.setExpected([(h, .c, FileBuildSettings(compilerArguments: ["C++ 1"], language: .c), changed3)])
     await manager.mainFilesChanged()
-    try await fulfillmentOfOrThrow([changed3], timeout: 1)
+    try await fulfillmentOfOrThrow(changed3, timeout: 1)
 
     await mainFiles.updateMainFiles(for: h, to: [])
 
@@ -279,7 +279,7 @@ final class BuildSystemManagerTests: XCTestCase {
       (h, .c, fallbackBuildSettings(for: h, language: .cpp, options: .init()), changed4)
     ])
     await manager.mainFilesChanged()
-    try await fulfillmentOfOrThrow([changed4])
+    try await fulfillmentOfOrThrow(changed4)
   }
 
   func testSettingsOneMainTwoHeader() async throws {
@@ -332,7 +332,7 @@ final class BuildSystemManagerTests: XCTestCase {
       for: cpp,
       to: TextDocumentSourceKitOptionsResponse(compilerArguments: [newCppArg, cpp.pseudoPath])
     )
-    try await fulfillmentOfOrThrow([changed1, changed2])
+    try await fulfillmentOfOrThrow(changed1, changed2)
   }
 }
 

--- a/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolJSONRPCTests/ConnectionTests.swift
@@ -52,7 +52,7 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 
   func testMessageBuffer() async throws {
@@ -81,7 +81,7 @@ class ConnectionTests: XCTestCase {
       _rawData: [notification1Str.utf8.last!, notfication2Str.utf8.first!].withUnsafeBytes { DispatchData(bytes: $0) }
     )
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
 
     let expectation2 = self.expectation(description: "notification received")
 
@@ -94,7 +94,7 @@ class ConnectionTests: XCTestCase {
       clientConnection.send(_rawData: [b].withUnsafeBytes { DispatchData(bytes: $0) })
     }
 
-    try await fulfillmentOfOrThrow([expectation2])
+    try await fulfillmentOfOrThrow(expectation2)
 
     // Close the connection before accessing requestBuffer, which ensures we don't race.
     connection.serverToClientConnection.close()
@@ -120,7 +120,7 @@ class ConnectionTests: XCTestCase {
       expectation2.fulfill()
     }
 
-    try await fulfillmentOfOrThrow([expectation, expectation2])
+    try await fulfillmentOfOrThrow(expectation, expectation2)
   }
 
   func testEchoNotification() async throws {
@@ -134,7 +134,7 @@ class ConnectionTests: XCTestCase {
 
     client.send(EchoNotification(string: "hello!"))
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 
   func testUnknownRequest() async throws {
@@ -151,7 +151,7 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 
   func testUnknownNotification() async throws {
@@ -173,7 +173,7 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 
   func testUnexpectedResponse() async throws {
@@ -192,7 +192,7 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 
   func testSendAfterClose() async throws {
@@ -212,7 +212,7 @@ class ConnectionTests: XCTestCase {
     connection.clientToServerConnection.close()
     connection.clientToServerConnection.close()
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 
   func testSendBeforeClose() async throws {
@@ -227,7 +227,7 @@ class ConnectionTests: XCTestCase {
     server.client.send(EchoNotification(string: "about to close!"))
     connection.serverToClientConnection.close()
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 
   /// We can explicitly close a connection, but the connection also
@@ -279,7 +279,7 @@ class ConnectionTests: XCTestCase {
       #endif
       conn.close()
 
-      try await fulfillmentOfOrThrow([expectation])
+      try await fulfillmentOfOrThrow(expectation)
       withExtendedLifetime(conn) {}
     }
   }
@@ -300,7 +300,7 @@ class ConnectionTests: XCTestCase {
       """
     connection.clientToServerConnection.send(message: messageContents)
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 }
 

--- a/Tests/LanguageServerProtocolTests/ConnectionTests.swift
+++ b/Tests/LanguageServerProtocolTests/ConnectionTests.swift
@@ -37,7 +37,7 @@ class ConnectionTests: XCTestCase {
       expectation.fulfill()
     }
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 
   func testEchoError() async throws {
@@ -57,7 +57,7 @@ class ConnectionTests: XCTestCase {
       expectation2.fulfill()
     }
 
-    try await fulfillmentOfOrThrow([expectation, expectation2])
+    try await fulfillmentOfOrThrow(expectation, expectation2)
   }
 
   func testEchoNotification() async throws {
@@ -71,6 +71,6 @@ class ConnectionTests: XCTestCase {
 
     client.send(EchoNotification(string: "hello!"))
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 }

--- a/Tests/SKLoggingTests/LoggingTests.swift
+++ b/Tests/SKLoggingTests/LoggingTests.swift
@@ -83,7 +83,7 @@ final class LoggingTests: XCTestCase {
       }
     )
     logger.log(level: .error, "my message")
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
     XCTAssert(
       message.starts(with: "[org.swift.sourcekit-lsp:test] error"),
       "Message did not have expected header. Received \n\(message)"

--- a/Tests/SKUtilitiesTests/DebouncerTests.swift
+++ b/Tests/SKUtilitiesTests/DebouncerTests.swift
@@ -23,7 +23,7 @@ final class DebouncerTests: XCTestCase {
     }
     await debouncer.scheduleCall()
     await debouncer.scheduleCall()
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
     // Sleep for 0.2s to make sure the debouncer actually debounces and doesn't fulfill the expectation twice.
     try await Task.sleep(for: .seconds(0.2))
   }
@@ -37,6 +37,6 @@ final class DebouncerTests: XCTestCase {
     }
     await debouncer.scheduleCall(1)
     await debouncer.scheduleCall(2)
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 }

--- a/Tests/SemanticIndexTests/TaskSchedulerTests.swift
+++ b/Tests/SemanticIndexTests/TaskSchedulerTests.swift
@@ -226,17 +226,17 @@ final class TaskSchedulerTests: XCTestCase {
     }
 
     // The high priority task should be able to finish because we have an execution slot for it.
-    try await fulfillmentOfOrThrow([highPriorityTaskFinished])
+    try await fulfillmentOfOrThrow(highPriorityTaskFinished)
 
     // But we shouldn't be able to execute the low priority task because it doesn't have an execution slot.
-    await assertThrowsError(try await fulfillmentOfOrThrow([lowPriorityTaskFinished1], timeout: 1)) { error in
+    await assertThrowsError(try await fulfillmentOfOrThrow(lowPriorityTaskFinished1, timeout: 1)) { error in
       XCTAssert(error is ExpectationNotFulfilledError)
     }
 
     await taskScheduler.setMaxConcurrentTasksByPriority([(.high, 1), (.low, 1)])
 
     // After increasing the number of execution slots, we should be able to execute the low-priority task
-    try await fulfillmentOfOrThrow([lowPriorityTaskFinished2])
+    try await fulfillmentOfOrThrow(lowPriorityTaskFinished2)
   }
 
   func testDecreaseNumberOfExecutionSlots() async throws {
@@ -261,7 +261,7 @@ final class TaskSchedulerTests: XCTestCase {
       taskStartedExecuting.fulfill()
 
       do {
-        try await fulfillmentOfOrThrow([executionSlotsReduced])
+        try await fulfillmentOfOrThrow(executionSlotsReduced)
 
         try await repeatUntilExpectedResult {
           try Task.checkCancellation()
@@ -276,14 +276,14 @@ final class TaskSchedulerTests: XCTestCase {
     }
 
     // Check that we cancel the in-progress task when reducing the number of execution slots
-    try await fulfillmentOfOrThrow([taskStartedExecuting])
+    try await fulfillmentOfOrThrow(taskStartedExecuting)
     await taskScheduler.setMaxConcurrentTasksByPriority([(.low, 0)])
     executionSlotsReduced.fulfill()
-    try await fulfillmentOfOrThrow([taskCancelled])
+    try await fulfillmentOfOrThrow(taskCancelled)
 
     // And check that we execute it again when increasing the number of execution slots again
     await taskScheduler.setMaxConcurrentTasksByPriority([(.low, 1)])
-    try await fulfillmentOfOrThrow([taskExecutedAgain])
+    try await fulfillmentOfOrThrow(taskExecutedAgain)
   }
 
   func testUseAllExecutionSlotsWithHighAndLowPriorityTasks() async throws {

--- a/Tests/SourceKitDTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitDTests/CrashRecoveryTests.swift
@@ -139,8 +139,8 @@ final class CrashRecoveryTests: XCTestCase {
 
     await clangdServer.crash()
 
-    try await fulfillmentOfOrThrow([clangdCrashed])
-    try await fulfillmentOfOrThrow([clangdRestarted])
+    try await fulfillmentOfOrThrow(clangdCrashed)
+    try await fulfillmentOfOrThrow(clangdRestarted)
   }
 
   func testClangdCrashRecovery() async throws {
@@ -298,15 +298,15 @@ final class CrashRecoveryTests: XCTestCase {
 
     await clangdServer.crash()
 
-    try await fulfillmentOfOrThrow([clangdCrashed], timeout: 5)
-    try await fulfillmentOfOrThrow([clangdRestartedFirstTime], timeout: 30)
+    try await fulfillmentOfOrThrow(clangdCrashed, timeout: 5)
+    try await fulfillmentOfOrThrow(clangdRestartedFirstTime, timeout: 30)
     // Clangd has restarted. Note the date so we can check that the second restart doesn't happen too quickly.
     let firstRestartDate = Date()
 
     // Crash clangd again. This time, it should only restart after a delay.
     await clangdServer.crash()
 
-    try await fulfillmentOfOrThrow([clangdRestartedSecondTime], timeout: 30)
+    try await fulfillmentOfOrThrow(clangdRestartedSecondTime, timeout: 30)
     XCTAssert(
       Date().timeIntervalSince(firstRestartDate) > 5,
       "Clangd restarted too quickly after crashing twice in a row. We are not preventing crash loops."

--- a/Tests/SourceKitDTests/SourceKitDTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDTests.swift
@@ -86,7 +86,7 @@ final class SourceKitDTests: XCTestCase {
 
     _ = try await sourcekitd.send(req, timeout: defaultTimeoutDuration, fileContents: nil)
 
-    try await fulfillmentOfOrThrow([expectation1, expectation2])
+    try await fulfillmentOfOrThrow(expectation1, expectation2)
 
     let close = sourcekitd.dictionary([
       keys.request: sourcekitd.requests.editorClose,

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -604,7 +604,7 @@ final class BackgroundIndexingTests: XCTestCase {
       DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
     )
 
-    try await fulfillmentOfOrThrow([receivedEmptyDiagnostics])
+    try await fulfillmentOfOrThrow(receivedEmptyDiagnostics)
 
     // Check that we received a work done progress for the re-preparation of the target
     _ = try await project.testClient.nextNotification(
@@ -2618,7 +2618,7 @@ final class BackgroundIndexingTests: XCTestCase {
         func myTestFunc() {}
         """
     )
-    try await fulfillmentOfOrThrow([updateIndexStoreStarted])
+    try await fulfillmentOfOrThrow(updateIndexStoreStarted)
     try await repeatUntilExpectedResult(sleepInterval: .milliseconds(2)) {
       try await !project.testClient.send(IsIndexingRequest()).indexing
     }

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -505,7 +505,7 @@ final class CodeActionTests: XCTestCase {
     }
     _ = try await testClient.send(ExecuteCommandRequest(command: command.command, arguments: command.arguments))
 
-    try await fulfillmentOfOrThrow([editReceived])
+    try await fulfillmentOfOrThrow(editReceived)
   }
 
   func testAddDocumentationCodeActionResult() async throws {

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -366,7 +366,7 @@ class DefinitionTests: XCTestCase {
       diagnosticRefreshRequestReceived.fulfill()
       return VoidResponse()
     }
-    try await fulfillmentOfOrThrow([diagnosticRefreshRequestReceived])
+    try await fulfillmentOfOrThrow(diagnosticRefreshRequestReceived)
 
     let afterChangingFileA = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(bUri), position: bPositions["1️⃣"])
@@ -438,7 +438,7 @@ class DefinitionTests: XCTestCase {
       diagnosticRefreshRequestReceived.fulfill()
       return VoidResponse()
     }
-    try await fulfillmentOfOrThrow([diagnosticRefreshRequestReceived])
+    try await fulfillmentOfOrThrow(diagnosticRefreshRequestReceived)
 
     let afterBuilding = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(bUri), position: bPositions["2️⃣"])

--- a/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
+++ b/Tests/SourceKitLSPTests/ExecuteCommandTests.swift
@@ -59,7 +59,7 @@ final class ExecuteCommandTests: XCTestCase {
 
     let _ = try await testClient.send(request)
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
 
     let label = try XCTUnwrap(applyEditTitle.value)
     let edit = try XCTUnwrap(applyEditWorkspaceEdit.value)
@@ -124,7 +124,7 @@ final class ExecuteCommandTests: XCTestCase {
 
     let _ = try await testClient.send(request)
 
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
 
     let label = try XCTUnwrap(applyEditTitle.value)
     let edit = try XCTUnwrap(applyEditWorkspaceEdit.value)

--- a/Tests/SourceKitLSPTests/ExpandMacroTests.swift
+++ b/Tests/SourceKitLSPTests/ExpandMacroTests.swift
@@ -121,7 +121,7 @@ final class ExpandMacroTests: XCTestCase {
 
         _ = try await project.testClient.send(request)
 
-        try await fulfillmentOfOrThrow([expectation])
+        try await fulfillmentOfOrThrow(expectation)
 
         let uris = try XCTUnwrap(
           peekDocumentsRequestURIs.value,
@@ -160,7 +160,7 @@ final class ExpandMacroTests: XCTestCase {
 
         _ = try await project.testClient.send(request)
 
-        try await fulfillmentOfOrThrow([expectation])
+        try await fulfillmentOfOrThrow(expectation)
 
         let url = try XCTUnwrap(
           showDocumentRequestURI.value?.fileURL,
@@ -311,7 +311,7 @@ final class ExpandMacroTests: XCTestCase {
 
         _ = try await project.testClient.send(request)
 
-        try await fulfillmentOfOrThrow([expectation])
+        try await fulfillmentOfOrThrow(expectation)
 
         let uris = try XCTUnwrap(
           peekDocumentsRequestURIs.value,
@@ -358,7 +358,7 @@ final class ExpandMacroTests: XCTestCase {
 
         _ = try await project.testClient.send(request)
 
-        try await fulfillmentOfOrThrow([expectation])
+        try await fulfillmentOfOrThrow(expectation)
 
         let url = try XCTUnwrap(
           showDocumentRequestURI.value?.fileURL,
@@ -498,7 +498,7 @@ final class ExpandMacroTests: XCTestCase {
     }
 
     _ = try await project.testClient.send(outerExpandMacroRequest)
-    try await fulfillmentOfOrThrow([outerPeekDocumentRequestReceived])
+    try await fulfillmentOfOrThrow(outerPeekDocumentRequestReceived)
 
     let outerPeekDocumentURI = try XCTUnwrap(outerPeekDocumentsRequestURIs.value?.only)
     let outerMacroExpansion = try await project.testClient.send(GetReferenceDocumentRequest(uri: outerPeekDocumentURI))
@@ -533,7 +533,7 @@ final class ExpandMacroTests: XCTestCase {
     }
 
     _ = try await project.testClient.send(intermediateExpandMacroRequest)
-    try await fulfillmentOfOrThrow([intermediatePeekDocumentRequestReceived])
+    try await fulfillmentOfOrThrow(intermediatePeekDocumentRequestReceived)
 
     let intermediatePeekDocumentURI = try XCTUnwrap(intermediatePeekDocumentsRequestURIs.value?.only)
     let intermediateMacroExpansion = try await project.testClient.send(
@@ -570,7 +570,7 @@ final class ExpandMacroTests: XCTestCase {
     }
 
     _ = try await project.testClient.send(innerExpandMacroRequest)
-    try await fulfillmentOfOrThrow([innerPeekDocumentRequestReceived])
+    try await fulfillmentOfOrThrow(innerPeekDocumentRequestReceived)
 
     let innerPeekDocumentURI = try XCTUnwrap(innerPeekDocumentsRequestURIs.value?.only)
     let innerMacroExpansion = try await project.testClient.send(GetReferenceDocumentRequest(uri: innerPeekDocumentURI))

--- a/Tests/SourceKitLSPTests/LifecycleTests.swift
+++ b/Tests/SourceKitLSPTests/LifecycleTests.swift
@@ -114,7 +114,7 @@ final class LifecycleTests: XCTestCase {
     }
     testClient.send(CancelRequestNotification(id: requestID))
 
-    try await fulfillmentOfOrThrow([completionRequestReplied])
+    try await fulfillmentOfOrThrow(completionRequestReplied)
 
     let fastStartDate = Date()
     let fastReply = try await testClient.send(

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -212,7 +212,7 @@ final class LocalClangTests: XCTestCase {
     )
     _ = try await testClient.send(executeCommand)
 
-    try await fulfillmentOfOrThrow([applyEdit])
+    try await fulfillmentOfOrThrow(applyEdit)
   }
 
   func testClangStdHeaderCanary() async throws {

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -1380,7 +1380,7 @@ final class LocalSwiftTests: XCTestCase {
         ]
       )
     )
-    try await fulfillmentOfOrThrow([reusedNodeCallback])
+    try await fulfillmentOfOrThrow(reusedNodeCallback)
 
     XCTAssertEqual(reusedNodes.value.count, 1)
     let firstNode = try XCTUnwrap(reusedNodes.value.first)

--- a/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
+++ b/Tests/SourceKitLSPTests/PullDiagnosticsTests.swift
@@ -200,7 +200,7 @@ final class PullDiagnosticsTests: XCTestCase {
     }
 
     try await project.changeFileOnDisk("FileA.swift", newMarkedContents: "func sayHello() {}")
-    try await fulfillmentOfOrThrow([diagnosticsRefreshRequestReceived])
+    try await fulfillmentOfOrThrow(diagnosticsRefreshRequestReceived)
 
     let afterChangingFileA = try await project.testClient.send(
       DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(bUri))
@@ -270,7 +270,7 @@ final class PullDiagnosticsTests: XCTestCase {
       )
     )
 
-    try await fulfillmentOfOrThrow([diagnosticsRefreshRequestReceived])
+    try await fulfillmentOfOrThrow(diagnosticsRefreshRequestReceived)
 
     let afterChangingFileA = try await project.testClient.send(
       DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(bUri))
@@ -325,7 +325,7 @@ final class PullDiagnosticsTests: XCTestCase {
       receivedDiagnostics.fulfill()
     }
     diagnosticRequestSent.signal()
-    try await fulfillmentOfOrThrow([receivedDiagnostics])
+    try await fulfillmentOfOrThrow(receivedDiagnostics)
   }
 
   func testDontReturnEmptyDiagnosticsIfDiagnosticRequestIsCancelled() async throws {
@@ -357,7 +357,7 @@ final class PullDiagnosticsTests: XCTestCase {
       enableBackgroundIndexing: true,
       pollIndex: false
     )
-    try await fulfillmentOfOrThrow([packageLoadingDidFinish])
+    try await fulfillmentOfOrThrow(packageLoadingDidFinish)
     let (uri, _) = try project.openDocument("Lib.swift")
 
     let diagnosticResponseReceived = self.expectation(description: "Received diagnostic response")
@@ -369,7 +369,7 @@ final class PullDiagnosticsTests: XCTestCase {
     }
     project.testClient.send(CancelRequestNotification(id: requestID))
     diagnosticRequestCancelled.fulfill()
-    try await fulfillmentOfOrThrow([diagnosticResponseReceived])
+    try await fulfillmentOfOrThrow(diagnosticResponseReceived)
   }
 
   func testNoteInSecondaryFile() async throws {

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -917,7 +917,7 @@ final class SemanticTokensTests: XCTestCase {
         contentChanges: [TextDocumentContentChangeEvent(range: Range(positions["1️⃣"]), text: "let x = 1")]
       )
     )
-    try await fulfillmentOfOrThrow([receivedSemanticTokensResponse])
+    try await fulfillmentOfOrThrow(receivedSemanticTokensResponse)
   }
 
   func testNoImplicitCancellationOnEditIfImplicitCancellationIsDisabled() async throws {
@@ -946,7 +946,7 @@ final class SemanticTokensTests: XCTestCase {
         contentChanges: [TextDocumentContentChangeEvent(range: Range(positions["1️⃣"]), text: "let x = 1")]
       )
     )
-    try await fulfillmentOfOrThrow([receivedSemanticTokensResponse])
+    try await fulfillmentOfOrThrow(receivedSemanticTokensResponse)
   }
 }
 

--- a/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftPMIntegrationTests.swift
@@ -354,7 +354,7 @@ final class SwiftPMIntegrationTests: XCTestCase {
     receivedInitialDiagnosticsReply.signal()
     try await Task.sleep(for: .seconds(1))
 
-    try await fulfillmentOfOrThrow([diagnosticRefreshRequestReceived])
+    try await fulfillmentOfOrThrow(diagnosticRefreshRequestReceived)
     let diagnosticsAfterPackageLoading = try await project.testClient.send(
       DocumentDiagnosticsRequest(textDocument: TextDocumentIdentifier(uri))
     )

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -1161,7 +1161,7 @@ final class WorkspaceTests: XCTestCase {
     project.testClient.send(
       DidChangeActiveDocumentNotification(textDocument: TextDocumentIdentifier(libBUri))
     )
-    try await fulfillmentOfOrThrow([didPrepareLibBAfterChangingBaseLib])
+    try await fulfillmentOfOrThrow(didPrepareLibBAfterChangingBaseLib)
 
     withExtendedLifetime(project) {}
   }
@@ -1287,7 +1287,7 @@ final class WorkspaceTests: XCTestCase {
     try XCTAssertEqual(XCTUnwrap(triggerPrepare).didPrepareTarget, true)
 
     // Check that we did actually run a preparation
-    try await fulfillmentOfOrThrow([didPrepareAfterChangingBaseLib])
+    try await fulfillmentOfOrThrow(didPrepareAfterChangingBaseLib)
 
     let prepareUpToDateAgain = try await project.testClient.send(
       SourceKitOptionsRequest(

--- a/Tests/SwiftExtensionsTests/AsyncUtilsTests.swift
+++ b/Tests/SwiftExtensionsTests/AsyncUtilsTests.swift
@@ -33,7 +33,7 @@ final class AsyncUtilsTests: XCTestCase {
     ) { error in
       XCTAssert(error is TimeoutError, "Received unexpected error \(error)")
     }
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
   }
 
   func testWithTimeoutReturnsImmediatelyEvenIfBodyDoesntCooperateInCancellation() async throws {
@@ -64,7 +64,7 @@ final class AsyncUtilsTests: XCTestCase {
         }
       }
     }
-    try await fulfillmentOfOrThrow([expectation])
+    try await fulfillmentOfOrThrow(expectation)
     try await Task(priority: .high) {
       try await task.value
     }.value

--- a/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
+++ b/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
@@ -326,7 +326,7 @@ final class SwiftSourceKitPluginTests: XCTestCase {
       slowCompletionResultReceived.fulfill()
     }
     slowCompletionTask.cancel()
-    try await fulfillmentOfOrThrow([slowCompletionResultReceived], timeout: 30)
+    try await fulfillmentOfOrThrow(slowCompletionResultReceived, timeout: 30)
 
     let fastCompletionStarted = Date()
     let result = try await sourcekitd.completeOpen(


### PR DESCRIPTION
In almost all cases, we pass a single expectation and that looks a lot nicer with a variadic parameter.