### PR TITLE
Wait for request to be sent to sourcekitd before cancelling it in `SwiftSourceKitPluginTests.testCancellation`

### DIFF
--- a/Sources/SKTestSupport/Assertions.swift
+++ b/Sources/SKTestSupport/Assertions.swift
@@ -119,6 +119,26 @@ package func assertNotNil<T>(
   XCTAssertNotNil(expression, message(), file: file, line: line)
 }
 
+/// Check that the string contains the given substring.
+package func assertContains(
+  _ string: some StringProtocol,
+  _ substring: some StringProtocol,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  XCTAssert(string.contains(substring), "Expected to contain '\(substring)': \(string)", file: file, line: line)
+}
+
+/// Check that the sequence contains the given element.
+package func assertContains<Element: Equatable>(
+  _ sequence: some Sequence<Element>,
+  _ element: Element,
+  file: StaticString = #filePath,
+  line: UInt = #line
+) {
+  XCTAssert(sequence.contains(element), "Expected to contain '\(element)': \(sequence)", file: file, line: line)
+}
+
 /// Same as `XCTUnwrap` but doesn't take autoclosures and thus `expression`
 /// can contain `await`.
 package func unwrap<T>(

--- a/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildServerBuildSystemTests.swift
@@ -501,7 +501,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
         allowFallbackSettings: false
       )
     )
-    XCTAssert(try XCTUnwrap(firstOptions).compilerArguments.contains("-DFIRST"))
+    assertContains(try XCTUnwrap(firstOptions).compilerArguments, "-DFIRST")
 
     let secondOptions = try await project.testClient.send(
       SourceKitOptionsRequest(
@@ -511,7 +511,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
         allowFallbackSettings: false
       )
     )
-    XCTAssert(try XCTUnwrap(secondOptions).compilerArguments.contains("-DSECOND"))
+    assertContains(try XCTUnwrap(secondOptions).compilerArguments, "-DSECOND")
 
     let optionsWithoutTarget = try await project.testClient.send(
       SourceKitOptionsRequest(
@@ -521,7 +521,7 @@ final class BuildServerBuildSystemTests: XCTestCase {
       )
     )
     // We currently pick the canonical target alphabetically, which means that `bsp://first` wins over `bsp://second`
-    XCTAssert(try XCTUnwrap(optionsWithoutTarget).compilerArguments.contains("-DFIRST"))
+    assertContains(try XCTUnwrap(optionsWithoutTarget).compilerArguments, "-DFIRST")
   }
 
   func testDontBlockBuildServerInitializationIfBuildSystemIsUnresponsive() async throws {

--- a/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
+++ b/Tests/BuildSystemIntegrationTests/BuildSystemManagerTests.swift
@@ -116,7 +116,7 @@ final class BuildSystemManagerTests: XCTestCase {
     await manager.registerForChangeNotifications(for: d, language: .c)
     await assertEqual(manager.cachedMainFile(for: a), c)
     let bMain = await manager.cachedMainFile(for: b)
-    XCTAssert(Set([c, d]).contains(bMain))
+    assertContains([c, d], bMain)
     await assertEqual(manager.cachedMainFile(for: c), c)
     await assertEqual(manager.cachedMainFile(for: d), d)
 

--- a/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
+++ b/Tests/BuildSystemIntegrationTests/SwiftPMBuildSystemTests.swift
@@ -1118,8 +1118,8 @@ final class SwiftPMBuildSystemTests: XCTestCase {
         fallbackAfterTimeout: false
       )
       let compilerArgs = try XCTUnwrap(settings?.compilerArguments)
-      XCTAssert(compilerArgs.contains("-package-description-version"))
-      XCTAssert(compilerArgs.contains(try versionSpecificManifestURL.filePath))
+      assertContains(compilerArgs, "-package-description-version")
+      assertContains(compilerArgs, try versionSpecificManifestURL.filePath)
     }
   }
 
@@ -1152,7 +1152,7 @@ final class SwiftPMBuildSystemTests: XCTestCase {
       )
       let compilerArgs = try XCTUnwrap(settings?.compilerArguments)
       assertArgumentsContain("-package-description-version", "5.1.0", arguments: compilerArgs)
-      XCTAssert(compilerArgs.contains(try manifestURL.filePath))
+      assertContains(compilerArgs, try manifestURL.filePath)
     }
   }
 }

--- a/Tests/SourceKitDTests/SourceKitDRegistryTests.swift
+++ b/Tests/SourceKitDTests/SourceKitDRegistryTests.swift
@@ -74,6 +74,7 @@ final class FakeSourceKitD: SourceKitD {
   var values: sourcekitd_api_values { fatalError() }
   func addNotificationHandler(_ handler: SKDNotificationHandler) { fatalError() }
   func removeNotificationHandler(_ handler: SKDNotificationHandler) { fatalError() }
+  func didSend(request: SKDRequestDictionary) {}
   private init() {
     token = nextToken.fetchAndIncrement()
   }

--- a/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
+++ b/Tests/SourceKitLSPTests/CompilationDatabaseTests.swift
@@ -151,7 +151,7 @@ final class CompilationDatabaseTests: XCTestCase {
         XCTFail("Expected ResponseError, got \(error)")
         return
       }
-      XCTAssert(error.message.contains("No language service"))
+      assertContains(error.message, "No language service")
     }
   }
 
@@ -217,7 +217,7 @@ final class CompilationDatabaseTests: XCTestCase {
       )
     )
     let hoverContent = try XCTUnwrap(hover?.contents.markupContent?.value)
-    XCTAssert(hoverContent.contains("void main()"))
+    assertContains(hoverContent, "void main()")
 
     // But for `testFromDummyToolchain.swift`, we can't launch sourcekitd (because it doesn't exist, we just provided a
     // dummy), so we should receive an error. The exact error here is not super relevant, the important part is that we
@@ -235,7 +235,7 @@ final class CompilationDatabaseTests: XCTestCase {
         XCTFail("Expected ResponseError, got \(error)")
         return
       }
-      XCTAssert(error.message.contains("No language service"))
+      assertContains(error.message, "No language service")
     }
   }
 }

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -730,7 +730,7 @@ final class LocalSwiftTests: XCTestCase {
 
     XCTAssertEqual(fixit.title, "Use 'new(_:hotness:)' instead")
     XCTAssertEqual(fixit.diagnostics?.count, 1)
-    XCTAssert(fixit.diagnostics?.first?.message.contains("is deprecated") == true)
+    assertContains(try XCTUnwrap(fixit.diagnostics?.first?.message), "is deprecated")
     XCTAssertEqual(
       fixit.edit?.changes?[uri],
       [

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -1181,7 +1181,7 @@ final class WorkspaceTests: XCTestCase {
       )
     )
     let options = try XCTUnwrap(optionsOptional)
-    XCTAssert(options.compilerArguments.contains("-module-name"))
+    assertContains(options.compilerArguments, "-module-name")
     XCTAssertEqual(options.kind, .normal)
     XCTAssertNil(options.didPrepareTarget)
   }
@@ -1366,7 +1366,7 @@ final class WorkspaceTests: XCTestCase {
         allowFallbackSettings: false
       )
     )
-    XCTAssert(options.compilerArguments.contains("-DHAVE_SETTINGS"))
+    assertContains(options.compilerArguments, "-DHAVE_SETTINGS")
   }
 
   func testOutputPaths() async throws {

--- a/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
+++ b/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
@@ -329,7 +329,7 @@ final class SwiftSourceKitPluginTests: XCTestCase {
       try await fulfillmentOfOrThrow(slowCompletionResultReceived, timeout: 30)
     } hook: { request in
       // Check that we aren't matching against a request sent by something else that has handle to the same sourcekitd.
-      XCTAssert(request.description.contains(path), "Received unexpected request: \(request)")
+      assertContains(request.description, path)
       slowCompletionRequestSent.fulfill()
     }
 

--- a/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
+++ b/Tests/SwiftSourceKitPluginTests/SwiftSourceKitPluginTests.swift
@@ -329,7 +329,7 @@ final class SwiftSourceKitPluginTests: XCTestCase {
       try await fulfillmentOfOrThrow(slowCompletionResultReceived, timeout: 30)
     } hook: { request in
       // Check that we aren't matching against a request sent by something else that has handle to the same sourcekitd.
-      assertContains(request.description, path)
+      assertContains(request.description.replacing(#"\\"#, with: #"\"#), path)
       slowCompletionRequestSent.fulfill()
     }
 


### PR DESCRIPTION
Otherwise, the cancellation could get handled before the request actually gets sent to sourcekitd, which is not what we want to test here. There appears to be a second underlying issue that causes unexpected results when we cancel the fast completion request after sending the slow completion request. I’ll look at that in a follow-up PR.