### PR TITLE
Fix theoretical issue in `withTaskPriorityChangedHandler` that could always report a priority change to `high`

### DIFF
--- a/Sources/SwiftExtensions/Task+WithPriorityChangedHandler.swift
+++ b/Sources/SwiftExtensions/Task+WithPriorityChangedHandler.swift
@@ -29,10 +29,7 @@ package func withTaskPriorityChangedHandler<T: Sendable>(
       // want to make sure that we don't leave the body task or the priority watching task running.
       taskGroup.cancelAll()
     }
-    // Run the task priority watcher with high priority instead of inheriting the initial priority. Otherwise a
-    // `.background` task might not get its priority elevated because the priority watching task also runs at
-    // `.background` priority and might not actually get executed in time.
-    taskGroup.addTask(priority: .high) {
+    taskGroup.addTask(priority: initialPriority) {
       while true {
         if Task.isCancelled {
           break


### PR DESCRIPTION
We were launching the task that watches for the priority change with `high` priority. If the base priority was `medium`, this should immediately report a priority change to `high`. It appears the only reason why this doesn’t happen right now is due to rdar://147868544.