### PR TITLE
Update import on SwiftPM PackageModel for `SwiftPMBuildSystem.swift`

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -20,7 +20,7 @@ package import LanguageServerProtocol
 import LanguageServerProtocolExtensions
 @preconcurrency import PackageGraph
 import PackageLoading
-import PackageModel
+@preconcurrency import PackageModel
 import SKLogging
 package import SKOptions
 @preconcurrency package import SPMBuildCore


### PR DESCRIPTION
With upcoming changes to SwiftPM's `TraitConfiguration` (see [#8370](https://github.com/swiftlang/swift-package-manager/pull/8370)) - notably, moving it from `PackageGraph` to `PackageModel` - `PackageModel` needs to be imported using `@preconcurrency` to omit data-race risk errors.