### PR TITLE
Ensure the `DLHandle` passed to `SourceKitD.init(dlhandle:path:pluginPaths:initialize:)` gets closed if the initializer fails

### DIFF
--- a/Sources/SourceKitD/dlopen.swift
+++ b/Sources/SourceKitD/dlopen.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SKLogging
 import SwiftExtensions
 
 #if os(Windows)
@@ -45,7 +46,9 @@ package final class DLHandle: Sendable {
   }
 
   deinit {
-    precondition(rawValue.value == nil, "DLHandle must be closed or explicitly leaked before destroying")
+    if rawValue.value != nil {
+      logger.fault("DLHandle must be closed or explicitly leaked before destroying")
+    }
   }
 
   /// The handle must not be used anymore after calling `close`.


### PR DESCRIPTION
Just something I noticed while looking through code. I am not aware of any issues caused by this.

Also relax the `precondition` in `DLHandle.deinit` to a fault. If we do not close a `DLHandle`, that’s a bug but it’s not so bad that we should crash sourcekit-lsp for it.