### PR TITLE
Don’t crash SourceKit-LSP if swift-format crashes while we write the source file to stdin

### DIFF
--- a/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
+++ b/Sources/LanguageServerProtocolJSONRPC/JSONRPCConnection.swift
@@ -124,13 +124,7 @@ public final class JSONRPCConnection: Connection {
     self.inputMirrorFile = inputMirrorFile
     self.outputMirrorFile = outputMirrorFile
     self.receiveHandler = nil
-    #if os(Linux) || os(Android)
-    // We receive a `SIGPIPE` if we write to a pipe that points to a crashed process. This in particular happens if the
-    // target of a `JSONRPCConnection` has crashed and we try to send it a message.
-    // On Darwin, `DispatchIO` ignores `SIGPIPE` for the pipes handled by it, but that features is not available on Linux.
-    // Instead, globally ignore `SIGPIPE` on Linux to prevent us from crashing if the `JSONRPCConnection`'s target crashes.
-    globallyDisableSigpipe()
-    #endif
+    globallyDisableSigpipeIfNeeded()
     state = .created
     self.messageRegistry = messageRegistry
 


### PR DESCRIPTION
When swift-format crashes before we send all data to its stdin, we get a SIGPIPE when trying to write more data to its studio on Linux. This, in turn, takes SourceKit-LSP down.

Do the same trick that we do when launching `JSONRPCConnection` of disabling SIGPIPE globally if we can’t disable it for individual pipes.

rdar://147665695