### PR TITLE
[build-script-helper] Remove unneeded flags for Android

### DIFF
--- a/Utilities/build-script-helper.py
+++ b/Utilities/build-script-helper.py
@@ -136,9 +136,6 @@ def get_swiftpm_options(swift_exec: str, args: argparse.Namespace, suppress_verb
     if '-android' in build_target:
         swiftpm_args += [
             '-Xlinker', '-rpath', '-Xlinker', '$ORIGIN/../lib/swift/android',
-            # SwiftPM will otherwise try to compile against GNU strerror_r on
-            # Android and fail.
-            '-Xswiftc', '-Xcc', '-Xswiftc', '-U_GNU_SOURCE',
         ]
     elif not build_os.startswith('macosx'):
         # Library rpath for swift, dispatch, Foundation, etc. when installing


### PR DESCRIPTION
Removing the definition of `_GNU_SOURCE` is no longer needed since swiftlang/swift-tools-support-core#500 made sure the right `strerror_r()` is used.