### PR TITLE
Fix issue that caused request cancellation after a timeout in tests to not work

### DIFF
--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -261,7 +261,7 @@ package final class TestSourceKitLSPClient: MessageHandler, Sendable {
           .failure(ResponseError.unknown("\(R.method) request timed out after \(defaultTimeoutDuration)"))
         )
       }
-      await server.handle(notification: CancelRequestNotification(id: requestID))
+      server.handle(CancelRequestNotification(id: requestID))
     }
     server.handle(request, id: requestID) { result in
       if replyOutstanding.takeValue() ?? false {


### PR DESCRIPTION
We were calling `server.handle(notification:)`, which called directly into `SourceKitLSPServer` but request handling is implemented in `QueueBasedMessageHandler.handle(_:)`. Call that to ensure that we actually cancel requests after the test timeout.