### PR TITLE
Require Swift 6.1 to build SourceKit-LSP

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 6.1
 
 import Foundation
 import PackageDescription

--- a/Sources/SKLogging/Logging.swift
+++ b/Sources/SKLogging/Logging.swift
@@ -19,15 +19,9 @@ package typealias LogLevel = os.OSLogType
 package typealias Logger = os.Logger
 package typealias Signposter = OSSignposter
 
-#if compiler(<5.11)
-extension OSSignposter: @unchecked Sendable {}
-extension OSSignpostID: @unchecked Sendable {}
-extension OSSignpostIntervalState: @unchecked Sendable {}
-#else
 extension OSSignposter: @retroactive @unchecked Sendable {}
 extension OSSignpostID: @retroactive @unchecked Sendable {}
 extension OSSignpostIntervalState: @retroactive @unchecked Sendable {}
-#endif
 
 extension os.Logger {
   package func makeSignposter() -> Signposter {

--- a/Sources/SKTestSupport/SkipUnless.swift
+++ b/Sources/SKTestSupport/SkipUnless.swift
@@ -353,30 +353,6 @@ package actor SkipUnless {
       return .featureSupported
     }
   }
-
-  /// Checks that swift-format supports running as `swift-format format -` to indicate that the source file should be
-  /// read from stdin, ie. that swift-format contains https://github.com/swiftlang/swift-format/pull/914.
-  package static func swiftFormatSupportsDashToIndicateReadingFromStdin(
-    file: StaticString = #filePath,
-    line: UInt = #line
-  ) async throws {
-    return try await shared.skipUnlessSupportedByToolchain(swiftVersion: SwiftVersion(6, 1), file: file, line: line) {
-      guard let swiftFormatPath = await ToolchainRegistry.forTesting.default?.swiftFormat else {
-        throw GenericError("Could not find swift-format")
-      }
-      let process = TSCBasic.Process(arguments: [try swiftFormatPath.filePath, "format", "-"])
-      let writeStream = try process.launch()
-      writeStream.send("let x = 1")
-      try writeStream.close()
-      let result = try await process.waitUntilExitStoppingProcessOnTaskCancellation()
-      let output = try result.utf8Output()
-      switch output {
-      case "": return false
-      case "let x = 1\n": return true
-      default: throw GenericError("Received unexpected formatting output: '\(output)'")
-      }
-    }
-  }
 }
 
 // MARK: - Parsing Swift compiler version

--- a/Tests/SourceKitLSPTests/FormattingTests.swift
+++ b/Tests/SourceKitLSPTests/FormattingTests.swift
@@ -22,8 +22,6 @@ import class TSCBasic.Process
 
 final class FormattingTests: XCTestCase {
   func testFormatting() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -57,8 +55,6 @@ final class FormattingTests: XCTestCase {
   }
 
   func testFormattingNoEdits() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -84,8 +80,6 @@ final class FormattingTests: XCTestCase {
   }
 
   func testConfigFileOnDisk() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
     let project = try await MultiFileTestProject(files: [
       ".swift-format": """
@@ -120,8 +114,6 @@ final class FormattingTests: XCTestCase {
   }
 
   func testConfigFileInParentDirectory() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
     let project = try await MultiFileTestProject(files: [
       ".swift-format": """
@@ -156,8 +148,6 @@ final class FormattingTests: XCTestCase {
   }
 
   func testConfigFileInNestedDirectory() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
     let project = try await MultiFileTestProject(files: [
       ".swift-format": """
@@ -200,8 +190,6 @@ final class FormattingTests: XCTestCase {
   }
 
   func testInvalidConfigurationFile() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     // We pick up an invalid swift-format configuration file and thus don't set the user-provided options.
     // The swift-format default is 2 spaces.
     let project = try await MultiFileTestProject(files: [
@@ -226,8 +214,6 @@ final class FormattingTests: XCTestCase {
   }
 
   func testInsertAndRemove() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -259,8 +245,6 @@ final class FormattingTests: XCTestCase {
   }
 
   func testMultiLineStringInsertion() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 

--- a/Tests/SourceKitLSPTests/OnTypeFormattingTests.swift
+++ b/Tests/SourceKitLSPTests/OnTypeFormattingTests.swift
@@ -18,8 +18,6 @@ import XCTest
 
 final class OnTypeFormattingTests: XCTestCase {
   func testOnlyFormatsSpecifiedLine() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -53,8 +51,6 @@ final class OnTypeFormattingTests: XCTestCase {
   }
 
   func testFormatsFullLineAndDoesNotFormatNextLine() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -92,8 +88,6 @@ final class OnTypeFormattingTests: XCTestCase {
   /// Otherwise could mess up writing code. You'd write {} and try to go into the braces to write more code,
   /// only for on-type formatting to immediately close the braces again.
   func testDoesNothingWhenInAnEmptyLine() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 

--- a/Tests/SourceKitLSPTests/RangeFormattingTests.swift
+++ b/Tests/SourceKitLSPTests/RangeFormattingTests.swift
@@ -18,8 +18,6 @@ import XCTest
 
 final class RangeFormattingTests: XCTestCase {
   func testOnlyFormatsSpecifiedLines() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -52,8 +50,6 @@ final class RangeFormattingTests: XCTestCase {
   }
 
   func testOnlyFormatsSpecifiedColumns() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -86,8 +82,6 @@ final class RangeFormattingTests: XCTestCase {
   }
 
   func testFormatsMultipleLines() async throws {
-    try await SkipUnless.swiftFormatSupportsDashToIndicateReadingFromStdin()
-
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 


### PR DESCRIPTION
Now that Swift 6.1 has been released, we no longer need to support building SourceKit-LSP using Swift 6.0.