### PR TITLE
Overview.md: Correct path to sourcekit-lsp logs

### DIFF
--- a/Contributor Documentation/Overview.md
+++ b/Contributor Documentation/Overview.md
@@ -31,4 +31,4 @@ SourceKit-LSP has fairly extensive logging to help diagnose issues. The way logg
 
 On macOS, SourceKit-LSP logs to the system log. [CONTRIBUTING.md](../CONTRIBUTING.md#logging) contains some information about how to read the system logs. Since [OSLog](https://developer.apple.com/documentation/os/logging) cannot be wrapped, the decision to log to macOS’s system log is done at build time and cannot be modified at runtime.
 
-On other platforms, the `NonDarwinLogger` types are used to log messages. These types are API-compatible with OSLog. Log messages are written to stderr by default. When possible, `SourceKitLSP.run` will redirect the log messages to log files in `/var/log/sourcekit-lsp` on launch.
+On other platforms, the `NonDarwinLogger` types are used to log messages. These types are API-compatible with OSLog. Log messages are written to stderr by default. When possible, `SourceKitLSP.run` will redirect the log messages to log files in `~/.sourcekit-lsp` on launch.


### PR DESCRIPTION
This text was originally added in d8067fb4390e4569fa4941c51bf325179c4c359b, but as of 7d3b44079ac6cc89e065ddb8b21190d15f0e354d the log directory is now ~/.sourcekit-lsp.