### PR TITLE
Update launch configuration for Swift extension v2.2.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,31 +1,28 @@
 {
     "configurations": [
         {
-            "type": "lldb",
+            "type": "swift",
             "request": "launch",
             "name": "Debug sourcekit-lsp",
             "program": "${workspaceFolder:sourcekit-lsp}/.build/debug/sourcekit-lsp",
             "args": [],
             "cwd": "${workspaceFolder:sourcekit-lsp}",
             "preLaunchTask": "swift: Build Debug sourcekit-lsp",
-            "sourceLanguages": ["swift"]
         },
         {
-            "type": "lldb",
+            "type": "swift",
             "request": "launch",
             "name": "Release sourcekit-lsp",
             "program": "${workspaceFolder:sourcekit-lsp}/.build/release/sourcekit-lsp",
             "args": [],
             "cwd": "${workspaceFolder:sourcekit-lsp}",
             "preLaunchTask": "swift: Build Release sourcekit-lsp",
-            "sourceLanguages": ["swift"]
         },
         {
-            "type": "lldb",
+            "type": "swift",
             "request": "attach",
             "name": "Attach sourcekit-lsp (debug)",
             "program": "${workspaceFolder:sourcekit-lsp}/.build/debug/sourcekit-lsp",
-            "sourceLanguages": ["swift"],
             "waitFor": true
         }
     ]


### PR DESCRIPTION
The recently released Swift extension v2.2.0 now has its own launch configuration type called `swift` that can be used instead of relying on `CodeLLDB` or `lldb-dap` directly. Use that launch config instead.