### PR TITLE
Add missing dependency declarations to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -292,8 +292,10 @@ var targets: [Target] = [
   .target(
     name: "SemanticIndex",
     dependencies: [
+      "BuildServerProtocol",
       "BuildSystemIntegration",
       "LanguageServerProtocol",
+      "LanguageServerProtocolExtensions",
       "SKLogging",
       "SwiftExtensions",
       "ToolchainRegistry",


### PR DESCRIPTION
These are imported by SemanticIndexManager.swift but weren’t declared as dependencies.