### PR TITLE
Mark all closures in the `.stream` outputRedirection of TSC as `@Sendable`

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -736,8 +736,8 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
       arguments: arguments,
       workingDirectory: nil,
       outputRedirection: .stream(
-        stdout: { stdoutHandler.handleDataFromPipe(Data($0)) },
-        stderr: { stderrHandler.handleDataFromPipe(Data($0)) }
+        stdout: { @Sendable bytes in stdoutHandler.handleDataFromPipe(Data(bytes)) },
+        stderr: { @Sendable bytes in stderrHandler.handleDataFromPipe(Data(bytes)) }
       )
     )
     let exitStatus = result.exitStatus.exhaustivelySwitchable

--- a/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
+++ b/Sources/SemanticIndex/UpdateIndexStoreTaskDescription.swift
@@ -388,8 +388,8 @@ package struct UpdateIndexStoreTaskDescription: IndexTaskDescription {
           arguments: processArguments,
           workingDirectory: workingDirectory,
           outputRedirection: .stream(
-            stdout: { stdoutHandler.handleDataFromPipe(Data($0)) },
-            stderr: { stderrHandler.handleDataFromPipe(Data($0)) }
+            stdout: { @Sendable bytes in stdoutHandler.handleDataFromPipe(Data(bytes)) },
+            stderr: { @Sendable bytes in stderrHandler.handleDataFromPipe(Data(bytes)) }
           )
         )
       }


### PR DESCRIPTION
- **Explanation**: The closures aren’t guaranteed to be called on the same thread as the process was launched, which can cause assertion failure by the concurrency runtime, crashing `sourcekit-lsp diagnose` on launch.
- **Scope**: Concurrency annotations when launching subprocess from SourceKit-LSP.
- **Issue**: rdar://142813605
- **Original PR**: https://github.com/swiftlang/sourcekit-lsp/pull/1919
- **Risk**: Low, this is adding concurrency annotations and has been tested in main and 6.2 snapshots for over three months.
- **Testing**: Manually verified that `sourcekit-lsp diagnose` no longer crashes with this fix
- **Reviewer**: @bnbarham 