### PR TITLE
Add SwiftASN1 as dep in CMakeLists file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(ArgumentParser CONFIG REQUIRED)
 find_package(SwiftCollections QUIET)
 find_package(SwiftSyntax CONFIG REQUIRED)
 find_package(SwiftCrypto CONFIG REQUIRED)
+find_package(SwiftASN1 CONFIG REQUIRED)
 
 include(SwiftSupport)
 


### PR DESCRIPTION
SwiftPM has added Crypto related functionality to Workspace to support signing of the swift-syntax prebuilts manifest signing. This breaks sourcekit-lsp builds on Windows complaining about SwiftASN1 being missing. Adding a clause here to match the one in SwiftPM's CMakeLists.txt file.