### PR TITLE
Log the path that SourceKit-LSP was launched from

### DIFF
--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -237,6 +237,8 @@ struct SourceKitLSP: AsyncParsableCommand {
       fatalError("failed to redirect stdout -> stderr: \(strerror(errno)!)")
     }
 
+    logger.log("sourcekit-lsp launched from \(ProcessInfo.processInfo.arguments[0])")
+
     let globalConfigurationOptions = globalConfigurationOptions
     if let logLevelStr = globalConfigurationOptions.loggingOrDefault.level,
       let logLevel = NonDarwinLogLevel(logLevelStr)


### PR DESCRIPTION
Generally helpful to get a hint about whether an open source toolchain is used and to help with toolchain discovery issues.