### PR TITLE
Add SwiftASN1 as an explicit dependency on BuildSystemIntegration

### DIFF
--- a/Sources/BuildSystemIntegration/CMakeLists.txt
+++ b/Sources/BuildSystemIntegration/CMakeLists.txt
@@ -35,7 +35,8 @@ target_link_libraries(BuildSystemIntegration PUBLIC
   PackageModel
   TSCBasic
   Build
-  SourceKitLSPAPI)
+  SourceKitLSPAPI
+  SwiftASN1)
 
 target_link_libraries(BuildSystemIntegration PRIVATE
   SKUtilities


### PR DESCRIPTION
The SwiftPM smoke test still fails to build. I see the SwiftASN1 modules aren't getting added to the include path. Hopefully an explicit dependency will fix that.