### PR TITLE
Resolve swiftly when referenced in compile commands

### DIFF
--- a/Sources/BuildSystemIntegration/BuildTargetIdentifierExtensions.swift
+++ b/Sources/BuildSystemIntegration/BuildTargetIdentifierExtensions.swift
@@ -99,7 +99,6 @@ extension BuildTargetIdentifier {
 // MARK: BuildTargetIdentifier for CompileCommands
 
 extension BuildTargetIdentifier {
-  /// - Important: *For testing only*
   package static func createCompileCommands(compiler: String) throws -> BuildTargetIdentifier {
     var components = URLComponents()
     components.scheme = "compilecommands"

--- a/Sources/BuildSystemIntegration/CMakeLists.txt
+++ b/Sources/BuildSystemIntegration/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(BuildSystemIntegration STATIC
   LegacyBuildServerBuildSystem.swift
   MainFilesProvider.swift
   SplitShellCommand.swift
+  SwiftlyResolver.swift
   SwiftPMBuildSystem.swift)
 set_target_properties(BuildSystemIntegration PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/BuildSystemIntegration/SwiftlyResolver.swift
+++ b/Sources/BuildSystemIntegration/SwiftlyResolver.swift
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import SKUtilities
+import SwiftExtensions
+import TSCExtensions
+
+import struct TSCBasic.AbsolutePath
+import class TSCBasic.Process
+
+/// Given a path to a compiler, which might be a symlink to `swiftly`, this type determines the compiler executable in
+/// an actual toolchain. It also caches the results. The client needs to invalidate the cache if the path that swiftly
+/// might resolve to has changed, eg. because `.swift-version` has been updated.
+actor SwiftlyResolver {
+  private struct CacheKey: Hashable {
+    let compiler: URL
+    let workingDirectory: URL?
+  }
+
+  private var cache: LRUCache<CacheKey, Result<URL?, Error>> = LRUCache(capacity: 100)
+
+  /// Check if `compiler` is a symlink to `swiftly`. If so, find the executable in the toolchain that swiftly resolves
+  /// to within the given working directory and return the URL of the corresponding compiler in that toolchain.
+  /// If `compiler` does not resolve to `swiftly`, return `nil`.
+  func resolve(compiler: URL, workingDirectory: URL?) async throws -> URL? {
+    let cacheKey = CacheKey(compiler: compiler, workingDirectory: workingDirectory)
+    if let cached = cache[cacheKey] {
+      return try cached.get()
+    }
+    let computed: Result<URL?, Error>
+    do {
+      computed = .success(
+        try await resolveSwiftlyTrampolineImpl(compiler: compiler, workingDirectory: workingDirectory)
+      )
+    } catch {
+      computed = .failure(error)
+    }
+    cache[cacheKey] = computed
+    return try computed.get()
+  }
+
+  private func resolveSwiftlyTrampolineImpl(compiler: URL, workingDirectory: URL?) async throws -> URL? {
+    let realpath = try compiler.realpath
+    guard realpath.lastPathComponent == "swiftly" else {
+      return nil
+    }
+    let swiftlyResult = try await Process.run(
+      arguments: [realpath.filePath, "use", "-p"],
+      workingDirectory: try AbsolutePath(validatingOrNil: workingDirectory?.filePath)
+    )
+    let swiftlyToolchain = URL(
+      fileURLWithPath: try swiftlyResult.utf8Output().trimmingCharacters(in: .whitespacesAndNewlines)
+    )
+    let resolvedCompiler = swiftlyToolchain.appending(components: "usr", "bin", compiler.lastPathComponent)
+    if FileManager.default.fileExists(at: resolvedCompiler) {
+      return resolvedCompiler
+    }
+    return nil
+  }
+
+  func clearCache() {
+    cache.removeAll()
+  }
+}

--- a/Sources/SKTestSupport/CreateBinary.swift
+++ b/Sources/SKTestSupport/CreateBinary.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+package import Foundation
+import SwiftExtensions
+import ToolchainRegistry
+import XCTest
+
+import class TSCBasic.Process
+
+/// Compiles the given Swift source code into a binary at `executablePath`.
+package func createBinary(_ sourceCode: String, at executablePath: URL) async throws {
+  try await withTestScratchDir { scratchDir in
+    let sourceFile = scratchDir.appending(component: "source.swift")
+    try await sourceCode.writeWithRetry(to: sourceFile)
+
+    var compilerArguments = try [
+      sourceFile.filePath,
+      "-o",
+      executablePath.filePath,
+    ]
+    if let defaultSDKPath {
+      compilerArguments += ["-sdk", defaultSDKPath]
+    }
+    try await Process.checkNonZeroExit(
+      arguments: [unwrap(ToolchainRegistry.forTesting.default?.swiftc?.filePath)] + compilerArguments
+    )
+  }
+}

--- a/Tests/SourceKitLSPTests/FormattingTests.swift
+++ b/Tests/SourceKitLSPTests/FormattingTests.swift
@@ -299,18 +299,13 @@ final class FormattingTests: XCTestCase {
     try await withTestScratchDir { scratchDir in
       let toolchain = try await unwrap(ToolchainRegistry.forTesting.default)
 
-      let crashingSwiftFilePath = scratchDir.appendingPathComponent("crashing-executable.swift")
       let crashingExecutablePath = scratchDir.appendingPathComponent("crashing-executable")
-      try await "fatalError()".writeWithRetry(to: crashingSwiftFilePath)
-      var compilerArguments = try [
-        crashingSwiftFilePath.filePath,
-        "-o",
-        crashingExecutablePath.filePath,
-      ]
-      if let defaultSDKPath {
-        compilerArguments += ["-sdk", defaultSDKPath]
-      }
-      try await Process.checkNonZeroExit(arguments: [XCTUnwrap(toolchain.swiftc?.filePath)] + compilerArguments)
+      try await createBinary(
+        """
+        fatalError()
+        """,
+        at: crashingExecutablePath
+      )
 
       let toolchainRegistry = ToolchainRegistry(toolchains: [
         Toolchain(


### PR DESCRIPTION
- **Explanation**: When the compiler in `compile_commands.json` references a `swift` executable that’s a symlink to `swiftly`, SourceKit-LSP got confused because the `swift` executable doesn’t reside in a real toolchain, causing us to not provide any semantic functionality. When we discover that the `swift` executable reference in compile commands references a `swiftly` executable, use `swiftly use -p` to resolve the binary in the real toolchain and continue operating based on that.
- **Scope**: compile_commands.json projects that reference a `swift` executable that’s managed by swiftly
- **Issue**: https://github.com/swiftlang/sourcekit-lsp/issues/2128 / rdar://150301344
- **Original PR**: https://github.com/swiftlang/sourcekit-lsp/pull/2143
- **Risk**: This should not impact projects that don’t reference `swift` executables managed by swiftly and if you used a compile_commands project with an executable managed by swiftly, behavior was completely broken, so there should be no risk of introducing new issues.
- **Testing**: Added regression test
- **Reviewer**: @bnbarham @hamishknight 