### PR TITLE
Fix visibility on import triggering a compile warning

### DIFF
--- a/Sources/SKLogging/CustomLogStringConvertible.swift
+++ b/Sources/SKLogging/CustomLogStringConvertible.swift
@@ -10,7 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+// NSObject is defined in Foundation on non-darwin platforms. On
+// darwin, NSObject is package-visible.
+#if canImport(ObjectiveC)
+import Foundation
+#else
 package import Foundation
+#endif
 
 #if !NO_CRYPTO_DEPENDENCY
 import Crypto


### PR DESCRIPTION
Previously, building sourcekit-lsp would produce the following warning:

    $ swift build
    Building for debugging...
    /Users/wilfred/src/sourcekit-lsp/Sources/SKLogging/CustomLogStringConvertible.swift:13:9: warning: package import of 'Foundation' was not used in package declarations
     11 | //===----------------------------------------------------------------------===//
     12 |
     13 | package import Foundation
        |         `- warning: package import of 'Foundation' was not used in package declarations

Remove the visibility modifier, so no warning is produced.