### PR TITLE
Fix race condition that causes task cancellation to be missed in `TaskScheduler`

### DIFF
--- a/Sources/SemanticIndex/PreparationTaskDescription.swift
+++ b/Sources/SemanticIndex/PreparationTaskDescription.swift
@@ -105,9 +105,7 @@ package struct PreparationTaskDescription: IndexTaskDescription {
       do {
         try await buildSystemManager.prepare(targets: Set(targetsToPrepare))
       } catch {
-        logger.error(
-          "Preparation failed: \(error.forLogging)"
-        )
+        logger.error("Preparation failed: \(error.forLogging)")
       }
       await hooks.preparationTaskDidFinish?(self)
       if !Task.isCancelled {


### PR DESCRIPTION
A queued task might have been cancelled after the execution ask was started but before the task was yielded to `executionTaskCreatedContinuation`. In that case the result task will simply cancel the await on the `executionTaskCreatedStream` and hence not call `valuePropagatingCancellation` on the execution task. This means that the queued task cancellation wouldn't be propagated to the execution task. To address this, check if `resultTaskCancelled` was  set and, if so, explicitly cancel the execution task here.

Fixes an issue I saw in CI during PR testing.