### PR TITLE
Do not schedule any new tasks in `TaskScheduler` if it has been shut down

### DIFF
--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -513,6 +513,9 @@ package actor TaskScheduler<TaskDescription: TaskDescriptionProtocol> {
   ///
   /// This will continue calling itself until the queue is empty.
   private func poke() {
+    if isShutDown {
+      return
+    }
     pendingTasks.sort(by: { $0.priority > $1.priority })
     for task in pendingTasks {
       guard


### PR DESCRIPTION
This is what `shutDown()` is documented to do. I also remember having this check before, it might have gotten lost during a rebase when I was working on https://github.com/swiftlang/sourcekit-lsp/pull/2081.

I noticed this while investigating https://github.com/swiftlang/sourcekit-lsp/pull/2152: In this case `buildTarget/prepare` was cancelled because the SourceKit-LSP server was shut down but indexing of a file was still started after the shutdown now that preparation had finished (because it was cancelled).