### PR TITLE
Fix Package.swift warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -229,7 +229,7 @@ var targets: [Target] = [
       .product(name: "SwiftDocC", package: "swift-docc"),
       .product(name: "SymbolKit", package: "swift-docc-symbolkit"),
     ],
-    exclude: ["CMakeLists.txt"],
+    exclude: [],
     swiftSettings: globalSwiftSettings
   ),
 
@@ -807,7 +807,7 @@ var dependencies: [Package.Dependency] {
       .package(url: "https://github.com/swiftlang/swift-docc.git", branch: relatedDependenciesBranch),
       .package(url: "https://github.com/swiftlang/swift-docc-symbolkit.git", branch: relatedDependenciesBranch),
       .package(url: "https://github.com/swiftlang/swift-markdown.git", branch: relatedDependenciesBranch),
-      .package(url: "https://github.com/apple/swift-tools-support-core.git", branch: relatedDependenciesBranch),
+      .package(url: "https://github.com/swiftlang/swift-tools-support-core.git", branch: relatedDependenciesBranch),
       .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
       .package(url: "https://github.com/swiftlang/swift-syntax.git", branch: relatedDependenciesBranch),
       .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),


### PR DESCRIPTION
Previously Package.swift referred a non-existent CMakeLists.txt file and used old URLs for the swift-tools-support-core repository, leading to the following build warnings:

    warning: 'sourcekit-lsp': Invalid Exclude '/Users/wilfred/src/sourcekit-lsp/Sources/DocCDocumentation/CMakeLists.txt': File not found.
    warning: 'swift-package-manager': 'swift-package-manager' dependency on 'https://github.com/swiftlang/swift-tools-support-core.git' conflicts with dependency on 'https://github.com/apple/swift-tools-support-core.git' which has the same identity 'swift-tools-support-core'. this will be escalated to an error in future versions of SwiftPM.
    warning: 'swift-driver': 'swift-driver' dependency on 'https://github.com/swiftlang/swift-tools-support-core.git' conflicts with dependency on 'https://github.com/apple/swift-tools-support-core.git' which has the same identity 'swift-tools-support-core'. this will be escalated to an error in future versions of SwiftPM.