### PR TITLE
Add a `--enable-inlay-hints` setting

### DIFF
--- a/Sources/SKOptions/SourceKitLSPOptions.swift
+++ b/Sources/SKOptions/SourceKitLSPOptions.swift
@@ -433,6 +433,9 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     return .seconds(300)
   }
 
+  /// Enable or disable registering inlay hints for the inlayHintProvider
+  public var enableInlayHints: Bool? = nil
+
   public init(
     swiftPM: SwiftPMOptions? = .init(),
     fallbackBuildSystem: FallbackBuildSystemOptions? = .init(),
@@ -451,7 +454,8 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     swiftPublishDiagnosticsDebounceDuration: Double? = nil,
     workDoneProgressDebounceDuration: Double? = nil,
     sourcekitdRequestTimeout: Double? = nil,
-    semanticServiceRestartTimeout: Double? = nil
+    semanticServiceRestartTimeout: Double? = nil,
+    enableInlayHints: Bool? = nil
   ) {
     self.swiftPM = swiftPM
     self.fallbackBuildSystem = fallbackBuildSystem
@@ -471,6 +475,7 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
     self.workDoneProgressDebounceDuration = workDoneProgressDebounceDuration
     self.sourcekitdRequestTimeout = sourcekitdRequestTimeout
     self.semanticServiceRestartTimeout = semanticServiceRestartTimeout
+    self.enableInlayHints = enableInlayHints
   }
 
   public init?(fromLSPAny lspAny: LSPAny?) throws {
@@ -531,7 +536,8 @@ public struct SourceKitLSPOptions: Sendable, Codable, Equatable {
       workDoneProgressDebounceDuration: override?.workDoneProgressDebounceDuration
         ?? base.workDoneProgressDebounceDuration,
       sourcekitdRequestTimeout: override?.sourcekitdRequestTimeout ?? base.sourcekitdRequestTimeout,
-      semanticServiceRestartTimeout: override?.semanticServiceRestartTimeout ?? base.semanticServiceRestartTimeout
+      semanticServiceRestartTimeout: override?.semanticServiceRestartTimeout ?? base.semanticServiceRestartTimeout,
+      enableInlayHints: base.enableInlayHints
     )
   }
 

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1146,7 +1146,7 @@ extension SourceKitLSPServer {
     if let semanticTokensOptions = server.semanticTokensProvider {
       await registry.registerSemanticTokensIfNeeded(options: semanticTokensOptions, for: languages, server: self)
     }
-    if let inlayHintProvider = server.inlayHintProvider, inlayHintProvider.isSupported {
+    if let inlayHintProvider = server.inlayHintProvider, inlayHintProvider.isSupported, options.enableInlayHints ?? true {
       let options: InlayHintOptions
       switch inlayHintProvider {
       case .bool(true):

--- a/Sources/sourcekit-lsp/SourceKitLSP.swift
+++ b/Sources/sourcekit-lsp/SourceKitLSP.swift
@@ -141,6 +141,14 @@ struct SourceKitLSP: AsyncParsableCommand {
   )
   var experimentalFeatures: [String] = []
 
+  @Option(
+    name: .customLong("enable-inlay-hints"),
+    help: """
+      Enable or disable inlay hint responses
+      """
+  )
+  var enableInlayHints: Bool = true
+
   /// Maps The options passed on the command line to a `SourceKitLSPOptions` struct.
   func commandLineOptions() -> SourceKitLSPOptions {
     return SourceKitLSPOptions(
@@ -170,7 +178,8 @@ struct SourceKitLSP: AsyncParsableCommand {
       defaultWorkspaceType: defaultWorkspaceType,
       generatedFilesPath: generatedFilesPath,
       backgroundIndexing: experimentalFeatures.contains("background-indexing"),
-      experimentalFeatures: Set(experimentalFeatures.compactMap(ExperimentalFeature.init))
+      experimentalFeatures: Set(experimentalFeatures.compactMap(ExperimentalFeature.init)),
+      enableInlayHints: enableInlayHints
     )
   }
 


### PR DESCRIPTION
The default behaviour for IDEs such as VS Code is to enable all inlay hints. It is possible to turn off inlay hints for Swift through VS Code through user settings but it may be tricky for new users to figure out how to do this. In order to not confuse new users and avoid annoying experienced users, it would be better to turn off the inlay hints by default. Most VS Code extensions such as  Go, Python etc. disable inlay hints (for variable type inference, at least) via the LSP probably to avoid touching user/IDE default settings.

This PR is an initial attempt at a new setting that will allow for inlay hint requests to be ignored if `--enable-inlay-hints` is set to `false` during SourceKit-LSP startup. The goal is to have Swift VS Code extension to disable inlay hints by default until there is a better way to do this via VS Code without having to edit user settings.