### PR TITLE
Pass `hostToolchainBinDir` to `SwiftSDKBundleStore`

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -216,6 +216,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
         swiftSDKsDirectory: localFileSystem.getSharedSwiftSDKsDirectory(
           explicitDirectory: options.swiftPMOrDefault.swiftSDKsDirectory.map { try AbsolutePath(validating: $0) }
         ),
+        hostToolchainBinDir: hostSwiftPMToolchain.swiftCompilerPath.parentDirectory,
         fileSystem: localFileSystem,
         observabilityScope: observabilitySystem.topScope.makeChildScope(description: "SwiftPM Bundle Store"),
         outputHandler: { _ in }


### PR DESCRIPTION
This became a required parameter in https://github.com/swiftlang/swift-package-manager/pull/8668, which can be easily computed, since the host toolchain in practice is always available when `SwiftSDKBundleStore` is initialized.