### PR TITLE
Pass `cancelOnSubsequentRequest: 0` to all requests that support it

### DIFF
--- a/Sources/SourceKitLSP/Swift/MacroExpansion.swift
+++ b/Sources/SourceKitLSP/Swift/MacroExpansion.swift
@@ -94,6 +94,7 @@ actor MacroExpansionManager {
     let length = snapshot.utf8OffsetRange(of: range).count
 
     let skreq = swiftLanguageService.sourcekitd.dictionary([
+      keys.cancelOnSubsequentRequest: 0,
       // Preferred name for e.g. an extracted variable.
       // Empty string means sourcekitd chooses a name automatically.
       keys.name: "",

--- a/Sources/SourceKitLSP/Swift/RefactoringResponse.swift
+++ b/Sources/SourceKitLSP/Swift/RefactoringResponse.swift
@@ -117,6 +117,7 @@ extension SwiftLanguageService {
     let utf8Column = snapshot.lineTable.utf8ColumnAt(line: line, utf16Column: utf16Column)
 
     let skreq = sourcekitd.dictionary([
+      keys.cancelOnSubsequentRequest: 0,
       // Preferred name for e.g. an extracted variable.
       // Empty string means sourcekitd chooses a name automatically.
       keys.name: "",

--- a/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
+++ b/Sources/SourceKitLSP/Swift/VariableTypeInfo.swift
@@ -86,6 +86,7 @@ extension SwiftLanguageService {
     let snapshot = try await self.latestSnapshot(for: uri)
 
     let skreq = sourcekitd.dictionary([
+      keys.cancelOnSubsequentRequest: 0,
       keys.sourceFile: snapshot.uri.sourcekitdSourceFile,
       keys.primaryFile: snapshot.uri.primaryFile?.pseudoPath,
       keys.compilerArgs: await self.compileCommand(for: uri, fallbackAfterTimeout: false)?.compilerArgs


### PR DESCRIPTION
Adopt the option introduced by https://github.com/swiftlang/swift/pull/81507. SourceKit-LSP uses explicit cancellation and perform any implicit cancellation inside sourcekitd.

Fixes #2021
rdar://145871554