### PR TITLE
Expose BuildServerProtocol as a product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ var globalSwiftSettings: [SwiftSetting] {
 var products: [Product] = [
   .executable(name: "sourcekit-lsp", targets: ["sourcekit-lsp"]),
   .library(name: "_SourceKitLSP", targets: ["SourceKitLSP"]),
+  .library(name: "BuildServerProtocol", targets: ["BuildServerProtocol"]),
   .library(name: "LSPBindings", targets: ["LanguageServerProtocol", "LanguageServerProtocolJSONRPC"]),
   .library(name: "InProcessClient", targets: ["InProcessClient"]),
   .library(name: "SwiftSourceKitPlugin", type: .dynamic, targets: ["SwiftSourceKitPlugin"]),


### PR DESCRIPTION
I'm working on a BSP for sourcekit-lsp and it would be immensely helpful for me to be able to reuse the existing Codable request/response specs on this repo. It seemed to me that publishing the existing library should be fine, but do let me know if that was intentionally not the case.