### PR TITLE
Update for new `ExpandEditorPlaceholdersToLiteralClosures` API

### DIFF
--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -405,11 +405,14 @@ class CodeCompletionSession {
       exprToExpand = insertText
     }
 
+    // Note we don't need special handling for macro expansions since
+    // their insertion text doesn't include the '#', so are parsed as
+    // function calls here.
     var parser = Parser(exprToExpand)
     let expr = ExprSyntax.parse(from: &parser)
     guard let call = OutermostFunctionCallFinder.findOutermostFunctionCall(in: expr),
       let expandedCall = ExpandEditorPlaceholdersToLiteralClosures.refactor(
-        syntax: call,
+        syntax: Syntax(call),
         in: ExpandEditorPlaceholdersToLiteralClosures.Context(
           format: .custom(
             ClosureCompletionFormat(indentationWidth: indentationWidth),


### PR DESCRIPTION
This refactoring now takes a `Syntax` parameter. We don't actually need to change anything else to handle placeholder expansion for macro expansion completions since they get parsed as function calls.