### PR TITLE
[6.2] Update for new `ExpandEditorPlaceholdersToLiteralClosures` API

### DIFF
--- a/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
+++ b/Sources/SourceKitLSP/Swift/CodeCompletionSession.swift
@@ -401,11 +401,14 @@ class CodeCompletionSession {
       exprToExpand = insertText
     }
 
+    // Note we don't need special handling for macro expansions since
+    // their insertion text doesn't include the '#', so are parsed as
+    // function calls here.
     var parser = Parser(exprToExpand)
     let expr = ExprSyntax.parse(from: &parser)
     guard let call = OutermostFunctionCallFinder.findOutermostFunctionCall(in: expr),
       let expandedCall = ExpandEditorPlaceholdersToLiteralClosures.refactor(
-        syntax: call,
+        syntax: Syntax(call),
         in: ExpandEditorPlaceholdersToLiteralClosures.Context(
           format: .custom(
             ClosureCompletionFormat(indentationWidth: indentationWidth),


### PR DESCRIPTION
*6.2 cherry-pick of https://github.com/swiftlang/sourcekit-lsp/pull/2170*

- Explanation: Updates sourcekit-lsp for a new swift-syntax API
- Scope: NFC
- Issue: rdar://152711580
- Risk: Low, this is an NFC change
- Testing: Added tests to test suite
- Reviewer: Alex Hoppen, Ben Barham