### PR TITLE
Avoid crashing on invalid range in `editDocument`

### DIFF
--- a/Sources/SKUtilities/LineTable.swift
+++ b/Sources/SKUtilities/LineTable.swift
@@ -124,30 +124,6 @@ extension LineTable {
   /// - parameter replacement: The new text for the given range.
   @inlinable
   mutating package func replace(
-    fromLine: Int,
-    utf8Offset fromOff: Int,
-    toLine: Int,
-    utf8Offset toOff: Int,
-    with replacement: String
-  ) {
-    let start = self.stringIndexOf(line: fromLine, utf8Column: fromOff)
-    let end = self.stringIndexOf(line: toLine, utf8Column: toOff)
-
-    var newText = self.content
-    newText.replaceSubrange(start..<end, with: replacement)
-
-    self = LineTable(newText)
-  }
-
-  /// Replace the line table's `content` in the given range and update the line data.
-  ///
-  /// - parameter fromLine: Starting line number (zero-based).
-  /// - parameter fromOff: Starting UTF-8 column offset (zero-based).
-  /// - parameter toLine: Ending line number (zero-based).
-  /// - parameter toOff: Ending UTF-8 column offset (zero-based).
-  /// - parameter replacement: The new text for the given range.
-  @inlinable
-  mutating package func replace(
     utf8Offset fromOff: Int,
     length: Int,
     with replacement: String

--- a/Sources/SwiftSourceKitPlugin/CodeCompletion/Connection.swift
+++ b/Sources/SwiftSourceKitPlugin/CodeCompletion/Connection.swift
@@ -140,8 +140,11 @@ final class Connection {
       return
     }
 
-    document.lineTable.replace(utf8Offset: offset, length: length, with: newText)
-
+    // Try replace the range, ignoring an invalid input. This matches SourceKit's
+    // behavior.
+    orLog("Replacing text") {
+      try document.lineTable.tryReplace(utf8Offset: offset, length: length, with: newText)
+    }
     sourcekitd.ideApi.set_file_contents(impl, path, document.lineTable.content)
   }
 

--- a/Sources/SwiftSourceKitPlugin/CodeCompletion/Connection.swift
+++ b/Sources/SwiftSourceKitPlugin/CodeCompletion/Connection.swift
@@ -145,23 +145,6 @@ final class Connection {
     sourcekitd.ideApi.set_file_contents(impl, path, document.lineTable.content)
   }
 
-  func editDocument(path: String, edit: TextEdit) {
-    guard let document = documents[path] else {
-      logger.error("Document at '\(path)' is not open")
-      return
-    }
-
-    document.lineTable.replace(
-      fromLine: edit.range.lowerBound.line - 1,
-      utf8Offset: edit.range.lowerBound.utf8Column - 1,
-      toLine: edit.range.upperBound.line - 1,
-      utf8Offset: edit.range.upperBound.utf8Column - 1,
-      with: edit.newText
-    )
-
-    sourcekitd.ideApi.set_file_contents(impl, path, document.lineTable.content)
-  }
-
   func closeDocument(path: String) {
     if documents[path] == nil {
       logger.error("Document at '\(path)' was not open")


### PR DESCRIPTION
Rename `LineTable.replace(utf8Offset:length:with)` to `tryReplace` and bail if the provided range is out of bounds of the buffer. This ensures we match the behavior of SourceKit when handling an `editor.replacetext` request.

rdar://161268691