### PR TITLE
[6.2] Handle both file paths and URLs from educational notes

### DIFF
--- a/Sources/SourceKitLSP/Swift/Diagnostic.swift
+++ b/Sources/SourceKitLSP/Swift/Diagnostic.swift
@@ -248,10 +248,19 @@ extension Diagnostic {
       educationalNotePaths.count > 0,
       let primaryPath = educationalNotePaths[0]
     {
-      let url = URL(fileURLWithPath: primaryPath)
-      let name = url.deletingPathExtension().lastPathComponent
-      code = .string(name)
-      codeDescription = .init(href: DocumentURI(url))
+      // Swift >= 6.2 returns a URL rather than a file path
+      let url: URL? =
+        if primaryPath.starts(with: "http") {
+          URL(string: primaryPath)
+        } else {
+          URL(fileURLWithPath: primaryPath)
+        }
+
+      if let url {
+        let name = url.deletingPathExtension().lastPathComponent
+        code = .string(name)
+        codeDescription = .init(href: DocumentURI(url))
+      }
     }
 
     var actions: [CodeAction]? = nil

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -379,8 +379,13 @@ final class LocalSwiftTests: XCTestCase {
     XCTAssertEqual(diags.diagnostics.count, 1)
     let diag = diags.diagnostics.first!
     XCTAssertEqual(diag.code, .string("property-wrapper-requirements"))
-    let filename = try XCTUnwrap(diag.codeDescription?.href.fileURL?.lastPathComponent)
-    XCTAssert(filename.starts(with: "property-wrapper-requirements"))
+
+    let noteUri = try XCTUnwrap(diag.codeDescription?.href)
+    if noteUri.fileURL != nil {
+      // Check we're not creating an absolute path out of a URL
+      XCTAssertFalse(noteUri.stringValue.contains("https://"))
+    }
+    XCTAssert(noteUri.arbitrarySchemeURL.lastPathComponent.starts(with: "property-wrapper-requirements"))
   }
 
   func testFixitsAreIncludedInPublishDiagnostics() async throws {


### PR DESCRIPTION
*6.2 cherry-pick of #2175*

- Explanation: sourcekitd was recently switched to returning the swift.org URL for diagnostics groups/educational notes. Handle either an absolute path or URL.
- Scope: Affects diagnostic groups/educational notes
- Issue: rdar://153736166
- Risk: Low, the fix is straightforward
- Testing: Added tests to test suite
- Reviewer: Alex Hoppen