### PR TITLE
[6.2] Fix the issue of indexPrefixMap being unordered, which causes the IndexStoreDB path to be unpredictable

### DIFF
--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -307,6 +307,16 @@ package final class Workspace: Sendable, BuildSystemManagerDelegate {
         let prefixMappings =
           (indexOptions.indexPrefixMap ?? [:])
           .map { PathMapping(original: $0.key, replacement: $0.value) }
+          .sorted {
+            // Fixes an issue where remapPath might match the shortest path first when multiple common prefixes exist
+            // Sort by path length descending to prioritize more specific paths;
+            // when lengths are equal, sort lexicographically in ascending order
+            if $0.original.count != $1.original.count {
+              return $0.original.count > $1.original.count  // Prefer longer paths (more specific)
+            } else {
+              return $0.original < $1.original  // Alphabetical sort when lengths are equal, ensures stable ordering
+            }
+          }
         if let indexInjector = hooks.indexHooks.indexInjector {
           let indexStoreDB = try await indexInjector.createIndex(
             storePath: indexStorePath,


### PR DESCRIPTION
*6.2 cherry-pick of #2177*

- Explanation: Ensures the `indexPrefixMap` has a deterministic ordering
- Scope: Affects the `indexPrefixMap`
- Issue: rdar://153736699
- Risk: Low, the fix is simple
- Testing: N/A
- Reviewer: Ben Barham