### PR TITLE
Explicitly specify the build system used when constructing SwiftPM BuildParameters

### DIFF
--- a/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
+++ b/Sources/BuildSystemIntegration/SwiftPMBuildSystem.swift
@@ -282,7 +282,8 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
       ),
       configuration: buildConfiguration,
       toolchain: hostSwiftPMToolchain,
-      flags: buildFlags
+      flags: buildFlags,
+      buildSystemKind: .native,
     )
 
     self.destinationBuildParameters = try BuildParameters(
@@ -294,6 +295,7 @@ package actor SwiftPMBuildSystem: BuiltInBuildSystem {
       toolchain: destinationSwiftPMToolchain,
       triple: destinationSDK.targetTriple,
       flags: buildFlags,
+      buildSystemKind: .native,
       prepareForIndexing: options.backgroundPreparationModeOrDefault.toSwiftPMPreparation
     )
 


### PR DESCRIPTION
In https://github.com/swiftlang/swift-package-manager/pull/8861, I'm removing the default value for BuildSystemKind to ensure any explicit use of a p[articular SwiftPM build system backend is explicit in the source. Adapt to this change in SourceKit-LSP's SwiftPMBuildSystem