### PR TITLE
[DocC Live Preview] Support parameter and return type disambiguations

### DIFF
--- a/Sources/DocCDocumentation/DocCSymbolInformation.swift
+++ b/Sources/DocCDocumentation/DocCSymbolInformation.swift
@@ -11,36 +11,30 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
-import IndexStoreDB
-package import SemanticIndex
 @_spi(LinkCompletion) @preconcurrency import SwiftDocC
+import SwiftExtensions
 import SymbolKit
 
 package struct DocCSymbolInformation {
-  let components: [(name: String, information: LinkCompletionTools.SymbolInformation)]
+  struct Component {
+    let name: String
+    let information: LinkCompletionTools.SymbolInformation
 
-  /// Find the DocCSymbolLink for a given symbol USR.
-  ///
-  /// - Parameters:
-  ///   - usr: The symbol USR to find in the index.
-  ///   - index: The CheckedIndex to search within.
-  package init?(fromUSR usr: String, in index: CheckedIndex) {
-    guard let topLevelSymbolOccurrence = index.primaryDefinitionOrDeclarationOccurrence(ofUSR: usr) else {
-      return nil
+    init(fromModuleName moduleName: String) {
+      self.name = moduleName
+      self.information = LinkCompletionTools.SymbolInformation(fromModuleName: moduleName)
     }
-    let moduleName = topLevelSymbolOccurrence.location.moduleName
-    var components = [topLevelSymbolOccurrence]
-    // Find any parent symbols
-    var symbolOccurrence: SymbolOccurrence = topLevelSymbolOccurrence
-    while let parentSymbolOccurrence = symbolOccurrence.parent(index) {
-      components.insert(parentSymbolOccurrence, at: 0)
-      symbolOccurrence = parentSymbolOccurrence
+
+    init(fromSymbol symbol: SymbolGraph.Symbol) {
+      self.name = symbol.pathComponents.last ?? symbol.names.title
+      self.information = LinkCompletionTools.SymbolInformation(symbol: symbol)
     }
-    self.components =
-      [(name: moduleName, LinkCompletionTools.SymbolInformation(fromModuleName: moduleName))]
-      + components.map {
-        (name: $0.symbol.name, information: LinkCompletionTools.SymbolInformation(fromSymbolOccurrence: $0))
-      }
+  }
+
+  let components: [Component]
+
+  init(components: [Component]) {
+    self.components = components
   }
 
   package func matches(_ link: DocCSymbolLink) -> Bool {
@@ -55,73 +49,11 @@ package struct DocCSymbolInformation {
 
 fileprivate typealias KindIdentifier = SymbolGraph.Symbol.KindIdentifier
 
-extension SymbolOccurrence {
-  var doccSymbolKind: String {
-    switch symbol.kind {
-    case .module:
-      KindIdentifier.module.identifier
-    case .namespace, .namespaceAlias:
-      KindIdentifier.namespace.identifier
-    case .macro:
-      KindIdentifier.macro.identifier
-    case .enum:
-      KindIdentifier.enum.identifier
-    case .struct:
-      KindIdentifier.struct.identifier
-    case .class:
-      KindIdentifier.class.identifier
-    case .protocol:
-      KindIdentifier.protocol.identifier
-    case .extension:
-      KindIdentifier.extension.identifier
-    case .union:
-      KindIdentifier.union.identifier
-    case .typealias:
-      KindIdentifier.typealias.identifier
-    case .function:
-      KindIdentifier.func.identifier
-    case .variable:
-      KindIdentifier.var.identifier
-    case .field:
-      KindIdentifier.property.identifier
-    case .enumConstant:
-      KindIdentifier.case.identifier
-    case .instanceMethod:
-      KindIdentifier.func.identifier
-    case .classMethod:
-      KindIdentifier.func.identifier
-    case .staticMethod:
-      KindIdentifier.func.identifier
-    case .instanceProperty:
-      KindIdentifier.property.identifier
-    case .classProperty, .staticProperty:
-      KindIdentifier.typeProperty.identifier
-    case .constructor:
-      KindIdentifier.`init`.identifier
-    case .destructor:
-      KindIdentifier.deinit.identifier
-    case .conversionFunction:
-      KindIdentifier.func.identifier
-    case .unknown, .using, .concept, .commentTag, .parameter:
-      "unknown"
-    }
-  }
-}
-
 extension LinkCompletionTools.SymbolInformation {
   init(fromModuleName moduleName: String) {
     self.init(
       kind: KindIdentifier.module.identifier,
       symbolIDHash: Self.hash(uniqueSymbolID: moduleName)
-    )
-  }
-
-  init(fromSymbolOccurrence occurrence: SymbolOccurrence) {
-    self.init(
-      kind: occurrence.doccSymbolKind,
-      symbolIDHash: Self.hash(uniqueSymbolID: occurrence.symbol.usr),
-      parameterTypes: nil,
-      returnTypes: nil
     )
   }
 }

--- a/Sources/SourceKitLSP/Documentation/DoccDocumentationHandler.swift
+++ b/Sources/SourceKitLSP/Documentation/DoccDocumentationHandler.swift
@@ -59,7 +59,30 @@ extension DocumentationLanguageService {
           throw ResponseError.requestFailed(doccDocumentationError: .indexNotAvailable)
         }
         guard let symbolLink = DocCSymbolLink(linkString: symbolName),
-          let symbolOccurrence = index.primaryDefinitionOrDeclarationOccurrence(ofDocCSymbolLink: symbolLink)
+          let symbolOccurrence = try await index.primaryDefinitionOrDeclarationOccurrence(
+            ofDocCSymbolLink: symbolLink,
+            fetchSymbolGraph: { location in
+              guard let symbolWorkspace = try await workspaceForDocument(uri: location.documentUri),
+                let languageService = try await languageService(for: location.documentUri, .swift, in: symbolWorkspace)
+                  as? SwiftLanguageService
+              else {
+                throw ResponseError.internalError("Unable to find Swift language service for \(location.documentUri)")
+              }
+              return try await languageService.withSnapshotFromDiskOpenedInSourcekitd(
+                uri: location.documentUri,
+                fallbackSettingsAfterTimeout: false
+              ) {
+                (snapshot, compileCommand) in
+                let (_, _, symbolGraph) = try await languageService.cursorInfo(
+                  snapshot,
+                  compileCommand: compileCommand,
+                  Range(snapshot.position(of: location)),
+                  includeSymbolGraph: true
+                )
+                return symbolGraph
+              }
+            }
+          )
         else {
           throw ResponseError.requestFailed(doccDocumentationError: .symbolNotFound(symbolName))
         }

--- a/Sources/SourceKitLSP/Swift/DoccDocumentation.swift
+++ b/Sources/SourceKitLSP/Swift/DoccDocumentation.swift
@@ -14,6 +14,7 @@
 import BuildSystemIntegration
 import DocCDocumentation
 import Foundation
+import IndexStoreDB
 package import LanguageServerProtocol
 import SemanticIndex
 import SKLogging
@@ -73,7 +74,22 @@ extension SwiftLanguageService {
         workspace: workspace,
         documentationManager: documentationManager,
         catalogURL: catalogURL,
-        for: symbolUSR
+        for: symbolUSR,
+        fetchSymbolGraph: { symbolLocation in
+          try await withSnapshotFromDiskOpenedInSourcekitd(
+            uri: symbolLocation.documentUri,
+            fallbackSettingsAfterTimeout: false
+          ) {
+            (snapshot, compileCommand) in
+            let (_, _, symbolGraph) = try await self.cursorInfo(
+              snapshot,
+              compileCommand: compileCommand,
+              Range(snapshot.position(of: symbolLocation)),
+              includeSymbolGraph: true
+            )
+            return symbolGraph
+          }
+        }
       )
     }
     return try await documentationManager.renderDocCDocumentation(
@@ -90,14 +106,18 @@ extension SwiftLanguageService {
     workspace: Workspace,
     documentationManager: DocCDocumentationManager,
     catalogURL: URL?,
-    for symbolUSR: String
+    for symbolUSR: String,
+    fetchSymbolGraph: @Sendable (_: SymbolLocation) async throws -> String?
   ) async throws -> String? {
     guard let catalogURL else {
       return nil
     }
     let catalogIndex = try await documentationManager.catalogIndex(for: catalogURL)
     guard let index = workspace.index(checkedFor: .deletedFiles),
-      let symbolInformation = DocCSymbolInformation(fromUSR: symbolUSR, in: index),
+      let symbolInformation = try await index.doccSymbolInformation(
+        ofUSR: symbolUSR,
+        fetchSymbolGraph: fetchSymbolGraph
+      ),
       let markupExtensionFileURL = catalogIndex.documentationExtension(for: symbolInformation)
     else {
       return nil
@@ -140,7 +160,10 @@ fileprivate struct DocumentableSymbol {
     } else if let functionDecl = node.as(FunctionDeclSyntax.self) {
       self = DocumentableSymbol(node: functionDecl, position: functionDecl.name.positionAfterSkippingLeadingTrivia)
     } else if let subscriptDecl = node.as(SubscriptDeclSyntax.self) {
-      self = DocumentableSymbol(node: subscriptDecl, position: subscriptDecl.positionAfterSkippingLeadingTrivia)
+      self = DocumentableSymbol(
+        node: subscriptDecl.subscriptKeyword,
+        position: subscriptDecl.subscriptKeyword.positionAfterSkippingLeadingTrivia
+      )
     } else if let variableDecl = node.as(VariableDeclSyntax.self) {
       guard let identifier = variableDecl.bindings.only?.pattern.as(IdentifierPatternSyntax.self) else {
         return nil

--- a/Tests/SourceKitLSPTests/DoccDocumentationTests.swift
+++ b/Tests/SourceKitLSPTests/DoccDocumentationTests.swift
@@ -121,8 +121,8 @@ final class DoccDocumentationTests: XCTestCase {
       markedText: """
         /// A structure containing important information.
         public struct Structure {
-          // Get the 1️⃣subscript at index
-          subscript(in2️⃣dex: Int) -> Int {
+          /// Get the 1️⃣subscript at index
+          public subscript(in2️⃣dex: Int) -> Int {
             return i3️⃣ndex
           }
         }
@@ -173,7 +173,7 @@ final class DoccDocumentationTests: XCTestCase {
       markedText: """
         /// A class containing important information.
         public class Class {
-          /// Initi1️⃣alize the class.
+          /// De-initi1️⃣alize the class.
           dein2️⃣it {
             // De-initi3️⃣alize stuff
           }
@@ -710,6 +710,179 @@ final class DoccDocumentationTests: XCTestCase {
       project: project,
       expectedResponses: [
         "2️⃣": .renderNode(kind: .symbol, path: "MyLibrary/Foo/Color", containing: "The color of Foo")
+      ]
+    )
+  }
+
+  func testMarkdownExtensionForFunctionDisambiguatedByUSRHash() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyLibrary/Foo.swift": """
+        /// 1️⃣The Int version of foo(_:)
+        public func foo(_ x: Int) -> Int {
+          x + 1
+        }
+
+        /// 2️⃣The String version of foo(_:)
+        public func foo(_ x: String) -> String {
+          x + "1"
+        }
+        """,
+        "MyLibrary/MyLibrary.docc/Foo-Int.md": """
+        3️⃣# ``MyLibrary/foo(_:)-7dlor``
+
+        # Additional information for the foo(_:)->Int function
+
+        This will be appended to the end of foo(_:)->Int's documentation page
+        """,
+        "MyLibrary/MyLibrary.docc/Foo-String.md": """
+        4️⃣# ``MyLibrary/foo(_:)-7dtuv``
+
+        # Additional information for the foo(_:)->String function
+
+        This will be appended to the end of foo(_:)->String's documentation page
+        """,
+      ],
+      enableBackgroundIndexing: true
+    )
+    try await renderDocumentation(
+      fileName: "Foo.swift",
+      project: project,
+      expectedResponses: [
+        "1️⃣": .renderNode(
+          kind: .symbol,
+          path: "MyLibrary/foo(_:)",
+          containing: "Additional information for the foo(_:)->Int function"
+        ),
+        "2️⃣": .renderNode(
+          kind: .symbol,
+          path: "MyLibrary/foo(_:)",
+          containing: "Additional information for the foo(_:)->String function"
+        ),
+      ]
+    )
+    try await renderDocumentation(
+      fileName: "Foo-Int.md",
+      project: project,
+      expectedResponses: [
+        "3️⃣": .renderNode(kind: .symbol, path: "MyLibrary/foo(_:)", containing: "The Int version of foo(_:)")
+      ]
+    )
+    try await renderDocumentation(
+      fileName: "Foo-String.md",
+      project: project,
+      expectedResponses: [
+        "4️⃣": .renderNode(kind: .symbol, path: "MyLibrary/foo(_:)", containing: "The String version of foo(_:)")
+      ]
+    )
+  }
+
+  func testMarkdownExtensionForFunctionDisambiguatedByReturnType() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyLibrary/Foo.swift": """
+        /// 1️⃣The Int version of foo(_:)
+        public func foo(_ x: Int) -> Int {
+          x + 1
+        }
+
+        /// 2️⃣The String version of foo(_:)
+        public func foo(_ x: String) -> String {
+          x + "1"
+        }
+        """,
+        "MyLibrary/MyLibrary.docc/Foo-Int.md": """
+        3️⃣# ``MyLibrary/foo(_:)->Int``
+
+        # Additional information for the foo(_:)->Int function
+
+        This will be appended to the end of foo(_:)->Int's documentation page
+        """,
+        "MyLibrary/MyLibrary.docc/Foo-String.md": """
+        4️⃣# ``MyLibrary/foo(_:)->String``
+
+        # Additional information for the foo(_:)->String function
+
+        This will be appended to the end of foo(_:)->String's documentation page
+        """,
+      ],
+      enableBackgroundIndexing: true
+    )
+    try await renderDocumentation(
+      fileName: "Foo-Int.md",
+      project: project,
+      expectedResponses: [
+        "3️⃣": .renderNode(kind: .symbol, path: "MyLibrary/foo(_:)", containing: "The Int version of foo(_:)")
+      ]
+    )
+    try await renderDocumentation(
+      fileName: "Foo-String.md",
+      project: project,
+      expectedResponses: [
+        "4️⃣": .renderNode(kind: .symbol, path: "MyLibrary/foo(_:)", containing: "The String version of foo(_:)")
+      ]
+    )
+  }
+
+  func testMarkdownExtensionForFunctionDisambiguatedByParameterType() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyLibrary/Foo.swift": """
+        /// 1️⃣The Int version of foo(_:)
+        public func foo(_ x: Int) -> Int {
+          x + 1
+        }
+
+        /// 2️⃣The String version of foo(_:)
+        public func foo(_ x: String) -> String {
+          x + "1"
+        }
+        """,
+        "MyLibrary/MyLibrary.docc/Foo-Int.md": """
+        3️⃣# ``MyLibrary/foo(_:)-(Int)``
+
+        # Additional information for the foo(_:)-(Int) function
+
+        This will be appended to the end of foo(_:)-(Int)'s documentation page
+        """,
+        "MyLibrary/MyLibrary.docc/Foo-String.md": """
+        4️⃣# ``MyLibrary/foo(_:)-(String)``
+
+        # Additional information for the foo(_:)-(String) function
+
+        This will be appended to the end of foo(_:)-(String)'s documentation page
+        """,
+      ],
+      enableBackgroundIndexing: true
+    )
+    try await renderDocumentation(
+      fileName: "Foo.swift",
+      project: project,
+      expectedResponses: [
+        "1️⃣": .renderNode(
+          kind: .symbol,
+          path: "MyLibrary/foo(_:)",
+          containing: "Additional information for the foo(_:)-(Int) function"
+        ),
+        "2️⃣": .renderNode(
+          kind: .symbol,
+          path: "MyLibrary/foo(_:)",
+          containing: "Additional information for the foo(_:)-(String) function"
+        ),
+      ]
+    )
+    try await renderDocumentation(
+      fileName: "Foo-Int.md",
+      project: project,
+      expectedResponses: [
+        "3️⃣": .renderNode(kind: .symbol, path: "MyLibrary/foo(_:)", containing: "The Int version of foo(_:)")
+      ]
+    )
+    try await renderDocumentation(
+      fileName: "Foo-String.md",
+      project: project,
+      expectedResponses: [
+        "4️⃣": .renderNode(kind: .symbol, path: "MyLibrary/foo(_:)", containing: "The String version of foo(_:)")
       ]
     )
   }


### PR DESCRIPTION
Adds support for parameter and return type disambiguations to `textDocument/doccDocumentation` requests. See [the docc documentation for more info](https://www.swift.org/documentation/docc/linking-to-symbols-and-other-content#Ambiguous-Symbol-Links).

The information for parameter and return types of functions does not exist in the index. So, we have to fetch the symbol graph from sourcekitd in order to get all of the info we need. This adds some overhead, but not enough to cause any significant performance impacts in my testing.