### PR TITLE
[6.2] Fix algorithmic bug causing exponential blowup in dependency analysis

### DIFF
--- a/Sources/BuildSystemIntegration/BuildSystemManager.swift
+++ b/Sources/BuildSystemIntegration/BuildSystemManager.swift
@@ -1071,7 +1071,7 @@ package actor BuildSystemManager: QueueBasedMessageHandler {
         dependents[dependency, default: []].insert(target)
         // Check if we have already recorded this target with a greater depth, in which case visiting it again will
         // not increase its depth or any of its children.
-        if depths[target, default: 0] < depth + 1 {
+        if depths[dependency, default: 0] < depth + 1 {
           worksList.append((dependency, depth + 1))
         }
       }


### PR DESCRIPTION
(cherry picked from commit 18de71082cacd2db8e0b17d2ad5c50e5c3fd918e)

Explanation: Fixes a case of exponential time complexity in build target depth computation.
Original PRs: https://github.com/swiftlang/sourcekit-lsp/pull/2218
Risk: Extremely low - the check here just prevents unnecessary computation.
Testing: No extra tests, but this is NFC
Reviewers: @bnbarham 