### PR TITLE
Fix issue that cause semantic tokens to be out-of-sync in neovim after a document changes on disk

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -571,6 +571,7 @@ extension SwiftLanguageService {
     inFlightPublishDiagnosticsTasks[notification.textDocument.uri] = nil
     await diagnosticReportManager.removeItemsFromCache(with: notification.textDocument.uri)
     buildSettingsForOpenFiles[notification.textDocument.uri] = nil
+    await syntaxTreeManager.clearSyntaxTrees(for: notification.textDocument.uri)
     switch try? ReferenceDocumentURL(from: notification.textDocument.uri) {
     case .macroExpansion:
       break

--- a/Sources/SourceKitLSP/Swift/SyntaxTreeManager.swift
+++ b/Sources/SourceKitLSP/Swift/SyntaxTreeManager.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import LanguageServerProtocol
 import SKUtilities
 import SwiftParser
 import SwiftSyntax
@@ -93,5 +94,10 @@ actor SyntaxTreeManager {
       return Parser.parseIncrementally(source: postEditSnapshot.text, parseTransition: parseTransition)
     }
     self.setComputation(for: postEditSnapshot.id, computation: incrementalParseComputation)
+  }
+
+  /// Remove all cached syntax trees for the given document, eg. when the document is closed.
+  func clearSyntaxTrees(for uri: DocumentURI) {
+    syntaxTreeComputations.removeAll(where: { $0.uri == uri })
   }
 }


### PR DESCRIPTION
When neovim detects a change of the document on-disk (eg. caused by git operations). It closes the document and re-opens it with the same document version but different contents. We didn’t clear the swift-syntax tree of a document when it was closed, so we re-used the old syntax tree for the re-opened document. Ensure we clear the syntax tree when the document is closed so we build a new tree when it is re-opened.