### PR TITLE
Do not include trivia in the hover range

### DIFF
--- a/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
+++ b/Sources/SourceKitLSP/Swift/SwiftLanguageService.swift
@@ -786,7 +786,7 @@ extension SwiftLanguageService {
     if let snapshot = try? await latestSnapshot(for: uri) {
       let tree = await syntaxTreeManager.syntaxTree(for: snapshot)
       if let token = tree.token(at: snapshot.absolutePosition(of: position)) {
-        tokenRange = snapshot.absolutePositionRange(of: token.position..<token.endPosition)
+        tokenRange = snapshot.absolutePositionRange(of: token.trimmedRange)
       }
     }
 

--- a/Tests/SourceKitLSPTests/HoverTests.swift
+++ b/Tests/SourceKitLSPTests/HoverTests.swift
@@ -32,7 +32,7 @@ final class HoverTests: XCTestCase {
 
         Details.
         """,
-      expectedRange: Position(line: 3, utf16index: 7)..<Position(line: 3, utf16index: 9)
+      expectedRange: Position(line: 3, utf16index: 7)..<Position(line: 3, utf16index: 8)
     )
   }
 
@@ -171,6 +171,24 @@ final class HoverTests: XCTestCase {
         - Precondition: Must have an apple
         """,
       expectedRange: Position(line: 3, utf16index: 5)..<Position(line: 3, utf16index: 13)
+    )
+  }
+
+  func testTrivia() async throws {
+    try await assertHover(
+      """
+      func foo() {}
+      func bar() {
+        /*some comment*/1️⃣foo/*more comment*/()
+      }
+      """,
+      expectedContent: """
+        ```swift
+        func foo()
+        ```
+
+        """,
+      expectedRange: Position(line: 2, utf16index: 18)..<Position(line: 2, utf16index: 21)
     )
   }
 }


### PR DESCRIPTION
We only want to send the token itself, not its surrounding trivia (which would include eg. any beginning newline/whitespace).