### PR TITLE
Make `BuildSettingsLogger` an instance member of `BuildServerManager`

### DIFF
--- a/Sources/BuildServerIntegration/BuildServerManager.swift
+++ b/Sources/BuildServerIntegration/BuildServerManager.swift
@@ -341,6 +341,8 @@ package actor BuildServerManager: QueueBasedMessageHandler {
   /// Build server delegate that will receive notifications about setting changes, etc.
   private weak var delegate: BuildServerManagerDelegate?
 
+  private let buildSettingsLogger = BuildSettingsLogger()
+
   /// The list of toolchains that are available.
   ///
   /// Used to determine which toolchain to use for a given document.
@@ -1033,7 +1035,7 @@ package actor BuildServerManager: QueueBasedMessageHandler {
       settings = settings.patching(newFile: document, originalFile: mainFile)
     }
 
-    await BuildSettingsLogger.shared.log(settings: settings, for: document)
+    await buildSettingsLogger.log(settings: settings, for: document)
     return settings
   }
 

--- a/Sources/BuildServerIntegration/BuildSettingsLogger.swift
+++ b/Sources/BuildServerIntegration/BuildSettingsLogger.swift
@@ -17,8 +17,6 @@ package import SKLogging
 
 /// Shared logger that only logs build settings for a file once unless they change
 package actor BuildSettingsLogger {
-  package static let shared = BuildSettingsLogger()
-
   private var loggedSettings: [DocumentURI: FileBuildSettings] = [:]
 
   package func log(level: LogLevel = .default, settings: FileBuildSettings, for uri: DocumentURI) {


### PR DESCRIPTION
Having `BuildSettingsLogger` can be problematic if we launch multple `SourceKitLSPServer` instances in the same process (such as during testing). In that case it could happen that a previous `SourceKitLSPServer` instance logs build settings and then the second instance doesn’t log its build settings (if they are the same) because the shared logger has already logged them.

This issue is resolved by scoping `BuildSettingsLogger` to the lifetime of `BuildServerManager` (ie. one per workspace).