### PR TITLE
Only run raw identifier tests for >= 6.2

### DIFF
--- a/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
+++ b/Tests/SourceKitLSPTests/DocumentTestDiscoveryTests.swift
@@ -704,6 +704,8 @@ final class DocumentTestDiscoveryTests: XCTestCase {
   }
 
   func testSwiftTestingTestWithRawIdentifiers() async throws {
+    try await SkipUnless.haveRawIdentifiers()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -784,6 +786,8 @@ final class DocumentTestDiscoveryTests: XCTestCase {
   }
 
   func testSwiftTestingTestWithNestedRawIdentifiers() async throws {
+    try await SkipUnless.haveRawIdentifiers()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -844,6 +848,8 @@ final class DocumentTestDiscoveryTests: XCTestCase {
   }
 
   func testSwiftTestingTestWithNestedRawIdentifiersExtension() async throws {
+    try await SkipUnless.haveRawIdentifiers()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 
@@ -909,6 +915,8 @@ final class DocumentTestDiscoveryTests: XCTestCase {
   }
 
   func testSwiftTestingTestWithSlashRawIdentifiers() async throws {
+    try await SkipUnless.haveRawIdentifiers()
+
     let testClient = try await TestSourceKitLSPClient()
     let uri = DocumentURI(for: .swift)
 

--- a/Tests/SourceKitLSPTests/SemanticTokensTests.swift
+++ b/Tests/SourceKitLSPTests/SemanticTokensTests.swift
@@ -882,6 +882,8 @@ final class SemanticTokensTests: XCTestCase {
   }
 
   func testRawIdentifier() async throws {
+    try await SkipUnless.haveRawIdentifiers()
+
     try await assertSemanticTokens(
       markedContents: """
         1️⃣func 2️⃣`square returns x * x`() {}


### PR DESCRIPTION
Raw identifiers were only added in 6.2, don't check for them before then.