### PR TITLE
Ensure that we end the `Reloading package` interval if a call in `reloadPackageAssumingOnPackageLoadingQueue` throws

### DIFF
--- a/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
+++ b/Sources/BuildServerIntegration/SwiftPMBuildServer.swift
@@ -389,6 +389,7 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     )
     await testHooks.reloadPackageDidStart?()
     defer {
+      signposter.endInterval("Reloading package", state)
       Task {
         self.connectionToSourceKitLSP.send(
           TaskFinishNotification(taskId: TaskId(id: "package-reloading"), status: .ok)
@@ -456,7 +457,6 @@ package actor SwiftPMBuildServer: BuiltInBuildServer {
     signposter.emitEvent("Finished traversing modules", id: signpostID)
 
     connectionToSourceKitLSP.send(OnBuildTargetDidChangeNotification(changes: nil))
-    signposter.endInterval("Reloading package", state)
   }
 
   package nonisolated var supportsPreparationAndOutputPaths: Bool { options.backgroundIndexingOrDefault }


### PR DESCRIPTION
If a call in `reloadPackageAssumingOnPackageLoadingQueue` throws, we weren’t getting to the end of it and would thus never end the signpost started within. Move the `endInterval` call up ensure it is always ended.

Found this while investigating https://ci-external.swift.org/job/swift-PR-windows/44247/console, which failed SourceKit-LSP testing because PackageA could not be loaded due to

```
Initial package loading: invalid access to C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\build\tmp\lsp-test\924F7085\PackageA\.build\index-build\x86_64-unknown-windows-msvc\debug\MyLibrary.build\output-file-map.json
```