### PR TITLE
Allow non-SwiftPM build systems to have larger indexing batch sizes

### DIFF
--- a/Sources/BuildServerIntegration/BuildServerManager.swift
+++ b/Sources/BuildServerIntegration/BuildServerManager.swift
@@ -316,13 +316,17 @@ package actor BuildServerManager: QueueBasedMessageHandler {
   /// `nil` if the `BuildServerManager` does not have an underlying build server.
   package let configPath: URL?
 
+  /// The kind of underlying build server adapter that is being managed.
+  /// `nil` if the `BuildServerManager` does not have an underlying build server.
+  package var kind: BuildServerSpec.Kind?
+
   /// The files for which the delegate has requested change notifications, ie. the files for which the delegate wants to
   /// get `fileBuildSettingsChanged` and `filesDependenciesUpdated` callbacks.
   private var watchedFiles: [DocumentURI: (mainFile: DocumentURI, language: Language)] = [:]
 
   private var connectionToClient: BuildServerManagerConnectionToClient
 
-  /// The build serer adapter that is used to answer build server queries.
+  /// The build server adapter that is used to answer build server queries.
   private var buildServerAdapter: BuildServerAdapter?
 
   /// The build server adapter after initialization finishes. When sending messages to the BSP server, this should be
@@ -451,6 +455,7 @@ package actor BuildServerManager: QueueBasedMessageHandler {
     self.toolchainRegistry = toolchainRegistry
     self.options = options
     self.connectionToClient = connectionToClient
+    self.kind = buildServerSpec?.kind
     self.configPath = buildServerSpec?.configPath
     self.buildServerAdapter = await buildServerSpec?.createBuildServerAdapter(
       toolchainRegistry: toolchainRegistry,

--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -222,6 +222,9 @@ package final actor SemanticIndexManager {
   /// The parameter is the number of files that were scheduled to be indexed.
   private let indexTasksWereScheduled: @Sendable (_ numberOfFileScheduled: Int) -> Void
 
+  /// The number of tasks to prepare concurrently, whenever a index request is scheduled.
+  private let indexTaskBatchSize: Int
+
   /// Callback that is called when `progressStatus` might have changed.
   private let indexProgressStatusDidChange: @Sendable () -> Void
 
@@ -261,6 +264,7 @@ package final actor SemanticIndexManager {
     updateIndexStoreTimeout: Duration,
     hooks: IndexHooks,
     indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>,
+    indexTaskBatchSize: Int,
     logMessageToIndexLog:
       @escaping @Sendable (
         _ message: String, _ type: WindowMessageType, _ structure: StructuredLogKind
@@ -273,6 +277,7 @@ package final actor SemanticIndexManager {
     self.updateIndexStoreTimeout = updateIndexStoreTimeout
     self.hooks = hooks
     self.indexTaskScheduler = indexTaskScheduler
+    self.indexTaskBatchSize = indexTaskBatchSize
     self.logMessageToIndexLog = logMessageToIndexLog
     self.indexTasksWereScheduled = indexTasksWereScheduled
     self.indexProgressStatusDidChange = indexProgressStatusDidChange
@@ -877,10 +882,7 @@ package final actor SemanticIndexManager {
 
     var indexTasks: [Task<Void, Never>] = []
 
-    // TODO: When we can index multiple targets concurrently in SwiftPM, increase the batch size to half the
-    // processor count, so we can get parallelism during preparation.
-    // (https://github.com/swiftlang/sourcekit-lsp/issues/1262)
-    for targetsBatch in sortedTargets.partition(intoBatchesOfSize: 1) {
+    for targetsBatch in sortedTargets.partition(intoBatchesOfSize: indexTaskBatchSize) {
       let preparationTaskID = UUID()
       let filesToIndex = targetsBatch.flatMap({ filesByTarget[$0]! })
 

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -162,12 +162,23 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     if options.backgroundIndexingOrDefault, let uncheckedIndex,
       await buildServerManager.initializationData?.prepareProvider ?? false
     {
+      let batchSize: Int
+      switch await buildServerManager.kind {
+      case .swiftPM:
+        // TODO: When we can index multiple targets concurrently in SwiftPM, increase the batch size to half the
+        // processor count, so we can get parallelism during preparation.
+        // (https://github.com/swiftlang/sourcekit-lsp/issues/1262)
+        batchSize = 1
+      default:
+        batchSize = max(1, ProcessInfo.processInfo.activeProcessorCount / 2)
+      }
       self.semanticIndexManager = SemanticIndexManager(
         index: uncheckedIndex,
         buildServerManager: buildServerManager,
         updateIndexStoreTimeout: options.indexOrDefault.updateIndexStoreTimeoutOrDefault,
         hooks: hooks.indexHooks,
         indexTaskScheduler: indexTaskScheduler,
+        indexTaskBatchSize: batchSize,
         logMessageToIndexLog: { [weak sourceKitLSPServer] in
           sourceKitLSPServer?.logMessageToIndexLog(message: $0, type: $1, structure: $2)
         },


### PR DESCRIPTION
I noticed that sourcekit-lsp forces the batch size to be 1 for SwiftPM reasons, but nowadays there are other ways to run it. On the [Bazel BSP](https://github.com/spotify/sourcekit-bazel-bsp) for example we have no issues building tons of targets at the same time, so it seemed feasible to keep the existing limitation for SwiftPM but allow other build systems to parallelize more index tasks.