### PR TITLE
[cmake] Remove dependency on PackageModelSyntax library

### DIFF
--- a/Sources/SourceKitLSP/CMakeLists.txt
+++ b/Sources/SourceKitLSP/CMakeLists.txt
@@ -99,7 +99,6 @@ target_link_libraries(SourceKitLSP PUBLIC
   SwiftSyntax::SwiftRefactor
   SwiftSyntax::SwiftSyntax)
 target_link_libraries(SourceKitLSP PRIVATE
-  PackageModelSyntax
   TSCExtensions
   $<$<NOT:$<PLATFORM_ID:Darwin>>:FoundationXML>)
 


### PR DESCRIPTION
This is a follow-up to https://github.com/swiftlang/sourcekit-lsp/pull/2235.

The change removed uses of `PackageModelSyntax` but left is in `target_link_libraries` of `SourceKitLSP`.