### PR TITLE
Add module map for CSKTestSupport

### DIFF
--- a/Sources/CSKTestSupport/include/CSKTestSupport.h
+++ b/Sources/CSKTestSupport/include/CSKTestSupport.h
@@ -1,0 +1,10 @@
+#ifndef CSKTestSupport_h
+#define CSKTestSupport_h
+
+#ifdef __linux__
+// For testing, override __cxa_atexit to prevent registration of static
+// destructors due to https://github.com/swiftlang/swift/issues/55112.
+int __cxa_atexit(void (*f) (void *), void *arg, void *dso_handle);
+#endif
+
+#endif /* CSKTestSupport_h */

--- a/Sources/CSKTestSupport/include/module.modulemap
+++ b/Sources/CSKTestSupport/include/module.modulemap
@@ -1,0 +1,4 @@
+module CSKTestSupport {
+  header "CSKTestSupport.h"
+  export *
+}


### PR DESCRIPTION
Create a module map for the CSKTestSupport module, exporting the header "CSKTestSupport.h". This allows for better modularization and encapsulation of the support functionalities.