### PR TITLE
[cmake] Remove dependency on PackageModelSyntax library

### DIFF
--- a/Sources/SwiftLanguageService/CMakeLists.txt
+++ b/Sources/SwiftLanguageService/CMakeLists.txt
@@ -74,7 +74,6 @@ target_link_libraries(SourceKitLSP PRIVATE
   Crypto
   TSCBasic
   PackageModel
-  PackageModelSyntax
   SwiftSyntax::SwiftDiagnostics
   SwiftSyntax::SwiftIDEUtils
   SwiftSyntax::SwiftParser


### PR DESCRIPTION
This is a follow-up to https://github.com/swiftlang/sourcekit-lsp/pull/2235.

The change removed uses of `PackageModelSyntax` but left is in `target_link_libraries` of `SourceKitLSP`.