### PR TITLE
[cmake] Remove unused dependency on PackageModel library

### DIFF
--- a/Sources/SwiftLanguageService/CMakeLists.txt
+++ b/Sources/SwiftLanguageService/CMakeLists.txt
@@ -73,7 +73,6 @@ target_link_libraries(SourceKitLSP PRIVATE
   TSCExtensions
   Crypto
   TSCBasic
-  PackageModel
   SwiftSyntax::SwiftDiagnostics
   SwiftSyntax::SwiftIDEUtils
   SwiftSyntax::SwiftParser

--- a/Sources/ToolchainRegistry/CMakeLists.txt
+++ b/Sources/ToolchainRegistry/CMakeLists.txt
@@ -9,7 +9,6 @@ target_link_libraries(ToolchainRegistry PUBLIC
 LanguageServerProtocolExtensions
   SKLogging
   SwiftExtensions
-  PackageModel
   TSCBasic)
 
 target_link_libraries(ToolchainRegistry PRIVATE


### PR DESCRIPTION
Neither `ToolchainRegistry` nor `SwiftLanguageService` are using this dependency.