### PR TITLE
Allow multiple language services to handle a single document

### DIFF
--- a/Sources/DocumentationLanguageService/DoccDocumentationHandler.swift
+++ b/Sources/DocumentationLanguageService/DoccDocumentationHandler.swift
@@ -63,15 +63,14 @@ extension DocumentationLanguageService {
           let symbolOccurrence = try await index.primaryDefinitionOrDeclarationOccurrence(
             ofDocCSymbolLink: symbolLink,
             fetchSymbolGraph: { location in
-              guard let symbolWorkspace = try await workspaceForDocument(uri: location.documentUri),
-                let languageService = await sourceKitLSPServer.languageService(
-                  for: location.documentUri,
-                  .swift,
-                  in: symbolWorkspace
-                )
-              else {
+              guard let symbolWorkspace = try await workspaceForDocument(uri: location.documentUri) else {
                 throw ResponseError.internalError("Unable to find language service for \(location.documentUri)")
               }
+              let languageService = try await sourceKitLSPServer.primaryLanguageService(
+                for: location.documentUri,
+                .swift,
+                in: symbolWorkspace
+              )
               return try await languageService.symbolGraph(forOnDiskContentsOf: location.documentUri, at: location)
             }
           )
@@ -79,16 +78,14 @@ extension DocumentationLanguageService {
           throw ResponseError.requestFailed(doccDocumentationError: .symbolNotFound(symbolName))
         }
         let symbolDocumentUri = symbolOccurrence.location.documentUri
-        guard
-          let symbolWorkspace = try await workspaceForDocument(uri: symbolDocumentUri),
-          let languageService = await sourceKitLSPServer.languageService(
-            for: symbolDocumentUri,
-            .swift,
-            in: symbolWorkspace
-          )
-        else {
+        guard let symbolWorkspace = try await workspaceForDocument(uri: symbolDocumentUri) else {
           throw ResponseError.internalError("Unable to find language service for \(symbolDocumentUri)")
         }
+        let languageService = try await sourceKitLSPServer.primaryLanguageService(
+          for: symbolDocumentUri,
+          .swift,
+          in: symbolWorkspace
+        )
         let symbolGraph = try await languageService.symbolGraph(
           forOnDiskContentsOf: symbolDocumentUri,
           at: symbolOccurrence.location

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -51,17 +51,6 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     return await sourceKitLSPServer.workspaceForDocument(uri: uri)
   }
 
-  func languageService(
-    for uri: DocumentURI,
-    _ language: LanguageServerProtocol.Language,
-    in workspace: Workspace
-  ) async throws -> LanguageService? {
-    guard let sourceKitLSPServer else {
-      throw ResponseError.unknown("Connection to the editor closed")
-    }
-    return await sourceKitLSPServer.languageService(for: uri, language, in: workspace)
-  }
-
   package nonisolated func canHandle(workspace: Workspace, toolchain: Toolchain) -> Bool {
     return true
   }

--- a/Sources/LanguageServerProtocol/Error.swift
+++ b/Sources/LanguageServerProtocol/Error.swift
@@ -85,6 +85,8 @@ public struct ErrorCode: RawRepresentable, Codable, Hashable, Sendable {
   public static let workspaceNotOpen: ErrorCode = ErrorCode(rawValue: -32003)
 
   /// The method is not implemented in this `LanguageService`.
+  ///
+  /// This informs `SourceKitLSPServer` that it should query secondary language services for the results.
   public static let requestNotImplemented: ErrorCode = ErrorCode(rawValue: -32004)
 }
 

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -274,16 +274,6 @@ package actor SourceKitLSPServer {
     }.valuePropagatingCancellation
   }
 
-  private func documentService(for uri: DocumentURI) async throws -> LanguageService {
-    guard let workspace = await self.workspaceForDocument(uri: uri) else {
-      throw ResponseError.workspaceNotOpen(uri)
-    }
-    guard let languageService = workspace.documentService(for: uri) else {
-      throw ResponseError.unknown("No language service for '\(uri)' found")
-    }
-    return languageService
-  }
-
   /// This method must be executed on `workspaceQueue` to ensure that the file handling capabilities of the
   /// workspaces don't change during the computation. Otherwise, we could run into a race condition like the following:
   ///  1. We don't have an entry for file `a.swift` in `workspaceForUri` and start the computation
@@ -385,11 +375,9 @@ package actor SourceKitLSPServer {
 
     // This should be created as soon as we receive an open call, even if the document
     // isn't yet ready.
-    guard let languageService = workspace.documentService(for: doc) else {
-      return
+    for languageService in workspace.languageServices(for: doc) {
+      await notificationHandler(notification, languageService)
     }
-
-    await notificationHandler(notification, languageService)
   }
 
   private func handleRequest<RequestType: TextDocumentRequest>(
@@ -406,10 +394,19 @@ package actor SourceKitLSPServer {
       guard let workspace = await self.workspaceForDocument(uri: request.textDocument.uri) else {
         throw ResponseError.workspaceNotOpen(request.textDocument.uri)
       }
-      guard let languageService = workspace.documentService(for: doc) else {
+      let languageServices = workspace.languageServices(for: doc)
+      if languageServices.isEmpty {
         throw ResponseError.unknown("No language service for '\(request.textDocument.uri)' found")
       }
-      return try await requestHandler(request, workspace, languageService)
+      // Return the results from the first language service that doesn't throw a `requestNotImplemented` error.
+      for languageService in languageServices {
+        do {
+          return try await requestHandler(request, workspace, languageService)
+        } catch let error as ResponseError where error.code == .requestNotImplemented {
+          continue
+        }
+      }
+      throw ResponseError.unknown("No language service implements request")
     }
   }
 
@@ -429,7 +426,7 @@ package actor SourceKitLSPServer {
       guard let workspace = await self.workspaceForDocument(uri: documentUri) else {
         continue
       }
-      guard workspace.documentService(for: documentUri) === languageService else {
+      guard workspace.languageServices(for: documentUri).contains(where: { $0 === languageService }) else {
         continue
       }
       guard let snapshot = try? self.documentManager.latestSnapshot(documentUri) else {
@@ -437,7 +434,10 @@ package actor SourceKitLSPServer {
         continue
       }
 
-      // Close the document properly in the document manager and build server manager to start with a clean sheet when re-opening it.
+      // Close the document properly in the document manager and build server manager to start with a clean sheet when
+      // re-opening it.
+      // This closes and re-opens the document in all of its language services, not just the crashed language service
+      // but since crashing language services should be rare, this is acceptable.
       let closeNotification = DidCloseTextDocumentNotification(textDocument: TextDocumentIdentifier(documentUri))
       await self.closeDocument(closeNotification, workspace: workspace)
 
@@ -466,94 +466,104 @@ package actor SourceKitLSPServer {
     return nil
   }
 
-  func languageService(
+  /// Get the language services that can handle the given languages in the given workspace using the given toolchain.
+  ///
+  /// If we have language services that can handle this combination but that haven't been started yet, start them.
+  func languageServices(
     for toolchain: Toolchain,
     _ language: Language,
     in workspace: Workspace
-  ) async -> LanguageService? {
-    guard let serverType = languageServiceRegistry.languageService(for: language) else {
-      logger.error("Unable to infer language server type for language '\(language)'")
-      return nil
-    }
-    // Pick the first language service that can handle this workspace.
-    if let languageService = existingLanguageService(serverType, toolchain: toolchain, workspace: workspace) {
-      return languageService
-    }
-
-    // Start a new service.
-    return await orLog("failed to start language service", level: .error) { [options = workspace.options, hooks] in
-      let service = try await serverType.init(
-        sourceKitLSPServer: self,
-        toolchain: toolchain,
-        options: options,
-        hooks: hooks,
-        workspace: workspace
-      )
-
-      guard let service else {
-        return nil
+  ) async -> [LanguageService] {
+    let result = await languageServiceRegistry.languageServices(for: language).asyncCompactMap {
+      (serverType) -> LanguageService? in
+      // Pick the first language service that can handle this workspace.
+      if let languageService = existingLanguageService(serverType, toolchain: toolchain, workspace: workspace) {
+        return languageService
       }
 
-      let pid = Int(ProcessInfo.processInfo.processIdentifier)
-      let resp = try await service.initialize(
-        InitializeRequest(
-          processId: pid,
-          rootPath: nil,
-          rootURI: workspace.rootUri,
-          initializationOptions: nil,
-          capabilities: workspace.capabilityRegistry.clientCapabilities,
-          trace: .off,
-          workspaceFolders: nil
+      // Start a new service.
+      return await orLog("failed to start language service", level: .error) { [options = workspace.options, hooks] in
+        let service = try await serverType.init(
+          sourceKitLSPServer: self,
+          toolchain: toolchain,
+          options: options,
+          hooks: hooks,
+          workspace: workspace
         )
-      )
-      let languages = languageClass(for: language)
-      await self.registerCapabilities(
-        for: resp.capabilities,
-        languages: languages,
-        registry: workspace.capabilityRegistry
-      )
 
-      var syncKind: TextDocumentSyncKind
-      switch resp.capabilities.textDocumentSync {
-      case .options(let options):
-        syncKind = options.change ?? .incremental
-      case .kind(let kind):
-        syncKind = kind
-      default:
-        syncKind = .incremental
+        guard let service else {
+          return nil
+        }
+
+        let pid = Int(ProcessInfo.processInfo.processIdentifier)
+        let resp = try await service.initialize(
+          InitializeRequest(
+            processId: pid,
+            rootPath: nil,
+            rootURI: workspace.rootUri,
+            initializationOptions: nil,
+            capabilities: workspace.capabilityRegistry.clientCapabilities,
+            trace: .off,
+            workspaceFolders: nil
+          )
+        )
+        let languages = languageClass(for: language)
+        await self.registerCapabilities(
+          for: resp.capabilities,
+          languages: languages,
+          registry: workspace.capabilityRegistry
+        )
+
+        var syncKind: TextDocumentSyncKind
+        switch resp.capabilities.textDocumentSync {
+        case .options(let options):
+          syncKind = options.change ?? .incremental
+        case .kind(let kind):
+          syncKind = kind
+        default:
+          syncKind = .incremental
+        }
+        guard syncKind == .incremental else {
+          throw ResponseError.internalError("non-incremental update not implemented")
+        }
+
+        await service.clientInitialized(InitializedNotification())
+
+        if let concurrentlyInitializedService = existingLanguageService(
+          serverType,
+          toolchain: toolchain,
+          workspace: workspace
+        ) {
+          // Since we 'await' above, another call to languageService might have
+          // happened concurrently, passed the `existingLanguageService` check at
+          // the top and started initializing another language service.
+          // If this race happened, just shut down our server and return the
+          // other one.
+          await service.shutdown()
+          return concurrentlyInitializedService
+        }
+
+        languageServices[LanguageServiceType(serverType), default: []].append(service)
+        return service
       }
-      guard syncKind == .incremental else {
-        throw ResponseError.internalError("non-incremental update not implemented")
-      }
-
-      await service.clientInitialized(InitializedNotification())
-
-      if let concurrentlyInitializedService = existingLanguageService(
-        serverType,
-        toolchain: toolchain,
-        workspace: workspace
-      ) {
-        // Since we 'await' above, another call to languageService might have
-        // happened concurrently, passed the `existingLanguageService` check at
-        // the top and started initializing another language service.
-        // If this race happened, just shut down our server and return the
-        // other one.
-        await service.shutdown()
-        return concurrentlyInitializedService
-      }
-
-      languageServices[LanguageServiceType(serverType), default: []].append(service)
-      return service
     }
+    if result.isEmpty {
+      logger.error("Unable to infer language server type for language '\(language)'")
+    }
+    return result
   }
 
-  package func languageService(
+  /// Get the language services that can handle the given document.
+  ///
+  /// If we have language services that can handle this document but that haven't been started yet, start them.
+  package func languageServices(
     for uri: DocumentURI,
     _ language: Language,
     in workspace: Workspace
-  ) async -> LanguageService? {
-    if let service = workspace.documentService(for: uri) {
-      return service
+  ) async -> [LanguageService] {
+    let existingLanguageServices = workspace.languageServices(for: uri)
+    if !existingLanguageServices.isEmpty {
+      return existingLanguageServices
     }
 
     let toolchain = await workspace.buildServerManager.toolchain(
@@ -563,11 +573,12 @@ package actor SourceKitLSPServer {
     )
     guard let toolchain else {
       logger.error("Failed to determine toolchain for \(uri)")
-      return nil
+      return []
     }
-    guard let service = await languageService(for: toolchain, language, in: workspace) else {
-      logger.error("Failed to create language service for \(uri)")
-      return nil
+    let languageServices = await self.languageServices(for: toolchain, language, in: workspace)
+
+    if languageServices.isEmpty {
+      logger.error("No language service found to handle \(uri.forLogging)")
     }
 
     logger.log(
@@ -577,7 +588,23 @@ package actor SourceKitLSPServer {
       """
     )
 
-    return workspace.setDocumentService(for: uri, service)
+    return workspace.setLanguageServices(for: uri, languageServices)
+  }
+
+  /// The language service with the highest precedence that can handle the given document.
+  ///
+  /// If we have language services that can handle this document but that haven't been started yet, start them.
+  ///
+  /// If no language service exists for this document, throw an error.
+  package func primaryLanguageService(
+    for uri: DocumentURI,
+    _ language: Language,
+    in workspace: Workspace
+  ) async throws -> LanguageService {
+    guard let languageService = await languageServices(for: uri, language, in: workspace).first else {
+      throw ResponseError.unknown("No language service found for \(uri)")
+    }
+    return languageService
   }
 }
 
@@ -1302,15 +1329,19 @@ extension SourceKitLSPServer {
     let uri = textDocument.uri
     let language = textDocument.language
 
-    // If we can't create a service, this document is unsupported and we can bail here.
-    guard let service = await languageService(for: uri, language, in: workspace) else {
+    let languageServices = await languageServices(for: uri, language, in: workspace)
+
+    if languageServices.isEmpty {
+      // If we can't create a service, this document is unsupported and we can bail here.
       return
     }
 
     await workspace.buildServerManager.registerForChangeNotifications(for: uri, language: language)
 
     // If the document is ready, we can immediately send the notification.
-    await service.openDocument(notification, snapshot: snapshot)
+    for languageService in languageServices {
+      await languageService.openDocument(notification, snapshot: snapshot)
+    }
   }
 
   func closeDocument(_ notification: DidCloseTextDocumentNotification) async {
@@ -1332,7 +1363,10 @@ extension SourceKitLSPServer {
       )
       return
     }
-    await workspace.documentService(for: uri)?.reopenDocument(notification)
+
+    for languageService in workspace.languageServices(for: uri) {
+      await languageService.reopenDocument(notification)
+    }
   }
 
   func closeDocument(_ notification: DidCloseTextDocumentNotification, workspace: Workspace) async {
@@ -1346,7 +1380,9 @@ extension SourceKitLSPServer {
 
     await workspace.buildServerManager.unregisterForChangeNotifications(for: uri)
 
-    await workspace.documentService(for: uri)?.closeDocument(notification)
+    for languageService in workspace.languageServices(for: uri) {
+      await languageService.closeDocument(notification)
+    }
 
     workspaceQueue.async {
       self.workspaceForUri[notification.textDocument.uri] = nil
@@ -1376,12 +1412,14 @@ extension SourceKitLSPServer {
       // Already logged failure
       return
     }
-    await workspace.documentService(for: uri)?.changeDocument(
-      notification,
-      preEditSnapshot: preEditSnapshot,
-      postEditSnapshot: postEditSnapshot,
-      edits: edits
-    )
+    for languageService in workspace.languageServices(for: uri) {
+      await languageService.changeDocument(
+        notification,
+        preEditSnapshot: preEditSnapshot,
+        postEditSnapshot: postEditSnapshot,
+        edits: edits
+      )
+    }
   }
 
   /// If the client doesn't support the `window/didChangeActiveDocument` notification, when the client interacts with a
@@ -1568,7 +1606,11 @@ extension SourceKitLSPServer {
     else {
       return request.item
     }
-    return try await documentService(for: uri).completionItemResolve(request)
+    guard let workspace = await self.workspaceForDocument(uri: uri) else {
+      throw ResponseError.workspaceNotOpen(uri)
+    }
+    let language = try documentManager.latestSnapshot(uri.buildSettingsFile).language
+    return try await primaryLanguageService(for: uri, language, in: workspace).completionItemResolve(request)
   }
 
   func doccDocumentation(
@@ -1767,21 +1809,44 @@ extension SourceKitLSPServer {
       command: req.command,
       arguments: req.argumentsWithoutSourceKitMetadata
     )
-    return try await documentService(for: uri).executeCommand(executeCommand)
+    guard let workspace = await self.workspaceForDocument(uri: uri) else {
+      throw ResponseError.workspaceNotOpen(uri)
+    }
+    let language = try documentManager.latestSnapshot(uri.buildSettingsFile).language
+    // First, check if we have a language service that explicitly declares support for this command.
+    if let languageService = await languageServices(for: uri, language, in: workspace)
+      .first(where: { type(of: $0).builtInCommands.contains(req.command) })
+    {
+      return try await languageService.executeCommand(executeCommand)
+    }
+    // Otherwise handle it in the primary language service. This is important to handle eg. commands in clangd, which
+    // are not declared as built-in commands.
+    return try await primaryLanguageService(for: uri, language, in: workspace).executeCommand(executeCommand)
   }
 
   func getReferenceDocument(_ req: GetReferenceDocumentRequest) async throws -> GetReferenceDocumentResponse {
     let buildSettingsUri = try ReferenceDocumentURL(from: req.uri).buildSettingsFile
 
-    guard let workspace = await workspaceForDocument(uri: buildSettingsUri) else {
+    guard let workspace = await self.workspaceForDocument(uri: buildSettingsUri) else {
       throw ResponseError.workspaceNotOpen(buildSettingsUri)
     }
+    let language: Language
 
-    guard let languageService = workspace.documentService(for: buildSettingsUri) else {
-      throw ResponseError.unknown("No Language Service for URI: \(buildSettingsUri)")
+    // The document that provided the build settings might no longer be open, so we need to be able to infer the
+    // language by other means as well.
+    if let snapshot = try? documentManager.latestSnapshot(buildSettingsUri) {
+      language = snapshot.language
+    } else if let target = await workspace.buildServerManager.canonicalTarget(for: buildSettingsUri),
+      let lang = await workspace.buildServerManager.defaultLanguage(for: buildSettingsUri, in: target)
+    {
+      language = lang
+    } else if let lang = Language(inferredFromFileExtension: buildSettingsUri) {
+      language = lang
+    } else {
+      throw ResponseError.unknown("Unable to infer language for \(buildSettingsUri)")
     }
 
-    return try await languageService.getReferenceDocument(req)
+    return try await primaryLanguageService(for: buildSettingsUri, language, in: workspace).getReferenceDocument(req)
   }
 
   func codeAction(

--- a/Sources/SourceKitLSP/SyntacticTestIndex.swift
+++ b/Sources/SourceKitLSP/SyntacticTestIndex.swift
@@ -239,13 +239,13 @@ actor SyntacticTestIndex {
     if Task.isCancelled {
       return
     }
-    guard let language = Language(inferredFromFileExtension: uri),
-      let languageServiceType = languageServiceRegistry.languageService(for: language)
-    else {
+    guard let language = Language(inferredFromFileExtension: uri) else {
       logger.log("Not indexing \(uri.forLogging) because the language service could not be inferred")
       return
     }
-    let testItems = await languageServiceType.syntacticTestItems(in: uri)
+    let testItems = await languageServiceRegistry.languageServices(for: language).asyncFlatMap {
+      await $0.syntacticTestItems(in: uri)
+    }
 
     guard !removedFiles.contains(uri) else {
       // Check whether the file got removed while we were scanning it for tests. If so, don't add it back to

--- a/Tests/SourceKitLSPTests/ClangdTests.swift
+++ b/Tests/SourceKitLSPTests/ClangdTests.swift
@@ -158,8 +158,10 @@ final class ClangdTests: XCTestCase {
     )
 
     // Monitor clangd to notice when it gets restarted
-    let clangdServer = try await unwrap(
-      testClient.server.languageService(for: uri, .c, in: unwrap(testClient.server.workspaceForDocument(uri: uri)))
+    let clangdServer = try await testClient.server.primaryLanguageService(
+      for: uri,
+      .c,
+      in: unwrap(testClient.server.workspaceForDocument(uri: uri))
     )
     await clangdServer.addStateChangeHandler { oldState, newState in
       if oldState == .connectionInterrupted, newState == .connected {

--- a/Tests/SourceKitLSPTests/CrashRecoveryTests.swift
+++ b/Tests/SourceKitLSPTests/CrashRecoveryTests.swift
@@ -81,11 +81,13 @@ final class CrashRecoveryTests: XCTestCase {
     // Crash sourcekitd
 
     let swiftLanguageService =
-      await testClient.server.languageService(
-        for: uri,
-        .swift,
-        in: testClient.server.workspaceForDocument(uri: uri)!
-      ) as! SwiftLanguageService
+      try unwrap(
+        await testClient.server.primaryLanguageService(
+          for: uri,
+          .swift,
+          in: testClient.server.workspaceForDocument(uri: uri)!
+        ) as? SwiftLanguageService
+      )
 
     await swiftLanguageService.crash()
 
@@ -119,11 +121,11 @@ final class CrashRecoveryTests: XCTestCase {
   }
 
   private func crashClangd(for testClient: TestSourceKitLSPClient, document docUri: DocumentURI) async throws {
-    let clangdServer = await testClient.server.languageService(
+    let clangdServer = try await testClient.server.primaryLanguageService(
       for: docUri,
       .cpp,
       in: testClient.server.workspaceForDocument(uri: docUri)!
-    )!
+    )
 
     let clangdCrashed = self.expectation(description: "clangd crashed")
     let clangdRestarted = self.expectation(description: "clangd restarted")
@@ -266,11 +268,11 @@ final class CrashRecoveryTests: XCTestCase {
 
     // Keep track of clangd crashes
 
-    let clangdServer = await testClient.server.languageService(
+    let clangdServer = try await testClient.server.primaryLanguageService(
       for: uri,
       .cpp,
       in: testClient.server.workspaceForDocument(uri: uri)!
-    )!
+    )
 
     let clangdCrashed = self.expectation(description: "clangd crashed")
     clangdCrashed.assertForOverFulfill = false
@@ -333,11 +335,13 @@ final class CrashRecoveryTests: XCTestCase {
     )
 
     let swiftLanguageService =
-      await testClient.server.languageService(
-        for: uri,
-        .swift,
-        in: testClient.server.workspaceForDocument(uri: uri)!
-      ) as! SwiftLanguageService
+      try unwrap(
+        await testClient.server.primaryLanguageService(
+          for: uri,
+          .swift,
+          in: testClient.server.workspaceForDocument(uri: uri)!
+        ) as? SwiftLanguageService
+      )
 
     await swiftLanguageService.crash()
 
@@ -371,8 +375,11 @@ final class CrashRecoveryTests: XCTestCase {
 
     // Monitor sourcekitd to notice when it gets terminated
     let swiftService = try await unwrap(
-      testClient.server.languageService(for: uri, .swift, in: unwrap(testClient.server.workspaceForDocument(uri: uri)))
-        as? SwiftLanguageService
+      testClient.server.primaryLanguageService(
+        for: uri,
+        .swift,
+        in: unwrap(testClient.server.workspaceForDocument(uri: uri))
+      ) as? SwiftLanguageService
     )
     await swiftService.addStateChangeHandler { oldState, newState in
       logger.debug("sourcekitd changed state: \(String(describing: oldState)) -> \(String(describing: newState))")

--- a/Tests/SourceKitLSPTests/LocalClangTests.swift
+++ b/Tests/SourceKitLSPTests/LocalClangTests.swift
@@ -340,11 +340,11 @@ final class LocalClangTests: XCTestCase {
     struct MyObject * newObject();
     """.writeWithRetry(to: XCTUnwrap(headerUri.fileURL))
 
-    let clangdServer = await project.testClient.server.languageService(
+    let clangdServer = try await project.testClient.server.primaryLanguageService(
       for: mainUri,
       .c,
       in: project.testClient.server.workspaceForDocument(uri: mainUri)!
-    )!
+    )
 
     await clangdServer.documentDependenciesUpdated([mainUri])
 

--- a/Tests/SourceKitLSPTests/LocalSwiftTests.swift
+++ b/Tests/SourceKitLSPTests/LocalSwiftTests.swift
@@ -1359,8 +1359,13 @@ final class LocalSwiftTests: XCTestCase {
     let reusedNodeCallback = self.expectation(description: "reused node callback called")
     let reusedNodes = ThreadSafeBox<[Syntax]>(initialValue: [])
     let swiftLanguageService =
-      await testClient.server.languageService(for: uri, .swift, in: testClient.server.workspaceForDocument(uri: uri)!)
-      as! SwiftLanguageService
+      try await unwrap(
+        testClient.server.primaryLanguageService(
+          for: uri,
+          .swift,
+          in: unwrap(testClient.server.workspaceForDocument(uri: uri))
+        ) as? SwiftLanguageService
+      )
     await swiftLanguageService.setReusedNodeCallback {
       reusedNodes.value.append($0)
       reusedNodeCallback.fulfill()


### PR DESCRIPTION
This allows us to implement all of `doccDocumentation` in `DocumentationLanguageService`. `DocumentationLanguageService` will be a secondary language service for Swift files and can also provide the docc documentation support that’s currently in `SwiftLangaugeService`.