### PR TITLE
Make `LanguageService` initializer non-failable

### DIFF
--- a/Sources/ClangLanguageService/ClangLanguageService.swift
+++ b/Sources/ClangLanguageService/ClangLanguageService.swift
@@ -109,7 +109,7 @@ package actor ClangLanguageService: LanguageService, MessageHandler {
 
   /// Creates a language server for the given client referencing the clang binary specified in `toolchain`.
   /// Returns `nil` if `clangd` can't be found.
-  package init?(
+  package init(
     sourceKitLSPServer: SourceKitLSPServer,
     toolchain: Toolchain,
     options: SourceKitLSPOptions,
@@ -117,7 +117,9 @@ package actor ClangLanguageService: LanguageService, MessageHandler {
     workspace: Workspace
   ) async throws {
     guard let clangdPath = toolchain.clangd else {
-      return nil
+      throw ResponseError.unknown(
+        "Cannot create SwiftLanguage service because \(toolchain.identifier) does not contain clangd"
+      )
     }
     self.clangPath = toolchain.clang
     self.clangdPath = clangdPath

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -34,7 +34,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
 
   package static var builtInCommands: [String] { [] }
 
-  package init?(
+  package init(
     sourceKitLSPServer: SourceKitLSPServer,
     toolchain: Toolchain,
     options: SourceKitLSPOptions,

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -104,7 +104,7 @@ package protocol LanguageService: AnyObject, Sendable {
 
   // MARK: - Creation
 
-  init?(
+  init(
     sourceKitLSPServer: SourceKitLSPServer,
     toolchain: Toolchain,
     options: SourceKitLSPOptions,

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -492,10 +492,6 @@ package actor SourceKitLSPServer {
           workspace: workspace
         )
 
-        guard let service else {
-          return nil
-        }
-
         let pid = Int(ProcessInfo.processInfo.processIdentifier)
         let resp = try await service.initialize(
           InitializeRequest(

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -197,14 +197,18 @@ package actor SwiftLanguageService: LanguageService, Sendable {
   /// `reopenDocuments` is a closure that will be called if sourcekitd crashes and the `SwiftLanguageService` asks its
   /// parent server to reopen all of its documents.
   /// Returns `nil` if `sourcekitd` couldn't be found.
-  package init?(
+  package init(
     sourceKitLSPServer: SourceKitLSPServer,
     toolchain: Toolchain,
     options: SourceKitLSPOptions,
     hooks: Hooks,
     workspace: Workspace
   ) async throws {
-    guard let sourcekitd = toolchain.sourcekitd else { return nil }
+    guard let sourcekitd = toolchain.sourcekitd else {
+      throw ResponseError.unknown(
+        "Cannot create SwiftLanguage service because \(toolchain.identifier) does not contain sourcekitd"
+      )
+    }
     self.sourcekitdPath = sourcekitd
     self.sourceKitLSPServer = sourceKitLSPServer
     self.swiftFormat = toolchain.swiftFormat


### PR DESCRIPTION
There’s no reason why we need to allow returning `nil` here, we can just throw an error in the cases where the language service can’t be created.