### PR TITLE
Add signature help LSP request support

### DIFF
--- a/Sources/ClangLanguageService/ClangLanguageService.swift
+++ b/Sources/ClangLanguageService/ClangLanguageService.swift
@@ -491,6 +491,10 @@ extension ClangLanguageService {
     return try await forwardRequestToClangd(req)
   }
 
+  package func signatureHelp(_ req: SignatureHelpRequest) async throws -> SignatureHelp? {
+    return try await forwardRequestToClangd(req)
+  }
+
   package func hover(_ req: HoverRequest) async throws -> HoverResponse? {
     return try await forwardRequestToClangd(req)
   }

--- a/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/RegistrationOptions.swift
@@ -90,6 +90,46 @@ public struct CompletionRegistrationOptions: RegistrationOptions, TextDocumentRe
   }
 }
 
+/// Signature help registration options.
+public struct SignatureHelpRegistrationOptions: RegistrationOptions, TextDocumentRegistrationOptionsProtocol, Hashable {
+  public var textDocumentRegistrationOptions: TextDocumentRegistrationOptions
+  public var signatureHelpOptions: SignatureHelpOptions
+
+  public init(documentSelector: DocumentSelector? = nil, signatureHelpOptions: SignatureHelpOptions) {
+    self.textDocumentRegistrationOptions =
+      TextDocumentRegistrationOptions(documentSelector: documentSelector)
+    self.signatureHelpOptions = signatureHelpOptions
+  }
+
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
+    guard let signatureHelpOptions = SignatureHelpOptions(fromLSPDictionary: dictionary) else {
+      return nil
+    }
+
+    self.signatureHelpOptions = signatureHelpOptions
+
+    guard let textDocumentRegistrationOptions = TextDocumentRegistrationOptions(fromLSPDictionary: dictionary) else {
+      return nil
+    }
+
+    self.textDocumentRegistrationOptions = textDocumentRegistrationOptions
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    var dict: [String: LSPAny] = [:]
+
+    if case .dictionary(let dictionary) = signatureHelpOptions.encodeToLSPAny() {
+      dict.merge(dictionary) { (current, _) in current }
+    }
+
+    if case .dictionary(let dictionary) = textDocumentRegistrationOptions.encodeToLSPAny() {
+      dict.merge(dictionary) { (current, _) in current }
+    }
+
+    return .dictionary(dict)
+  }
+}
+
 /// Folding range registration options.
 public struct FoldingRangeRegistrationOptions: RegistrationOptions, TextDocumentRegistrationOptionsProtocol, Hashable {
   public var textDocumentRegistrationOptions: TextDocumentRegistrationOptions

--- a/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
+++ b/Sources/LanguageServerProtocol/SupportTypes/ServerCapabilities.swift
@@ -612,6 +612,38 @@ public struct SignatureHelpOptions: WorkDoneProgressOptions, Codable, Hashable, 
     self.triggerCharacters = triggerCharacters
     self.retriggerCharacters = retriggerCharacters
   }
+
+  public init?(fromLSPDictionary dictionary: [String: LSPAny]) {
+    if let arrayAny = dictionary["triggerCharacters"] {
+      triggerCharacters = [String](fromLSPArray: arrayAny)
+    }
+
+    if let arrayAny = dictionary["retriggerCharacters"] {
+      retriggerCharacters = [String](fromLSPArray: arrayAny)
+    }
+
+    if case .bool(let value) = dictionary["workDoneProgress"] {
+      workDoneProgress = value
+    }
+  }
+
+  public func encodeToLSPAny() -> LSPAny {
+    var dict: [String: LSPAny] = [:]
+
+    if let triggerCharacters {
+      dict["triggerCharacters"] = triggerCharacters.encodeToLSPAny()
+    }
+
+    if let retriggerCharacters {
+      dict["retriggerCharacters"] = retriggerCharacters.encodeToLSPAny()
+    }
+
+    if let workDoneProgress {
+      dict["workDoneProgress"] = .bool(workDoneProgress)
+    }
+
+    return .dictionary(dict)
+  }
 }
 
 public struct DocumentFilter: Codable, Hashable, Sendable {

--- a/Sources/SourceKitD/sourcekitd_uids.swift
+++ b/Sources/SourceKitD/sourcekitd_uids.swift
@@ -103,6 +103,14 @@ package struct sourcekitd_api_keys {
   package let fullyAnnotatedDecl: sourcekitd_api_uid_t
   /// `key.fully_annotated_generic_signature`
   package let fullyAnnotatedGenericSignature: sourcekitd_api_uid_t
+  /// `key.signatures`
+  package let signatures: sourcekitd_api_uid_t
+  /// `key.active_signature`
+  package let activeSignature: sourcekitd_api_uid_t
+  /// `key.parameters`
+  package let parameters: sourcekitd_api_uid_t
+  /// `key.active_parameter`
+  package let activeParameter: sourcekitd_api_uid_t
   /// `key.doc.brief`
   package let docBrief: sourcekitd_api_uid_t
   /// `key.context`
@@ -411,6 +419,8 @@ package struct sourcekitd_api_keys {
   package let indexUnitOutputPath: sourcekitd_api_uid_t
   /// `key.include_locals`
   package let includeLocals: sourcekitd_api_uid_t
+  /// `key.compress`
+  package let compress: sourcekitd_api_uid_t
   /// `key.ignore_clang_modules`
   package let ignoreClangModules: sourcekitd_api_uid_t
   /// `key.include_system_modules`
@@ -566,6 +576,10 @@ package struct sourcekitd_api_keys {
     annotatedDecl = api.uid_get_from_cstr("key.annotated_decl")!
     fullyAnnotatedDecl = api.uid_get_from_cstr("key.fully_annotated_decl")!
     fullyAnnotatedGenericSignature = api.uid_get_from_cstr("key.fully_annotated_generic_signature")!
+    signatures = api.uid_get_from_cstr("key.signatures")!
+    activeSignature = api.uid_get_from_cstr("key.active_signature")!
+    parameters = api.uid_get_from_cstr("key.parameters")!
+    activeParameter = api.uid_get_from_cstr("key.active_parameter")!
     docBrief = api.uid_get_from_cstr("key.doc.brief")!
     context = api.uid_get_from_cstr("key.context")!
     typeRelation = api.uid_get_from_cstr("key.typerelation")!
@@ -720,6 +734,7 @@ package struct sourcekitd_api_keys {
     indexStorePath = api.uid_get_from_cstr("key.index_store_path")!
     indexUnitOutputPath = api.uid_get_from_cstr("key.index_unit_output_path")!
     includeLocals = api.uid_get_from_cstr("key.include_locals")!
+    compress = api.uid_get_from_cstr("key.compress")!
     ignoreClangModules = api.uid_get_from_cstr("key.ignore_clang_modules")!
     includeSystemModules = api.uid_get_from_cstr("key.include_system_modules")!
     ignoreStdlib = api.uid_get_from_cstr("key.ignore_stdlib")!
@@ -809,6 +824,8 @@ package struct sourcekitd_api_requests {
   package let codeCompleteSetPopularAPI: sourcekitd_api_uid_t
   /// `source.request.codecomplete.setcustom`
   package let codeCompleteSetCustom: sourcekitd_api_uid_t
+  /// `source.request.signaturehelp`
+  package let signatureHelp: sourcekitd_api_uid_t
   /// `source.request.typecontextinfo`
   package let typeContextInfo: sourcekitd_api_uid_t
   /// `source.request.conformingmethods`
@@ -907,6 +924,7 @@ package struct sourcekitd_api_requests {
     codeCompleteCacheOnDisk = api.uid_get_from_cstr("source.request.codecomplete.cache.ondisk")!
     codeCompleteSetPopularAPI = api.uid_get_from_cstr("source.request.codecomplete.setpopularapi")!
     codeCompleteSetCustom = api.uid_get_from_cstr("source.request.codecomplete.setcustom")!
+    signatureHelp = api.uid_get_from_cstr("source.request.signaturehelp")!
     typeContextInfo = api.uid_get_from_cstr("source.request.typecontextinfo")!
     conformingMethodList = api.uid_get_from_cstr("source.request.conformingmethods")!
     activeRegions = api.uid_get_from_cstr("source.request.activeregions")!

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -51,6 +51,10 @@ package final actor CapabilityRegistry {
     clientCapabilities.textDocument?.completion?.dynamicRegistration == true
   }
 
+  package var clientHasDynamicSignatureHelpRegistration: Bool {
+    clientCapabilities.textDocument?.signatureHelp?.dynamicRegistration == true
+  }
+
   package var clientHasDynamicFoldingRangeRegistration: Bool {
     clientCapabilities.textDocument?.foldingRange?.dynamicRegistration == true
   }

--- a/Sources/SourceKitLSP/CapabilityRegistry.swift
+++ b/Sources/SourceKitLSP/CapabilityRegistry.swift
@@ -27,6 +27,9 @@ package final actor CapabilityRegistry {
   /// Dynamically registered completion options.
   private var completion: [CapabilityRegistration: CompletionRegistrationOptions] = [:]
 
+  /// Dynamically registered signature help options.
+  private var signatureHelp: [CapabilityRegistration: SignatureHelpRegistrationOptions] = [:]
+
   /// Dynamically registered folding range options.
   private var foldingRange: [CapabilityRegistration: FoldingRangeRegistrationOptions] = [:]
 
@@ -221,6 +224,26 @@ package final actor CapabilityRegistry {
       in: server,
       registrationDict: completion,
       setRegistrationDict: { completion[$0] = $1 }
+    )
+  }
+
+  package func registerSignatureHelpIfNeeded(
+    options: SignatureHelpOptions,
+    for languages: [Language],
+    server: SourceKitLSPServer
+  ) async {
+    guard clientHasDynamicCompletionRegistration else { return }
+
+    await registerLanguageSpecificCapability(
+      options: SignatureHelpRegistrationOptions(
+        documentSelector: DocumentSelector(for: languages),
+        signatureHelpOptions: options
+      ),
+      forMethod: SignatureHelpRequest.method,
+      languages: languages,
+      in: server,
+      registrationDict: signatureHelp,
+      setRegistrationDict: { signatureHelp[$0] = $1 }
     )
   }
 

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -196,6 +196,7 @@ package protocol LanguageService: AnyObject, Sendable {
 
   func completion(_ req: CompletionRequest) async throws -> CompletionList
   func completionItemResolve(_ req: CompletionItemResolveRequest) async throws -> CompletionItem
+  func signatureHelp(_ req: SignatureHelpRequest) async throws -> SignatureHelp?
   func hover(_ req: HoverRequest) async throws -> HoverResponse?
   func doccDocumentation(_ req: DoccDocumentationRequest) async throws -> DoccDocumentationResponse
   func symbolInfo(_ request: SymbolInfoRequest) async throws -> [SymbolDetails]
@@ -368,6 +369,10 @@ package extension LanguageService {
 
   func completionItemResolve(_ req: CompletionItemResolveRequest) async throws -> CompletionItem {
     throw ResponseError.requestNotImplemented(CompletionItemResolveRequest.self)
+  }
+
+  func signatureHelp(_ req: SignatureHelpRequest) async throws -> SignatureHelp? {
+    throw ResponseError.requestNotImplemented(SignatureHelpRequest.self)
   }
 
   func hover(_ req: HoverRequest) async throws -> HoverResponse? {

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1189,6 +1189,9 @@ extension SourceKitLSPServer {
     if let completionOptions = server.completionProvider {
       await registry.registerCompletionIfNeeded(options: completionOptions, for: languages, server: self)
     }
+    if let signatureHelpOptions = server.signatureHelpProvider {
+      await registry.registerSignatureHelpIfNeeded(options: signatureHelpOptions, for: languages, server: self)
+    }
     if server.foldingRangeProvider?.isSupported == true {
       await registry.registerFoldingRangeIfNeeded(options: FoldingRangeOptions(), for: languages, server: self)
     }

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -1083,6 +1083,7 @@ extension SourceKitLSPServer {
       ? nil
       : LanguageServerProtocol.SignatureHelpOptions(
         triggerCharacters: ["(", "["],
+        // We retrigger on `:` as it's potentially after an argument label which can change the active parameter or signature.
         retriggerCharacters: [",", ":"]
       )
 

--- a/Sources/SwiftLanguageService/AdjustPositionToStartOfArgument.swift
+++ b/Sources/SwiftLanguageService/AdjustPositionToStartOfArgument.swift
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+import SKLogging
+import SourceKitLSP
+import SwiftSyntax
+
+private class StartOfArgumentFinder: SyntaxAnyVisitor {
+  let requestedPosition: AbsolutePosition
+  var resolvedPosition: AbsolutePosition?
+
+  init(position: AbsolutePosition) {
+    self.requestedPosition = position
+    super.init(viewMode: .sourceAccurate)
+  }
+
+  override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+    if (node.position...node.endPosition).contains(requestedPosition) {
+      return .visitChildren
+    }
+    return .skipChildren
+  }
+
+  override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+    return visit(arguments: node.arguments)
+  }
+
+  override func visit(_ node: SubscriptCallExprSyntax) -> SyntaxVisitorContinueKind {
+    return visit(arguments: node.arguments)
+  }
+
+  private func visit(arguments: LabeledExprListSyntax) -> SyntaxVisitorContinueKind {
+    guard (arguments.position...arguments.endPosition).contains(requestedPosition) else {
+      return .skipChildren
+    }
+
+    guard !arguments.isEmpty else {
+      self.resolvedPosition = arguments.position
+      return .skipChildren
+    }
+
+    for argument in arguments {
+      if (argument.position...argument.endPosition).contains(requestedPosition) {
+        if let trailingComma = argument.trailingComma,
+          requestedPosition >= trailingComma.endPositionBeforeTrailingTrivia
+        {
+          self.resolvedPosition = trailingComma.endPositionBeforeTrailingTrivia
+        } else {
+          self.resolvedPosition = argument.expression.positionAfterSkippingLeadingTrivia
+        }
+        return .visitChildren
+      }
+    }
+
+    return .skipChildren
+  }
+}
+
+extension SwiftLanguageService {
+  func adjustPositionToStartOfArgument(
+    _ position: Position,
+    in snapshot: DocumentSnapshot
+  ) async -> Position {
+    let tree = await self.syntaxTreeManager.syntaxTree(for: snapshot)
+    let visitor = StartOfArgumentFinder(position: snapshot.absolutePosition(of: position))
+    visitor.walk(tree)
+    if let resolvedPosition = visitor.resolvedPosition {
+      return snapshot.position(of: resolvedPosition)
+    }
+    return position
+  }
+}

--- a/Sources/SwiftLanguageService/AdjustPositionToStartOfArgument.swift
+++ b/Sources/SwiftLanguageService/AdjustPositionToStartOfArgument.swift
@@ -25,7 +25,7 @@ private class StartOfArgumentFinder: SyntaxAnyVisitor {
   }
 
   override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
-    if (node.position...node.endPosition).contains(requestedPosition) {
+    if node.range.contains(requestedPosition) {
       return .visitChildren
     }
     return .skipChildren

--- a/Sources/SwiftLanguageService/CMakeLists.txt
+++ b/Sources/SwiftLanguageService/CMakeLists.txt
@@ -44,6 +44,8 @@ add_library(SwiftLanguageService STATIC
   DocumentSymbols.swift
   SyntaxHighlightingTokens.swift
   GeneratedInterfaceManager.swift
+  SignatureHelp.swift
+  AdjustPositionToStartOfArgument.swift
 )
 set_target_properties(SwiftLanguageService PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/SwiftLanguageService/SignatureHelp.swift
+++ b/Sources/SwiftLanguageService/SignatureHelp.swift
@@ -32,12 +32,12 @@ fileprivate extension ParameterInformation {
 fileprivate extension SignatureInformation {
   init?(_ signature: SKDResponseDictionary, _ keys: sourcekitd_api_keys) {
     guard let label = signature[keys.name] as String?,
-      let activeParameter = signature[keys.activeParameter] as Int?,
       let skParameters = signature[keys.parameters] as SKDResponseArray?
     else {
       return nil
     }
 
+    let activeParameter = signature[keys.activeParameter] as Int?
     let parameters = skParameters.compactMap { ParameterInformation($0, keys) }
 
     let documentation: StringOrMarkupContent? = signature[keys.docComment].map {
@@ -63,7 +63,15 @@ fileprivate extension SignatureHelp {
 
     let signatures = skSignatures.compactMap { SignatureInformation($0, keys) }
 
-    self.init(signatures: signatures, activeSignature: activeSignature)
+    guard !signatures.isEmpty else {
+      return nil
+    }
+
+    self.init(
+      signatures: signatures,
+      activeSignature: activeSignature,
+      activeParameter: signatures[activeSignature].activeParameter
+    )
   }
 }
 

--- a/Sources/SwiftLanguageService/SignatureHelp.swift
+++ b/Sources/SwiftLanguageService/SignatureHelp.swift
@@ -77,6 +77,8 @@ fileprivate extension SignatureInformation {
         // an out-of-range index that way editors don't show an active parameter.
         // As of LSP 3.17, not returning an active parameter defaults to choosing
         // the first parameter which isn't the desired behavior.
+        // LSP 3.17 states that out-of-range values are treated as 0 but this is
+        // not the case in VS Code so we rely on that as a workaround.
         // LSP 3.18 defines a `noActiveParameterSupport` option which allows the
         // active parameter to be `null` causing editors not to show an active
         // parameter which would be the best solution here.

--- a/Sources/SwiftLanguageService/SignatureHelp.swift
+++ b/Sources/SwiftLanguageService/SignatureHelp.swift
@@ -71,10 +71,12 @@ extension SwiftLanguageService {
   package func signatureHelp(_ req: SignatureHelpRequest) async throws -> SignatureHelp? {
     let snapshot = try documentManager.latestSnapshot(req.textDocument.uri)
 
+    let adjustedPosition = await adjustPositionToStartOfArgument(req.position, in: snapshot)
+
     let compileCommand = await compileCommand(for: snapshot.uri, fallbackAfterTimeout: false)
 
     let skreq = sourcekitd.dictionary([
-      keys.offset: snapshot.utf8Offset(of: req.position),
+      keys.offset: snapshot.utf8Offset(of: adjustedPosition),
       keys.sourceFile: snapshot.uri.sourcekitdSourceFile,
       keys.primaryFile: snapshot.uri.primaryFile?.pseudoPath,
       keys.compilerArgs: compileCommand?.compilerArgs as [SKDRequestValue]?,

--- a/Sources/SwiftLanguageService/SignatureHelp.swift
+++ b/Sources/SwiftLanguageService/SignatureHelp.swift
@@ -67,8 +67,23 @@ fileprivate extension SignatureInformation {
       return nil
     }
 
-    let activeParameter = signature[keys.activeParameter] as Int?
     let parameters = skParameters.compactMap { ParameterInformation($0, label, keys) }
+
+    let activeParameter: Int? =
+      if let activeParam: Int = signature[keys.activeParameter] {
+        activeParam
+      } else if !parameters.isEmpty {
+        // If we have parameters and no active parameter is present, we return
+        // an out-of-range index that way editors don't show an active parameter.
+        // As of LSP 3.17, not returning an active parameter defaults to choosing
+        // the first parameter which isn't the desired behavior.
+        // LSP 3.18 defines a `noActiveParameterSupport` option which allows the
+        // active parameter to be `null` causing editors not to show an active
+        // parameter which would be the best solution here.
+        parameters.count
+      } else {
+        nil
+      }
 
     let documentation: StringOrMarkupContent? =
       if let docComment: String = signature[keys.docComment] {

--- a/Sources/SwiftLanguageService/SignatureHelp.swift
+++ b/Sources/SwiftLanguageService/SignatureHelp.swift
@@ -25,7 +25,14 @@ fileprivate extension ParameterInformation {
       return nil
     }
 
-    self.init(label: .offsets(start: nameOffset, end: nameOffset + nameLength))
+    let documentation = parameter[keys.docComment].map {
+      StringOrMarkupContent.markupContent(MarkupContent(kind: .markdown, value: $0))
+    }
+
+    self.init(
+      label: .offsets(start: nameOffset, end: nameOffset + nameLength),
+      documentation: documentation
+    )
   }
 }
 
@@ -40,8 +47,8 @@ fileprivate extension SignatureInformation {
     let activeParameter = signature[keys.activeParameter] as Int?
     let parameters = skParameters.compactMap { ParameterInformation($0, keys) }
 
-    let documentation: StringOrMarkupContent? = signature[keys.docComment].map {
-      .markupContent(MarkupContent(kind: .markdown, value: $0))
+    let documentation = signature[keys.docComment].map {
+      StringOrMarkupContent.markupContent(MarkupContent(kind: .markdown, value: $0))
     }
 
     self.init(

--- a/Sources/SwiftLanguageService/SignatureHelp.swift
+++ b/Sources/SwiftLanguageService/SignatureHelp.swift
@@ -17,20 +17,43 @@ import SourceKitD
 import SourceKitLSP
 import SwiftBasicFormat
 
+fileprivate extension String {
+  func utf16Offset(of utf8Offset: Int, callerFile: StaticString = #fileID, callerLine: UInt = #line) -> Int {
+    guard
+      let stringIndex = self.utf8.index(self.startIndex, offsetBy: utf8Offset, limitedBy: self.endIndex)
+    else {
+      logger.fault(
+        """
+        UTF-8 offset is past the end of the string while getting UTF-16 offset of \(utf8Offset) \
+        (\(callerFile, privacy: .public):\(callerLine, privacy: .public))
+        """
+      )
+      return self.utf16.count
+    }
+    return self.utf16.distance(from: self.startIndex, to: stringIndex)
+  }
+}
+
 fileprivate extension ParameterInformation {
-  init?(_ parameter: SKDResponseDictionary, _ keys: sourcekitd_api_keys) {
+  init?(_ parameter: SKDResponseDictionary, _ signatureLabel: String, _ keys: sourcekitd_api_keys) {
     guard let nameOffset = parameter[keys.nameOffset] as Int?,
       let nameLength = parameter[keys.nameLength] as Int?
     else {
       return nil
     }
 
-    let documentation = parameter[keys.docComment].map {
-      StringOrMarkupContent.markupContent(MarkupContent(kind: .markdown, value: $0))
-    }
+    let documentation: StringOrMarkupContent? =
+      if let docComment: String = parameter[keys.docComment] {
+        .markupContent(MarkupContent(kind: .markdown, value: docComment))
+      } else {
+        nil
+      }
+
+    let labelStart = signatureLabel.utf16Offset(of: nameOffset)
+    let labelEnd = signatureLabel.utf16Offset(of: nameOffset + nameLength)
 
     self.init(
-      label: .offsets(start: nameOffset, end: nameOffset + nameLength),
+      label: .offsets(start: labelStart, end: labelEnd),
       documentation: documentation
     )
   }
@@ -45,11 +68,14 @@ fileprivate extension SignatureInformation {
     }
 
     let activeParameter = signature[keys.activeParameter] as Int?
-    let parameters = skParameters.compactMap { ParameterInformation($0, keys) }
+    let parameters = skParameters.compactMap { ParameterInformation($0, label, keys) }
 
-    let documentation = signature[keys.docComment].map {
-      StringOrMarkupContent.markupContent(MarkupContent(kind: .markdown, value: $0))
-    }
+    let documentation: StringOrMarkupContent? =
+      if let docComment: String = signature[keys.docComment] {
+        .markupContent(MarkupContent(kind: .markdown, value: docComment))
+      } else {
+        nil
+      }
 
     self.init(
       label: label,

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -385,6 +385,10 @@ extension SwiftLanguageService {
           resolveProvider: true,
           triggerCharacters: [".", "("]
         ),
+        signatureHelpProvider: SignatureHelpOptions(
+          triggerCharacters: ["(", "["],
+          retriggerCharacters: [",", ":"]
+        ),
         definitionProvider: nil,
         implementationProvider: .bool(true),
         referencesProvider: nil,

--- a/Tests/SourceKitLSPTests/SwiftSignatureHelpTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftSignatureHelpTests.swift
@@ -1,0 +1,434 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import LanguageServerProtocol
+import SKTestSupport
+import SourceKitLSP
+import SwiftExtensions
+import XCTest
+
+final class SwiftSignatureHelpTests: XCTestCase {
+  func testSignatureHelpFunction() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      /// This is a test function
+      /// - Parameters:
+      ///   - a: The first parameter
+      ///   - b: The second parameter
+      /// - Returns: The result of the test
+      func test(a: Int, b: String) -> Double { 0 }
+
+      func main() {
+        test(1️⃣)
+      }
+      """,
+      uri: uri
+    )
+
+    let result = try await testClient.send(
+      SignatureHelpRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        position: positions["1️⃣"]
+      )
+    )
+
+    let signatureHelp = try XCTUnwrap(result)
+    let signature = try XCTUnwrap(signatureHelp.signatures.only)
+
+    XCTAssertEqual(signatureHelp.activeSignature, 0)
+    XCTAssertEqual(signatureHelp.activeParameter, 0)
+    XCTAssertEqual(signature.label, "test(a: Int, b: String) -> Double")
+    XCTAssertEqual(
+      signature.documentation,
+      .markupContent(
+        MarkupContent(
+          kind: .markdown,
+          value: """
+            This is a test function
+            - Parameters:
+              - a: The first parameter
+              - b: The second parameter
+            - Returns: The result of the test
+            """
+        )
+      )
+    )
+    XCTAssertEqual(
+      signature.parameters,
+      [
+        ParameterInformation(label: .offsets(start: 5, end: 11)),
+        ParameterInformation(label: .offsets(start: 13, end: 22)),
+      ]
+    )
+  }
+
+  func testSignatureHelpSubscript() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      struct Matrix {
+        /// Returns the element at the given row and column
+        /// - Parameters:
+        ///   - row: The row index
+        ///   - column: The column index
+        /// - Returns: The element at the given row and column
+        subscript(row: Int, column: Int) -> Int { 0 }
+      }
+
+      func main(matrix: Matrix) {
+        matrix[1, 1️⃣]
+      }
+      """,
+      uri: uri
+    )
+
+    let result = try await testClient.send(
+      SignatureHelpRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        position: positions["1️⃣"]
+      )
+    )
+
+    let signatureHelp = try XCTUnwrap(result)
+    let signature = try XCTUnwrap(signatureHelp.signatures.only)
+
+    XCTAssertEqual(signatureHelp.activeSignature, 0)
+    XCTAssertEqual(signatureHelp.activeParameter, 1)
+    XCTAssertEqual(signature.label, "subscript(row: Int, column: Int) -> Int")
+    XCTAssertEqual(
+      signature.documentation,
+      .markupContent(
+        MarkupContent(
+          kind: .markdown,
+          value: """
+            Returns the element at the given row and column
+            - Parameters:
+              - row: The row index
+              - column: The column index
+            - Returns: The element at the given row and column
+            """
+        )
+      )
+    )
+    XCTAssertEqual(
+      signature.parameters,
+      [
+        ParameterInformation(label: .offsets(start: 10, end: 18)),
+        ParameterInformation(label: .offsets(start: 20, end: 31)),
+      ]
+    )
+  }
+
+  func testSignatureHelpInitializer() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      struct Matrix {
+        /// Initializes a matrix with 0 elements in each row and column
+        ///
+        /// - Precondition: `rows` and `columns` must be positive
+        init(rows: Int, columns: Int) { }
+      }
+
+      func main() {
+        let matrix = Matrix(rows: 3, 1️⃣)
+      }
+      """,
+      uri: uri
+    )
+
+    let result = try await testClient.send(
+      SignatureHelpRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        position: positions["1️⃣"]
+      )
+    )
+
+    let signatureHelp = try XCTUnwrap(result)
+    let signature = try XCTUnwrap(signatureHelp.signatures.only)
+
+    XCTAssertEqual(signatureHelp.activeSignature, 0)
+    XCTAssertEqual(signatureHelp.activeParameter, 1)
+    XCTAssertEqual(signature.label, "init(rows: Int, columns: Int)")
+    XCTAssertEqual(
+      signature.documentation,
+      .markupContent(
+        MarkupContent(
+          kind: .markdown,
+          value: """
+            Initializes a matrix with 0 elements in each row and column
+
+            - Precondition: `rows` and `columns` must be positive
+            """
+        )
+      )
+    )
+    XCTAssertEqual(
+      signature.parameters,
+      [
+        ParameterInformation(label: .offsets(start: 5, end: 14)),
+        ParameterInformation(label: .offsets(start: 16, end: 28)),
+      ]
+    )
+  }
+
+  func testSignatureHelpWithNoParameters() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      /// This is a test function
+      func test() -> Double { 0 }
+
+      func main() {
+        test(1️⃣)
+      }
+      """,
+      uri: uri
+    )
+
+    let result = try await testClient.send(
+      SignatureHelpRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        position: positions["1️⃣"]
+      )
+    )
+
+    let signatureHelp = try XCTUnwrap(result)
+    let signature = try XCTUnwrap(signatureHelp.signatures.only)
+
+    XCTAssertEqual(signatureHelp.activeSignature, 0)
+    XCTAssertNil(signatureHelp.activeParameter)
+    XCTAssertEqual(signature.label, "test() -> Double")
+    XCTAssertEqual(
+      signature.documentation,
+      .markupContent(
+        MarkupContent(kind: .markdown, value: "This is a test function")
+      )
+    )
+    XCTAssertEqual(signature.parameters?.isEmpty, true)
+  }
+
+  func testSignatureHelpNoSignatures() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      func main() {
+        test(1️⃣)
+      }
+      """,
+      uri: uri
+    )
+
+    let result = try await testClient.send(
+      SignatureHelpRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        position: positions["1️⃣"]
+      )
+    )
+
+    XCTAssertNil(result)
+  }
+
+  func testSignatureHelpAdjustToStartOfArgument() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      struct Adder {
+        func add(first: Double!, second: Float, third: Int) -> Double { 0 }
+        func clone() -> Adder { self }
+      }
+
+      func main(adder: Adder) {
+        adder.add(1️⃣fir2️⃣st: 13️⃣, second: 2 + 4️⃣Float.pi, 5️⃣third: 3)
+        adder.add(first: adder.add(first: 1, second: 6️⃣))
+        adder.clone().add(7️⃣)
+      }
+      """,
+      uri: uri
+    )
+
+    func getSignature(marker: String, line: UInt = #line) async throws -> SignatureInformation {
+      let result = try await testClient.send(
+        SignatureHelpRequest(
+          textDocument: TextDocumentIdentifier(uri),
+          position: positions[marker]
+        )
+      )
+
+      let signatureHelp = try XCTUnwrap(result)
+      let signature = try XCTUnwrap(signatureHelp.signatures.only)
+
+      XCTAssertEqual(signature.label, "add(first: Double!, second: Float, third: Int) -> Double", line: line)
+      XCTAssertNil(signature.documentation)
+      XCTAssertEqual(
+        signature.parameters,
+        [
+          ParameterInformation(label: .offsets(start: 4, end: 18)),
+          ParameterInformation(label: .offsets(start: 20, end: 33)),
+          ParameterInformation(label: .offsets(start: 35, end: 45)),
+        ]
+      )
+
+      return signature
+    }
+
+    let firstPosition = try await getSignature(marker: "1️⃣")
+    XCTAssertEqual(firstPosition.activeParameter, 0)
+
+    let secondPosition = try await getSignature(marker: "2️⃣")
+    XCTAssertEqual(secondPosition.activeParameter, 0)
+
+    let thirdPosition = try await getSignature(marker: "3️⃣")
+    XCTAssertEqual(thirdPosition.activeParameter, 0)
+
+    let fourthPosition = try await getSignature(marker: "4️⃣")
+    XCTAssertEqual(fourthPosition.activeParameter, 1)
+
+    let fifthPosition = try await getSignature(marker: "5️⃣")
+    XCTAssertEqual(fifthPosition.activeParameter, 2)
+
+    let sixthPosition = try await getSignature(marker: "6️⃣")
+    XCTAssertEqual(sixthPosition.activeParameter, 1)
+
+    let seventhPosition = try await getSignature(marker: "7️⃣")
+    XCTAssertEqual(seventhPosition.activeParameter, 0)
+  }
+
+  func testSignatureHelpMultipleOverloads() async throws {
+    let testClient = try await TestSourceKitLSPClient()
+    let uri = DocumentURI(for: .swift)
+
+    let positions = testClient.openDocument(
+      """
+      struct Adder {
+        func add(_ x: Int, to y: Int) -> Int { 0 }
+
+        /// Adds one to an integer
+        func add(oneTo x: inout Int) { }
+      }
+
+      func test(adder: Adder) {
+        adder.add(1️⃣)
+      }
+      """,
+      uri: uri
+    )
+
+    let result = try await testClient.send(
+      SignatureHelpRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        position: positions["1️⃣"]
+      )
+    )
+
+    let signatureHelp = try XCTUnwrap(result)
+    XCTAssertEqual(signatureHelp.activeSignature, 0)
+    XCTAssertEqual(signatureHelp.activeParameter, 0)
+    XCTAssertEqual(signatureHelp.signatures.count, 2)
+
+    let firstSignature = try XCTUnwrap(signatureHelp.signatures[0])
+    XCTAssertEqual(firstSignature.label, "add(_ x: Int, to: Int) -> Int")
+    XCTAssertEqual(firstSignature.activeParameter, 0)
+    XCTAssertNil(firstSignature.documentation)
+    XCTAssertEqual(
+      firstSignature.parameters,
+      [
+        ParameterInformation(label: .offsets(start: 4, end: 12)),
+        ParameterInformation(label: .offsets(start: 14, end: 21)),
+      ]
+    )
+
+    let secondSignature = try XCTUnwrap(signatureHelp.signatures[1])
+    XCTAssertEqual(secondSignature.label, "add(oneTo: inout Int)")
+    XCTAssertEqual(secondSignature.activeParameter, 0)
+    XCTAssertEqual(
+      secondSignature.parameters,
+      [ParameterInformation(label: .offsets(start: 4, end: 20))]
+    )
+    XCTAssertEqual(
+      secondSignature.documentation,
+      .markupContent(MarkupContent(kind: .markdown, value: "Adds one to an integer"))
+    )
+  }
+
+  func testSignatureHelpSwiftPMProject() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "utils.swift": """
+        /// A utility function that combines values
+        /// - Parameters:
+        ///   - first: The first value
+        ///   - second: The second value
+        /// - Returns: The combined result
+        func combine(first: String, second: Int) -> String {
+          return "\\(first)-\\(second)"
+        }
+        """,
+        "main.swift": """
+        func test() {
+          combine(1️⃣)
+        }
+        """,
+      ]
+    )
+    let (uri, positions) = try project.openDocument("main.swift")
+
+    let result = try await project.testClient.send(
+      SignatureHelpRequest(
+        textDocument: TextDocumentIdentifier(uri),
+        position: positions["1️⃣"]
+      )
+    )
+
+    let signatureHelp = try XCTUnwrap(result)
+    let signature = try XCTUnwrap(signatureHelp.signatures.only)
+
+    XCTAssertEqual(signature.label, "combine(first: String, second: Int) -> String")
+    XCTAssertEqual(signatureHelp.activeSignature, 0)
+    XCTAssertEqual(signatureHelp.activeParameter, 0)
+    XCTAssertEqual(
+      signature.documentation,
+      .markupContent(
+        MarkupContent(
+          kind: .markdown,
+          value: """
+            A utility function that combines values
+            - Parameters:
+              - first: The first value
+              - second: The second value
+            - Returns: The combined result
+            """
+        )
+      )
+    )
+    XCTAssertEqual(
+      signature.parameters,
+      [
+        ParameterInformation(label: .offsets(start: 8, end: 21)),
+        ParameterInformation(label: .offsets(start: 23, end: 34)),
+      ]
+    )
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/swiftlang/swift/pull/83378

---

Adds support for the LSP signature help request.

> [!NOTE]
> As of https://github.com/swiftlang/swift/pull/83378, SourceKitD still doesn't separate parameter documentation from the signature documentation and thus parameters don't have their own separate documentation. This should just work once SourceKitD implements this functionality and we'll only need to modify the tests.