### PR TITLE
[SwiftLanguageService] Adopt to throwing refactoring actions

### DIFF
--- a/Sources/SwiftLanguageService/CodeActions/ConvertStringConcatenationToStringInterpolation.swift
+++ b/Sources/SwiftLanguageService/CodeActions/ConvertStringConcatenationToStringInterpolation.swift
@@ -17,9 +17,9 @@ import SwiftSyntax
 /// ConvertStringConcatenationToStringInterpolation is a code action that converts a valid string concatenation into a
 /// string interpolation.
 struct ConvertStringConcatenationToStringInterpolation: SyntaxRefactoringProvider {
-  static func refactor(syntax: SequenceExprSyntax, in context: Void) -> SequenceExprSyntax? {
+  static func refactor(syntax: SequenceExprSyntax, in context: Void) throws -> SequenceExprSyntax {
     guard let (componentsOnly, commonPounds) = preflight(exprList: syntax.elements) else {
-      return nil
+      throw RefactoringNotApplicableError("unsupported expression")
     }
 
     var segments: StringLiteralSegmentListSyntax = []

--- a/Sources/SwiftLanguageService/CodeActions/SyntaxRefactoringCodeActionProvider.swift
+++ b/Sources/SwiftLanguageService/CodeActions/SyntaxRefactoringCodeActionProvider.swift
@@ -33,7 +33,9 @@ extension SyntaxRefactoringCodeActionProvider where Self.Context == Void {
       return []
     }
 
-    let sourceEdits = Self.textRefactor(syntax: node)
+    guard let sourceEdits = try? Self.textRefactor(syntax: node) else {
+      return []
+    }
 
     let textEdits = sourceEdits.compactMap { (edit) -> TextEdit? in
       let edit = TextEdit(

--- a/Sources/SwiftLanguageService/CodeCompletionSession.swift
+++ b/Sources/SwiftLanguageService/CodeCompletionSession.swift
@@ -412,7 +412,7 @@ class CodeCompletionSession {
     var parser = Parser(exprToExpand)
     let expr = ExprSyntax.parse(from: &parser)
     guard let call = OutermostFunctionCallFinder.findOutermostFunctionCall(in: expr),
-      let expandedCall = ExpandEditorPlaceholdersToLiteralClosures.refactor(
+      let expandedCall = try? ExpandEditorPlaceholdersToLiteralClosures.refactor(
         syntax: Syntax(call),
         in: ExpandEditorPlaceholdersToLiteralClosures.Context(
           format: .custom(

--- a/Tests/SourceKitLSPTests/SyntaxRefactorTests.swift
+++ b/Tests/SourceKitLSPTests/SyntaxRefactorTests.swift
@@ -278,8 +278,8 @@ func assertRefactor<R: EditRefactoringProvider>(
   file: StaticString = #filePath,
   line: UInt = #line
 ) throws {
-  let edits = R.textRefactor(syntax: input, in: context)
-  guard !edits.isEmpty else {
+  let edits = try? R.textRefactor(syntax: input, in: context)
+  guard let edits, !edits.isEmpty else {
     if !expected.isEmpty {
       XCTFail(
         """


### PR DESCRIPTION
This PR is failed with [swift-syntax](https://github.com/swiftlang/swift-syntax/pull/3142).

`EditRefactoringProvider.textRefactor` and `EditRefactoringProvider.refactor` requirements are now throwing and produce a non-optional type.