### PR TITLE
Support `trace-from-signpost` for logs captured in time zones ahead of UTC

### DIFF
--- a/Sources/Diagnose/TraceFromSignpostsCommand.swift
+++ b/Sources/Diagnose/TraceFromSignpostsCommand.swift
@@ -31,7 +31,7 @@ private struct LogParseRegex {
   private init() {
     regex = Regex {
       Capture(as: dateComponent) {
-        #/[-0-9]+ [0-9:.-]+/#
+        #/[-0-9]+ [0-9:.+-]+/#
       }
       " "
       #/[0-9a-fx]+/#  // Thread ID


### PR DESCRIPTION
We need to match `+` in the date component of the log so we can capture times such as `2025-08-20 09:19:44.156241+0200`. Previously this only worked for times that were behind UTC.