### PR TITLE
Pass objects to linker flags as is in macro test projects

### DIFF
--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -133,7 +133,7 @@ package class SwiftPMTestProject: MultiFileTestProject {
 
       let linkerFlags = objectFiles.map {
         """
-        "-l", "\($0)",
+        "\($0)",
         """
       }.joined(separator: "\n")
 


### PR DESCRIPTION
These are absolute paths, no "-l" is necessary here and is actually an error with eg. `ld.bfd`.