### PR TITLE
Fix issue that caused targets to be sorted top-down instead of bottom-up for background indexing

### DIFF
--- a/Sources/BuildServerIntegration/BuildServerManager.swift
+++ b/Sources/BuildServerIntegration/BuildServerManager.swift
@@ -1119,7 +1119,7 @@ package actor BuildServerManager: QueueBasedMessageHandler {
       let lhsDepth = buildTargets[lhs]?.depth ?? 0
       let rhsDepth = buildTargets[rhs]?.depth ?? 0
       if lhsDepth != rhsDepth {
-        return rhsDepth > lhsDepth
+        return lhsDepth > rhsDepth
       }
       return lhs.uri.stringValue < rhs.uri.stringValue
     }


### PR DESCRIPTION
This sign flip slipped in with https://github.com/swiftlang/sourcekit-lsp/pull/1674.

There was also a non-determinism in the prepration schedule order.