### PR TITLE
Add support for copied header files to SourceKit-LSP

### DIFF
--- a/Contributor Documentation/BSP Extensions.md
+++ b/Contributor Documentation/BSP Extensions.md
@@ -95,6 +95,15 @@ export interface SourceKitSourceItemData {
    * `outputPathsProvider: true` in `SourceKitInitializeBuildResponseData`.
    */
   outputPath?: string;
+
+  /**
+   * If this source item gets copied to a different destination during preparation, the destinations it will be copied
+   * to.
+   *
+   * If a user action would jump to one of these copied files, this allows SourceKit-LSP to redirect the navigation to
+   * the original source file instead of jumping to a file in the build directory.
+   */
+  copyDestinations?: DocumentURI[];
 }
 ```
 

--- a/Contributor Documentation/LSP Extensions.md
+++ b/Contributor Documentation/LSP Extensions.md
@@ -795,12 +795,20 @@ export interface SynchronizeParams {
    * This option is experimental, guarded behind the `synchronize-for-build-system-updates` experimental feature, and
    * may be modified or removed in future versions of SourceKit-LSP without notice. Do not rely on it.
    */
-  buildServerUpdates?: bool
+  buildServerUpdates?: bool;
+
+  /**
+   *  Wait for the build server to update its internal mapping of copied files to their original location.
+   *
+   * This option is experimental, guarded behind the `synchronize-copy-file-map` experimental feature, and may be
+   * modified or removed in future versions of SourceKit-LSP without notice. Do not rely on it.
+   */
+  copyFileMap?: bool;
 
   /**
    * Wait for background indexing to finish and all index unit files to be loaded into indexstore-db.
    */
-  index?: bool
+  index?: bool;
 }
 ```
 

--- a/Sources/LanguageServerProtocol/Requests/SynchronizeRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/SynchronizeRequest.swift
@@ -38,11 +38,18 @@ public struct SynchronizeRequest: RequestType {
   /// may be modified or removed in future versions of SourceKit-LSP without notice. Do not rely on it.
   public var buildServerUpdates: Bool?
 
+  /// Wait for the build server to update its internal mapping of copied files to their original location.
+  ///
+  /// This option is experimental, guarded behind the `synchronize-copy-file-map` experimental feature, and may be
+  /// modified or removed in future versions of SourceKit-LSP without notice. Do not rely on it.
+  public var copyFileMap: Bool?
+
   /// Wait for background indexing to finish and all index unit files to be loaded into indexstore-db.
   public var index: Bool?
 
-  public init(buildServerUpdates: Bool? = nil, index: Bool? = nil) {
+  public init(buildServerUpdates: Bool? = nil, copyFileMap: Bool? = nil, index: Bool? = nil) {
     self.buildServerUpdates = buildServerUpdates
+    self.copyFileMap = copyFileMap
     self.index = index
   }
 }

--- a/Sources/SKOptions/ExperimentalFeatures.swift
+++ b/Sources/SKOptions/ExperimentalFeatures.swift
@@ -45,6 +45,11 @@ public enum ExperimentalFeature: String, Codable, Sendable, CaseIterable {
   /// - Note: Internal option, for testing only
   case synchronizeForBuildSystemUpdates = "synchronize-for-build-system-updates"
 
+  /// Enable the `copyFileMap` option in the `workspace/synchronize` request.
+  ///
+  /// - Note: Internal option, for testing only
+  case synchronizeCopyFileMap = "synchronize-copy-file-map"
+
   /// All non-internal experimental features.
   public static var allNonInternalCases: [ExperimentalFeature] {
     allCases.filter { !$0.isInternal }
@@ -66,6 +71,8 @@ public enum ExperimentalFeature: String, Codable, Sendable, CaseIterable {
     case .outputPathsRequest:
       return true
     case .synchronizeForBuildSystemUpdates:
+      return true
+    case .synchronizeCopyFileMap:
       return true
     }
   }

--- a/Sources/SKTestSupport/TestSourceKitLSPClient.swift
+++ b/Sources/SKTestSupport/TestSourceKitLSPClient.swift
@@ -27,7 +27,7 @@ import XCTest
 extension SourceKitLSPOptions {
   package static func testDefault(
     backgroundIndexing: Bool = true,
-    experimentalFeatures: Set<ExperimentalFeature> = []
+    experimentalFeatures: Set<ExperimentalFeature> = [.synchronizeCopyFileMap]
   ) async throws -> SourceKitLSPOptions {
     let pluginPaths = try await sourceKitPluginPaths
     return SourceKitLSPOptions(

--- a/Tests/SourceKitLSPTests/DefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DefinitionTests.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BuildServerIntegration
+import BuildServerProtocol
 import LanguageServerProtocol
 @_spi(Testing) import SKLogging
 import SKTestSupport
@@ -586,5 +588,105 @@ class DefinitionTests: XCTestCase {
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
     )
     XCTAssertEqual(response?.locations, [Location(uri: project.fileURI, range: Range(project.positions["2️⃣"]))])
+  }
+
+  func testJumpToCopiedHeader() async throws {
+    actor BuildServer: CustomBuildServer {
+      let inProgressRequestsTracker = CustomBuildServerInProgressRequestTracker()
+      private let projectRoot: URL
+
+      private var headerCopyDestination: URL {
+        projectRoot.appending(components: "header-copy", "CopiedTest.h")
+      }
+
+      init(projectRoot: URL, connectionToSourceKitLSP: any Connection) {
+        self.projectRoot = projectRoot
+      }
+
+      func initializeBuildRequest(_ request: InitializeBuildRequest) async throws -> InitializeBuildResponse {
+        return try initializationResponseSupportingBackgroundIndexing(
+          projectRoot: projectRoot,
+          outputPathsProvider: false
+        )
+      }
+
+      func buildTargetSourcesRequest(_ request: BuildTargetSourcesRequest) -> BuildTargetSourcesResponse {
+        return BuildTargetSourcesResponse(items: [
+          SourcesItem(
+            target: .dummy,
+            sources: [
+              SourceItem(
+                uri: DocumentURI(projectRoot.appendingPathComponent("Test.c")),
+                kind: .file,
+                generated: false,
+                dataKind: .sourceKit,
+                data: SourceKitSourceItemData(
+                  language: .c,
+                  kind: .source,
+                  outputPath: nil,
+                  copyDestinations: nil
+                ).encodeToLSPAny()
+              ),
+              SourceItem(
+                uri: DocumentURI(projectRoot.appendingPathComponent("Test.h")),
+                kind: .file,
+                generated: false,
+                dataKind: .sourceKit,
+                data: SourceKitSourceItemData(
+                  language: .c,
+                  kind: .header,
+                  outputPath: nil,
+                  copyDestinations: [DocumentURI(headerCopyDestination)]
+                ).encodeToLSPAny()
+              ),
+            ]
+          )
+        ])
+      }
+
+      func textDocumentSourceKitOptionsRequest(
+        _ request: TextDocumentSourceKitOptionsRequest
+      ) throws -> TextDocumentSourceKitOptionsResponse? {
+        return TextDocumentSourceKitOptionsResponse(compilerArguments: [
+          request.textDocument.uri.pseudoPath, "-I", try headerCopyDestination.deletingLastPathComponent().filePath,
+        ])
+      }
+
+      func prepareTarget(_ request: BuildTargetPrepareRequest) async throws -> VoidResponse {
+        try FileManager.default.createDirectory(
+          at: headerCopyDestination.deletingLastPathComponent(),
+          withIntermediateDirectories: true
+        )
+        try FileManager.default.copyItem(
+          at: projectRoot.appending(component: "Test.h"),
+          to: headerCopyDestination
+        )
+        return VoidResponse()
+      }
+    }
+
+    let project = try await CustomBuildServerTestProject(
+      files: [
+        "Test.h": """
+        void hello();
+        """,
+        "Test.c": """
+        #include <CopiedTest.h>
+
+        void test() {
+          1️⃣hello();
+        }
+        """,
+      ],
+      buildServer: BuildServer.self,
+      enableBackgroundIndexing: true,
+    )
+    try await project.testClient.send(SynchronizeRequest(copyFileMap: true))
+
+    let (uri, positions) = try project.openDocument("Test.c")
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(uri), position: positions["1️⃣"])
+    )
+    XCTAssertEqual(response?.locations?.map(\.uri), [try project.uri(for: "Test.h")])
   }
 }


### PR DESCRIPTION
If a build server copies files (eg. header) to the build directory during preparation and those copied files are referenced for semantic functionality, we would currently jump to the file in the build directory. Teach SourceKit-LSP about files that are copied during preparation and if we detect that we are jumping to such a file, jump to the original file instead.

So far only the definition request checks the copied file paths. Adding support for copied file paths in the other requests will be a follow-up change.