### PR TITLE
Add a ShowFocusedDiagnosticsRequest LSP extension and wire it up to inferred types remarks

### DIFF
--- a/Contributor Documentation/LSP Extensions.md
+++ b/Contributor Documentation/LSP Extensions.md
@@ -770,6 +770,35 @@ export interface PeekDocumentsResult {
 }
 ```
 
+## `workspace/showFocusedDiagnostics`
+
+Request from the server to the client to display focused diagnostics for a specific subset of the source.
+
+It requires the experimental client capability `"workspace/showFocusedDiagnostics"` to use.
+
+- params: `ShowFocusedDiagnosticsParams`
+- result: `ShowFocusedDiagnosticsResult`
+
+```ts
+export interface ShowFocusedDiagnosticsParams {
+  /**
+   * Array of diagnostics to display
+   */
+  diagnostics: Diagnostic[];
+  /**
+   * The `DocumentUri` of the text document in which to present the diagnostics.
+   */
+  uri: DocumentUri;
+}
+
+/**
+ * Response to indicate the `success` of the `ShowFocusedDiagnosticsRequest`
+ */
+export interface ShowFocusedDiagnosticsResult {
+  success: boolean;
+}
+```
+
 ## `workspace/synchronize`
 
 Request from the client to the server to wait for SourceKit-LSP to handle all ongoing requests and, optionally, wait for background activity to finish.

--- a/Sources/LanguageServerProtocol/Requests/ShowFocusedDiagnosticsRequest.swift
+++ b/Sources/LanguageServerProtocol/Requests/ShowFocusedDiagnosticsRequest.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Request from the server to the client to show focused diagnostics **(LSP Extension)**
+///
+/// This request is handled by the client to display focused diagnostic information
+/// related to a subset of the source.
+///
+/// - Parameters:
+///   - diagnostics: Array of diagnostics to display
+///   - uri: Document URI in which to present the diagnostics
+///
+/// - Returns: `ShowFocusedDiagnosticsResponse` which indicates the `success` of the request.
+///
+/// ### LSP Extension
+///
+/// This request is an extension to LSP supported by SourceKit-LSP.
+/// It requires the experimental client capability `workspace/showFocusedDiagnostics` to use.
+public struct ShowFocusedDiagnosticsRequest: RequestType {
+  public static let method: String = "workspace/showFocusedDiagnostics"
+  public typealias Response = ShowFocusedDiagnosticsResponse
+
+  public var diagnostics: [Diagnostic]
+  public var uri: DocumentURI
+
+  public init(diagnostics: [Diagnostic], uri: DocumentURI) {
+    self.diagnostics = diagnostics
+    self.uri = uri
+  }
+}
+
+/// Response to indicate the `success` of the `ShowFocusedDiagnosticsRequest`
+public struct ShowFocusedDiagnosticsResponse: ResponseType {
+  public var success: Bool
+
+  public init(success: Bool) {
+    self.success = success
+  }
+}

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -963,6 +963,7 @@ extension SourceKitLSPServer {
         PeekDocumentsRequest.method,
         GetReferenceDocumentRequest.method,
         DidChangeActiveDocumentNotification.method,
+        ShowFocusedDiagnosticsRequest.method,
       ]
       for capabilityName in experimentalClientCapabilities {
         guard let experimentalCapability = initializationOptions[capabilityName] else {

--- a/Sources/SwiftLanguageService/FocusedRemarksCommand.swift
+++ b/Sources/SwiftLanguageService/FocusedRemarksCommand.swift
@@ -1,0 +1,101 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+package import LanguageServerProtocol
+import SourceKitD
+
+/// Describes a kind of focused remarks supported by the compiler. Remarks should be exposed via
+/// a flag which accepts a position in the document as a <line:column> pair and only emits
+/// diagnostics relavant to that position (e.g. expressions or function bodies with source ranges that
+/// contain the position).
+package enum FocusedRemarksKind: String, CaseIterable, Codable {
+  case showInferredTypes
+
+  package var defaultTitle: String {
+    switch self {
+    case .showInferredTypes:
+      return "Show Inferred Types"
+    }
+  }
+
+  package func additionalCompilerArgs(line: Int, column: Int) -> [String] {
+    switch self {
+    case .showInferredTypes:
+      return [
+        "-Xfrontend",
+        "-Rinferred-types-at",
+        "-Xfrontend",
+        "\(line):\(column)",
+      ]
+    }
+  }
+}
+
+package struct FocusedRemarksCommand: SwiftCommand {
+  package static let identifier: String = "focused.remarks.command"
+
+  package let commandType: FocusedRemarksKind
+  package var title: String
+  package let position: Position
+  package let textDocument: TextDocumentIdentifier
+
+  package init(commandType: FocusedRemarksKind, position: Position, textDocument: TextDocumentIdentifier) {
+    self.commandType = commandType
+    self.position = position
+    self.textDocument = textDocument
+    self.title = commandType.defaultTitle
+  }
+
+  package init?(fromLSPDictionary dictionary: [String: LSPAny]) {
+    guard case .dictionary(let documentDict)? = dictionary[CodingKeys.textDocument.stringValue],
+      case .string(let title)? = dictionary[CodingKeys.title.stringValue],
+      case .dictionary(let positionDict)? = dictionary[CodingKeys.position.stringValue],
+      case .string(let commandTypeString)? = dictionary[CodingKeys.commandType.stringValue]
+    else {
+      return nil
+    }
+    guard let position = Position(fromLSPDictionary: positionDict),
+      let textDocument = TextDocumentIdentifier(fromLSPDictionary: documentDict),
+      let commandType = FocusedRemarksKind(rawValue: commandTypeString)
+    else {
+      return nil
+    }
+
+    self.init(
+      commandType: commandType,
+      title: title,
+      position: position,
+      textDocument: textDocument
+    )
+  }
+
+  package init(
+    commandType: FocusedRemarksKind,
+    title: String,
+    position: Position,
+    textDocument: TextDocumentIdentifier
+  ) {
+    self.commandType = commandType
+    self.title = title
+    self.position = position
+    self.textDocument = textDocument
+  }
+
+  package func encodeToLSPAny() -> LSPAny {
+    return .dictionary([
+      CodingKeys.title.stringValue: .string(title),
+      CodingKeys.position.stringValue: position.encodeToLSPAny(),
+      CodingKeys.textDocument.stringValue: textDocument.encodeToLSPAny(),
+      CodingKeys.commandType.stringValue: .string(commandType.rawValue),
+    ])
+  }
+}

--- a/Sources/SwiftLanguageService/SwiftCommand.swift
+++ b/Sources/SwiftLanguageService/SwiftCommand.swift
@@ -51,6 +51,7 @@ extension SwiftLanguageService {
     [
       SemanticRefactorCommand.self,
       ExpandMacroCommand.self,
+      FocusedRemarksCommand.self,
     ].map { (command: any SwiftCommand.Type) in
       command.identifier
     }


### PR DESCRIPTION
The goal here is to provide a general way for the compiler to provide on-demand visualizations/markup of source focused on a particular region of code the user is working in. Initially, I've wired this up to the remark added in https://github.com/swiftlang/swift/pull/84032 which emits remarks for each type inferred in an expression at the given position.