### PR TITLE
Improve `Indexing: Scheduling tasks` message

### DIFF
--- a/Sources/SemanticIndex/SemanticIndexManager.swift
+++ b/Sources/SemanticIndex/SemanticIndexManager.swift
@@ -104,7 +104,7 @@ package enum IndexTaskStatus: Comparable {
 /// messages to the user, we only show the highest priority task.
 package enum IndexProgressStatus: Sendable, Equatable {
   case preparingFileForEditorFunctionality
-  case schedulingIndexing
+  case generatingBuildGraph
   case indexing(
     preparationTasks: [BuildTargetIdentifier: IndexTaskStatus],
     indexTasks: [FileIndexInfo: IndexTaskStatus]
@@ -115,8 +115,8 @@ package enum IndexProgressStatus: Sendable, Equatable {
     switch (self, other) {
     case (_, .preparingFileForEditorFunctionality), (.preparingFileForEditorFunctionality, _):
       return .preparingFileForEditorFunctionality
-    case (_, .schedulingIndexing), (.schedulingIndexing, _):
-      return .schedulingIndexing
+    case (_, .generatingBuildGraph), (.generatingBuildGraph, _):
+      return .generatingBuildGraph
     case (
       .indexing(let selfPreparationTasks, let selfIndexTasks),
       .indexing(let otherPreparationTasks, let otherIndexTasks)
@@ -250,7 +250,7 @@ package final actor SemanticIndexManager {
     // flickering between indexing progress and `Scheduling indexing` if we trigger an index schedule task while
     // indexing is already in progress
     if !buildGraphGenerationTasks.isEmpty {
-      return .schedulingIndexing
+      return .generatingBuildGraph
     }
     return .upToDate
   }

--- a/Sources/SourceKitLSP/IndexProgressManager.swift
+++ b/Sources/SourceKitLSP/IndexProgressManager.swift
@@ -93,8 +93,8 @@ actor IndexProgressManager {
     case .preparingFileForEditorFunctionality:
       message = "Preparing current file"
       percentage = 0
-    case .schedulingIndexing:
-      message = "Scheduling tasks"
+    case .generatingBuildGraph:
+      message = "Determining files"
       percentage = 0
     case .indexing(let preparationTasks, let indexTasks):
       // We can get into a situation where queuedIndexTasks < indexTasks.count if we haven't processed all

--- a/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
+++ b/Tests/SourceKitLSPTests/BackgroundIndexingTests.swift
@@ -379,7 +379,7 @@ final class BackgroundIndexingTests: XCTestCase {
       XCTFail("Expected begin notification")
       return
     }
-    XCTAssertEqual(beginData.message, "Scheduling tasks")
+    XCTAssertEqual(beginData.message, "Determining files")
     let indexingWorkDoneProgressToken = beginNotification.token
 
     _ = try await project.testClient.nextNotification(


### PR DESCRIPTION
The majority of the work here is getting the list of files to index from the build server. Let’s rename the message to reflect that.