### PR TITLE
Use native root check on Windows

### DIFF
--- a/Sources/SwiftExtensions/URLExtensions.swift
+++ b/Sources/SwiftExtensions/URLExtensions.swift
@@ -12,6 +12,10 @@
 
 package import Foundation
 
+#if os(Windows)
+import WinSDK
+#endif
+
 enum FilePathError: Error, CustomStringConvertible {
   case noFileSystemRepresentation(URL)
   case noFileURL(URL)
@@ -84,14 +88,14 @@ extension URL {
   }
 
   package var isRoot: Bool {
-    #if os(Windows)
-    // FIXME: We should call into Windows' native check to check if this path is a root once https://github.com/swiftlang/swift-foundation/issues/976 is fixed.
-    return self.pathComponents.count <= 1
-    #else
-    // On Linux, we may end up with an string for the path due to https://github.com/swiftlang/swift-foundation/issues/980
-    // TODO: Remove the check for "" once https://github.com/swiftlang/swift-foundation/issues/980 is fixed.
-    return self.path == "/" || self.path == ""
-    #endif
+    get throws {
+      let checkPath = try filePath
+      #if os(Windows)
+      return checkPath.withCString(encodedAs: UTF16.self, PathCchIsRoot)
+      #else
+      return checkPath == "/"
+      #endif
+    }
   }
 
   /// Returns true if the path of `self` starts with the path in `other`.

--- a/Sources/ToolchainRegistry/Toolchain.swift
+++ b/Sources/ToolchainRegistry/Toolchain.swift
@@ -370,7 +370,7 @@ func containingXCToolchain(
   _ path: URL
 ) -> (XCToolchainPlist, URL)? {
   var path = path
-  while !path.isRoot {
+  while !((try? path.isRoot) ?? true) {
     if path.pathExtension == "xctoolchain" {
       if let infoPlist = orLog("Loading information from xctoolchain", { try XCToolchainPlist(fromDirectory: path) }) {
         return (infoPlist, path)


### PR DESCRIPTION
Not sure exactly what paths are triggering this on Windows, as all the logs in #2174 are within `C:\`. But the stacktrace seems to strongly imply that we have an infinite loop here, so let's see if switching to the native check fixes this now that
https://github.com/swiftlang/swift-foundation/issues/976 is in.

Resolves #2174