### PR TITLE
[6.2] Use native root check on Windows

### DIFF
--- a/Sources/SwiftExtensions/URLExtensions.swift
+++ b/Sources/SwiftExtensions/URLExtensions.swift
@@ -12,6 +12,10 @@
 
 package import Foundation
 
+#if os(Windows)
+import WinSDK
+#endif
+
 enum FilePathError: Error, CustomStringConvertible {
   case noFileSystemRepresentation(URL)
   case noFileURL(URL)
@@ -83,14 +87,14 @@ extension URL {
   }
 
   package var isRoot: Bool {
-    #if os(Windows)
-    // FIXME: We should call into Windows' native check to check if this path is a root once https://github.com/swiftlang/swift-foundation/issues/976 is fixed.
-    return self.pathComponents.count <= 1
-    #else
-    // On Linux, we may end up with an string for the path due to https://github.com/swiftlang/swift-foundation/issues/980
-    // TODO: Remove the check for "" once https://github.com/swiftlang/swift-foundation/issues/980 is fixed.
-    return self.path == "/" || self.path == ""
-    #endif
+    get throws {
+      let checkPath = try filePath
+      #if os(Windows)
+      return checkPath.withCString(encodedAs: UTF16.self, PathCchIsRoot)
+      #else
+      return checkPath == "/"
+      #endif
+    }
   }
 
   /// Returns true if the path of `self` starts with the path in `other`.

--- a/Sources/ToolchainRegistry/Toolchain.swift
+++ b/Sources/ToolchainRegistry/Toolchain.swift
@@ -370,7 +370,7 @@ func containingXCToolchain(
   _ path: URL
 ) -> (XCToolchainPlist, URL)? {
   var path = path
-  while !path.isRoot {
+  while !((try? path.isRoot) ?? true) {
     if path.pathExtension == "xctoolchain" {
       if let infoPlist = orLog("Loading information from xctoolchain", { try XCToolchainPlist(fromDirectory: path) }) {
         return (infoPlist, path)


### PR DESCRIPTION
- **Explanation**: Switches to Windows native root check rather than our component count check to (hopefully) fix an infinite loop when checking for root paths.
- **Scope**: Windows
- **Issues**: #2174
- **Original PRs**: https://github.com/swiftlang/sourcekit-lsp/pull/2286
- **Risk**: Very low - we've been using essentially this code in swift-format for a long time now
- **Testing**: No new tests. Haven't actually been able to reproduce this on Windows, hoping those hitting it can make sure this fixes things.
- **Reviewers**: @ahoppen 