### PR TITLE
Use `CustomBuildServerTestProject` in `BuildServerTests`

### DIFF
--- a/Sources/SKTestSupport/CustomBuildServerTestProject.swift
+++ b/Sources/SKTestSupport/CustomBuildServerTestProject.swift
@@ -278,6 +278,7 @@ package final class CustomBuildServerTestProject<BuildServer: CustomBuildServer>
     options: SourceKitLSPOptions? = nil,
     hooks: Hooks = Hooks(),
     enableBackgroundIndexing: Bool = false,
+    usePullDiagnostics: Bool = true,
     pollIndex: Bool = true,
     preInitialization: ((TestSourceKitLSPClient) -> Void)? = nil,
     testScratchDir: URL? = nil,
@@ -296,6 +297,7 @@ package final class CustomBuildServerTestProject<BuildServer: CustomBuildServer>
       options: options,
       hooks: hooks,
       enableBackgroundIndexing: enableBackgroundIndexing,
+      usePullDiagnostics: usePullDiagnostics,
       preInitialization: preInitialization,
       testScratchDir: testScratchDir,
       testName: testName

--- a/Sources/SourceKitLSP/Workspace.swift
+++ b/Sources/SourceKitLSP/Workspace.swift
@@ -363,26 +363,6 @@ package final class Workspace: Sendable, BuildServerManagerDelegate {
     await scheduleUpdateOfUnitOutputPathsInIndexIfNecessary()
   }
 
-  package static func forTesting(
-    options: SourceKitLSPOptions,
-    sourceKitLSPServer: SourceKitLSPServer,
-    testHooks: Hooks,
-    buildServerManager: BuildServerManager,
-    indexTaskScheduler: TaskScheduler<AnyIndexTaskDescription>
-  ) async -> Workspace {
-    return await Workspace(
-      sourceKitLSPServer: sourceKitLSPServer,
-      rootUri: nil,
-      capabilityRegistry: CapabilityRegistry(clientCapabilities: ClientCapabilities()),
-      options: options,
-      hooks: testHooks,
-      buildServerManager: buildServerManager,
-      index: nil,
-      indexDelegate: nil,
-      indexTaskScheduler: indexTaskScheduler
-    )
-  }
-
   /// Returns a `CheckedIndex` that verifies that all the returned entries are up-to-date with the given
   /// `IndexCheckLevel`.
   package func index(checkedFor checkLevel: IndexCheckLevel) -> CheckedIndex? {

--- a/Tests/SourceKitLSPTests/BuildServerTests.swift
+++ b/Tests/SourceKitLSPTests/BuildServerTests.swift
@@ -49,151 +49,10 @@ fileprivate actor TestBuildServer: CustomBuildServer {
 }
 
 final class BuildServerTests: XCTestCase {
-  /// The mock client used to communicate with the SourceKit-LSP server.p
-  ///
-  /// - Note: Set before each test run in `setUp`.
-  private var testClient: TestSourceKitLSPClient! = nil
-
-  /// The server's workspace data. Accessing this is unsafe if the server does so concurrently.
-  ///
-  /// - Note: Set before each test run in `setUp`.
-  private var workspace: Workspace! = nil
-
-  /// The build server that we use to verify SourceKitLSPServer behavior.
-  ///
-  /// - Note: Set before each test run in `setUp`.
-  private var buildServer: TestBuildServer! = nil
-
-  /// Whether clangd exists in the toolchain.
-  ///
-  /// - Note: Set before each test run in `setUp`.
-  private var haveClangd: Bool = false
-
-  override func setUp() async throws {
-    testClient = try await TestSourceKitLSPClient(usePullDiagnostics: false)
-
-    let server = testClient.server
-
-    let testBuildServer = ThreadSafeBox<TestBuildServer?>(initialValue: nil)
-    let buildServerManager = await BuildServerManager(
-      buildServerSpec: BuildServerSpec(
-        kind: .injected({ projectRoot, connectionToSourceKitLSP in
-          assert(testBuildServer.value == nil, "Build server injector hook can only create a single TestBuildServer")
-          let buildServer = TestBuildServer(
-            projectRoot: projectRoot,
-            connectionToSourceKitLSP: connectionToSourceKitLSP
-          )
-          testBuildServer.value = buildServer
-          return LocalConnection(receiverName: "TestBuildServer", handler: buildServer)
-        }),
-        projectRoot: URL(fileURLWithPath: "/"),
-        configPath: URL(fileURLWithPath: "/")
-      ),
-      toolchainRegistry: .forTesting,
-      options: try .testDefault(),
-      connectionToClient: DummyBuildServerManagerConnectionToClient(),
-      buildServerHooks: BuildServerHooks()
-    )
-    buildServer = try unwrap(testBuildServer.value)
-
-    self.workspace = await Workspace.forTesting(
-      options: try .testDefault(),
-      sourceKitLSPServer: server,
-      testHooks: Hooks(),
-      buildServerManager: buildServerManager,
-      indexTaskScheduler: .forTesting
-    )
-
-    await server.setWorkspaces([(workspace: workspace, isImplicit: false)])
-    await workspace.buildServerManager.setDelegate(workspace)
-  }
-
-  override func tearDown() {
-    buildServer = nil
-    workspace = nil
-    testClient = nil
-  }
-
-  // MARK: - Tests
-
   func testClangdDocumentUpdatedBuildSettings() async throws {
-    guard haveClangd else { return }
-
-    let doc = DocumentURI(for: .objective_c)
-    let args = [doc.pseudoPath, "-DDEBUG"]
-    let text = """
-      #ifdef FOO
-      static void foo() {}
-      #endif
-
-      int main() {
-        foo();
-        return 0;
-      }
-      """
-
-    await buildServer.setBuildSettings(for: doc, to: TextDocumentSourceKitOptionsResponse(compilerArguments: args))
-
-    let documentManager = self.testClient.server.documentManager
-
-    testClient.openDocument(text, uri: doc)
-
-    let diags = try await testClient.nextDiagnosticsNotification()
-    XCTAssertEqual(diags.diagnostics.count, 1)
-    XCTAssertEqual(text, try documentManager.latestSnapshot(doc).text)
-
-    // Modify the build settings and inform the delegate.
-    // This should trigger a new publish diagnostics and we should no longer have errors.
-    let newSettings = TextDocumentSourceKitOptionsResponse(compilerArguments: args + ["-DFOO"])
-    await buildServer.setBuildSettings(for: doc, to: newSettings)
-
-    try await repeatUntilExpectedResult {
-      guard let refreshedDiags = try? await testClient.nextDiagnosticsNotification(timeout: .seconds(1)) else {
-        return false
-      }
-      return try text == documentManager.latestSnapshot(doc).text && refreshedDiags.diagnostics.count == 0
-    }
-  }
-
-  func testSwiftDocumentUpdatedBuildSettings() async throws {
-    let doc = DocumentURI(for: .swift)
-    let args = fallbackBuildSettings(
-      for: doc,
-      language: .swift,
-      options: SourceKitLSPOptions.FallbackBuildSystemOptions()
-    )!.compilerArguments
-
-    await buildServer.setBuildSettings(for: doc, to: TextDocumentSourceKitOptionsResponse(compilerArguments: args))
-
-    let text = """
-      #if FOO
-      func foo() {}
-      #endif
-
-      foo()
-      """
-
-    let documentManager = self.testClient.server.documentManager
-
-    testClient.openDocument(text, uri: doc)
-    let diags1 = try await testClient.nextDiagnosticsNotification()
-    XCTAssertEqual(diags1.diagnostics.count, 1)
-    XCTAssertEqual(text, try documentManager.latestSnapshot(doc).text)
-
-    // Modify the build settings and inform the delegate.
-    // This should trigger a new publish diagnostics and we should no longer have errors.
-    let newSettings = TextDocumentSourceKitOptionsResponse(compilerArguments: args + ["-DFOO"])
-    await buildServer.setBuildSettings(for: doc, to: newSettings)
-
-    // No expected errors here because we fixed the settings.
-    let diags2 = try await testClient.nextDiagnosticsNotification()
-    XCTAssertEqual(diags2.diagnostics.count, 0)
-  }
-
-  func testClangdDocumentFallbackWithholdsDiagnostics() async throws {
-    let doc = DocumentURI(for: .objective_c)
-    let args = [doc.pseudoPath, "-DDEBUG"]
-    let text = """
+    let project = try await CustomBuildServerTestProject(
+      files: [
+        "test.c": """
         #ifdef FOO
         static void foo() {}
         #endif
@@ -202,61 +61,150 @@ final class BuildServerTests: XCTestCase {
           foo();
           return 0;
         }
-      """
+        """
+      ],
+      buildServer: TestBuildServer.self,
+      usePullDiagnostics: false
+    )
 
-    let documentManager = self.testClient.server.documentManager
+    let args = [try project.uri(for: "test.c").pseudoPath, "-DDEBUG"]
+    try await project.buildServer().setBuildSettings(
+      for: project.uri(for: "test.c"),
+      to: TextDocumentSourceKitOptionsResponse(compilerArguments: args)
+    )
 
-    testClient.openDocument(text, uri: doc)
-    let openDiags = try await testClient.nextDiagnosticsNotification()
+    let (uri, _) = try project.openDocument("test.c")
+
+    let diags = try await project.testClient.nextDiagnosticsNotification()
+    XCTAssertEqual(diags.diagnostics.count, 1)
+
+    // Modify the build settings and inform the delegate.
+    // This should trigger a new publish diagnostics and we should no longer have errors.
+    let newSettings = TextDocumentSourceKitOptionsResponse(compilerArguments: args + ["-DFOO"])
+    try await project.buildServer().setBuildSettings(for: uri, to: newSettings)
+
+    try await repeatUntilExpectedResult {
+      guard let refreshedDiags = try? await project.testClient.nextDiagnosticsNotification(timeout: .seconds(1)) else {
+        return false
+      }
+      return refreshedDiags.diagnostics.count == 0
+    }
+  }
+
+  func testSwiftDocumentUpdatedBuildSettings() async throws {
+    let project = try await CustomBuildServerTestProject(
+      files: [
+        "test.swift": """
+        #if FOO
+        func foo() {}
+        #endif
+
+        foo()
+        """
+      ],
+      buildServer: TestBuildServer.self,
+      usePullDiagnostics: false
+    )
+
+    let args = try XCTUnwrap(
+      fallbackBuildSettings(
+        for: project.uri(for: "test.swift"),
+        language: .swift,
+        options: SourceKitLSPOptions.FallbackBuildSystemOptions()
+      )
+    ).compilerArguments
+
+    try await project.buildServer().setBuildSettings(
+      for: project.uri(for: "test.swift"),
+      to: TextDocumentSourceKitOptionsResponse(compilerArguments: args)
+    )
+
+    let (uri, _) = try project.openDocument("test.swift")
+    let diags1 = try await project.testClient.nextDiagnosticsNotification()
+    XCTAssertEqual(diags1.diagnostics.count, 1)
+
+    // Modify the build settings and inform the delegate.
+    // This should trigger a new publish diagnostics and we should no longer have errors.
+    let newSettings = TextDocumentSourceKitOptionsResponse(compilerArguments: args + ["-DFOO"])
+    try await project.buildServer().setBuildSettings(for: uri, to: newSettings)
+
+    // No expected errors here because we fixed the settings.
+    let diags2 = try await project.testClient.nextDiagnosticsNotification()
+    XCTAssertEqual(diags2.diagnostics.count, 0)
+  }
+
+  func testClangdDocumentFallbackWithholdsDiagnostics() async throws {
+    let project = try await CustomBuildServerTestProject(
+      files: [
+        "test.c": """
+        #ifdef FOO
+        static void foo() {}
+        #endif
+
+        int main() {
+          foo();
+          return 0;
+        }
+        """
+      ],
+      buildServer: TestBuildServer.self,
+      usePullDiagnostics: false
+    )
+
+    let args = [try project.uri(for: "test.c").pseudoPath, "-DDEBUG"]
+
+    let (uri, _) = try project.openDocument("test.c")
+    let openDiags = try await project.testClient.nextDiagnosticsNotification()
     // Expect diagnostics to be withheld.
     XCTAssertEqual(openDiags.diagnostics.count, 0)
-    XCTAssertEqual(text, try documentManager.latestSnapshot(doc).text)
 
     // Modify the build settings and inform the delegate.
     // This should trigger a new publish diagnostics and we should see a diagnostic.
     let newSettings = TextDocumentSourceKitOptionsResponse(compilerArguments: args)
-    await buildServer.setBuildSettings(for: doc, to: newSettings)
+    try await project.buildServer().setBuildSettings(for: uri, to: newSettings)
 
-    let refreshedDiags = try await testClient.nextDiagnosticsNotification()
+    let refreshedDiags = try await project.testClient.nextDiagnosticsNotification()
     XCTAssertEqual(refreshedDiags.diagnostics.count, 1)
-    XCTAssertEqual(text, try documentManager.latestSnapshot(doc).text)
   }
 
   func testSwiftDocumentFallbackWithholdsSemanticDiagnostics() async throws {
-    let doc = DocumentURI(for: .swift)
-
-    // Primary settings must be different than the fallback settings.
-    let fallbackSettings = fallbackBuildSettings(
-      for: doc,
-      language: .swift,
-      options: SourceKitLSPOptions.FallbackBuildSystemOptions()
-    )!
-    let primarySettings = TextDocumentSourceKitOptionsResponse(
-      compilerArguments: fallbackSettings.compilerArguments + ["-DPRIMARY"],
-      workingDirectory: fallbackSettings.workingDirectory
-    )
-
-    let text = """
+    let project = try await CustomBuildServerTestProject(
+      files: [
+        "test.swift": """
         #if FOO
         func foo() {}
         #endif
 
         foo()
         func
-      """
+        """
+      ],
+      buildServer: TestBuildServer.self,
+      usePullDiagnostics: false
+    )
 
-    let documentManager = self.testClient.server.documentManager
+    // Primary settings must be different than the fallback settings.
+    let fallbackSettings = try XCTUnwrap(
+      fallbackBuildSettings(
+        for: project.uri(for: "test.swift"),
+        language: .swift,
+        options: SourceKitLSPOptions.FallbackBuildSystemOptions()
+      )
+    )
+    let primarySettings = TextDocumentSourceKitOptionsResponse(
+      compilerArguments: fallbackSettings.compilerArguments + ["-DPRIMARY"],
+      workingDirectory: fallbackSettings.workingDirectory
+    )
 
-    testClient.openDocument(text, uri: doc)
-    let openDiags = try await testClient.nextDiagnosticsNotification()
+    let (uri, _) = try project.openDocument("test.swift")
+    let openDiags = try await project.testClient.nextDiagnosticsNotification()
     XCTAssertEqual(openDiags.diagnostics.count, 1)
-    XCTAssertEqual(text, try documentManager.latestSnapshot(doc).text)
 
     // Swap from fallback settings to primary build server settings.
-    await buildServer.setBuildSettings(for: doc, to: primarySettings)
+    try await project.buildServer().setBuildSettings(for: uri, to: primarySettings)
 
     // Two errors since `-DFOO` was not passed.
-    let refreshedDiags = try await testClient.nextDiagnosticsNotification()
+    let refreshedDiags = try await project.testClient.nextDiagnosticsNotification()
     XCTAssertEqual(refreshedDiags.diagnostics.count, 2)
   }
 }


### PR DESCRIPTION
I suspect that we don’t wait for `TestSourceKitLSPClient` to finish deinitializing (and thus waiting for the shutdown response) when we destroy it in `tearDown` based on the logs in https://ci.swift.org/job/oss-swift-incremental-RA-macos-apple-silicon/9004 (rdar://160344405).

Since I generally dislike the `setUp` and `tearDown` methods and we have `CustomBuildServerTestProject` now to model a setup of a SourceKitLSP server with a custom build server, use that instead of manually hooking up the build server through a workspace.