### PR TITLE
Remove errant test

### DIFF
--- a/Tests/SourceKitLSPTests/FormattingTests.swift
+++ b/Tests/SourceKitLSPTests/FormattingTests.swift
@@ -284,7 +284,6 @@ final class FormattingTests: XCTestCase {
     let edits = try XCTUnwrap(response)
     let formattedSource = apply(edits: edits, to: source)
 
-    XCTAssert(edits.allSatisfy { $0.newText.allSatisfy(\.isWhitespace) })
     XCTAssertEqual(
       formattedSource,
       #"""


### PR DESCRIPTION
Because of a difference in algorithms, the linear-space `CollectionDifference` algorithm includes some non-whitespace changes for this test example.

The current algorithm only identifies whitespace as differences, but the updated algorithm includes both a removal and insertion of the "A" character here: https://github.com/natecook1000/sourcekit-lsp/blob/46c99dabc4acf116a572fd58ae162a83b61e6cec/Tests/SourceKitLSPTests/FormattingTests.swift#L266