### PR TITLE
Remove SwiftPM dependency from SwiftLanguageService

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -616,9 +616,6 @@ var targets: [Target] = [
       .product(name: "Crypto", package: "swift-crypto"),
       .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
     ]
-      + swiftPMDependency([
-        .product(name: "SwiftPM-auto", package: "swift-package-manager")
-      ])
       + swiftSyntaxDependencies([
         "SwiftBasicFormat",
         "SwiftDiagnostics",

--- a/Sources/SwiftLanguageService/CodeActions/PackageManifestEdits.swift
+++ b/Sources/SwiftLanguageService/CodeActions/PackageManifestEdits.swift
@@ -17,8 +17,6 @@ import SwiftParser
 @_spi(PackageRefactor) import SwiftRefactor
 import SwiftSyntax
 
-import struct Basics.RelativePath
-
 /// Syntactic code action provider to provide refactoring actions that
 /// edit a package manifest.
 struct PackageManifestEdits: SyntaxCodeActionProvider {


### PR DESCRIPTION
This was needed for the package manifest refactorings, but they're now provided by swift-syntax instead.