### PR TITLE
Make `ConvertStringConcatenationToStringInterpolation` backward compa…

### DIFF
--- a/Sources/SwiftLanguageService/CodeActions/ConvertStringConcatenationToStringInterpolation.swift
+++ b/Sources/SwiftLanguageService/CodeActions/ConvertStringConcatenationToStringInterpolation.swift
@@ -69,6 +69,12 @@ struct ConvertStringConcatenationToStringInterpolation: SyntaxRefactoringProvide
     )
   }
 
+  @available(*, deprecated, message: "This method is deprecated. Please use throwing version instead.")
+  static func refactor(syntax: SequenceExprSyntax, in context: Void) -> SequenceExprSyntax? {
+    let newRefactor: (SequenceExprSyntax, Void) throws -> SequenceExprSyntax = refactor(syntax:in:)
+    return try? newRefactor(syntax, context)
+  }
+
   /// If `exprList` is a valid string concatenation, returns 1) all elements in `exprList` with concat operators
   /// stripped and 2) the longest pounds amongst all string literals, otherwise returns nil.
   ///


### PR DESCRIPTION
…tible

I have changed `EditRefactoringProvider` in swift-syntax to require throwing `refactor(syntax:in:)` but we need to make it possible to build sourcekit-lsp with an older version of swift-syntax as well.

This change re-introduces the original `refactor(syntax:in:)` that produces an optional value and marks it as deprecated.