### PR TITLE
Drop support for building with Swift 6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import Foundation
 import PackageDescription

--- a/Sources/BuildServerIntegration/LegacyBuildServer.swift
+++ b/Sources/BuildServerIntegration/LegacyBuildServer.swift
@@ -20,8 +20,8 @@ import SKOptions
 import SwiftExtensions
 import ToolchainRegistry
 
-#if compiler(>=6.3)
-#warning("We have had a one year transition period to the pull based build server. Consider removing this build server")
+#if compiler(>=6.5)
+#warning("We have had a two year transition period to the pull based build server. Consider removing this build server")
 #endif
 
 /// Bridges the gap between the legacy push-based BSP settings model and the new pull based BSP settings model.

--- a/Sources/CompletionScoring/Utilities/SwiftExtensions.swift
+++ b/Sources/CompletionScoring/Utilities/SwiftExtensions.swift
@@ -289,11 +289,6 @@ protocol ContiguousZeroBasedIndexedCollection: Collection where Index == Int {
   var indices: Range<Int> { get }
 }
 
-#if compiler(<6.2)
-/// Provide a compatibility layer for `SendableMetatype` if it doesn't exist in the compiler
-typealias SendableMetatype = Any
-#endif
-
 extension ContiguousZeroBasedIndexedCollection {
   func slicedConcurrentForEachSliceRange(body: @Sendable (Range<Index>) -> Void) where Self: SendableMetatype {
     // We want to use `DispatchQueue.concurrentPerform`, but we want to be called only a few times. So that we

--- a/Sources/SourceKitD/SourceKitD.swift
+++ b/Sources/SourceKitD/SourceKitD.swift
@@ -173,18 +173,6 @@ package actor SourceKitD {
     pluginPaths: PluginPaths?
   ) async throws -> SourceKitD {
     try await SourceKitDRegistry.shared.getOrAdd(dylibPath, pluginPaths: pluginPaths) {
-      #if canImport(Darwin)
-      #if compiler(>=6.3)
-      #warning("Remove this when we no longer need to support sourcekitd_plugin_initialize")
-      #endif
-      if let pluginPaths {
-        try setenv(
-          name: "SOURCEKIT_LSP_PLUGIN_SOURCEKITD_PATH_\(pluginPaths.clientPlugin.realpath.filePath)",
-          value: dylibPath.filePath,
-          override: false
-        )
-      }
-      #endif
       return try SourceKitD(dylib: dylibPath, pluginPaths: pluginPaths)
     }
   }

--- a/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActionProvider.swift
+++ b/Sources/SwiftLanguageService/CodeActions/SyntaxCodeActionProvider.swift
@@ -16,11 +16,6 @@ import SourceKitLSP
 import SwiftRefactor
 import SwiftSyntax
 
-#if compiler(<6.2)
-/// Provide a compatibility layer for `SendableMetatype` if it doesn't exist in the compiler
-typealias SendableMetatype = Any
-#endif
-
 /// Describes types that provide one or more code actions based on purely
 /// syntactic information.
 protocol SyntaxCodeActionProvider: SendableMetatype {

--- a/Sources/SwiftSourceKitClientPlugin/ClientPlugin.swift
+++ b/Sources/SwiftSourceKitClientPlugin/ClientPlugin.swift
@@ -16,45 +16,11 @@ import SourceKitD
 import SwiftExtensions
 import SwiftSourceKitPluginCommon
 
-#if compiler(>=6.3)
-#warning("Remove sourcekitd_plugin_initialize when we no longer support toolchains that call it")
-#endif
-
 /// Legacy plugin initialization logic in which sourcekitd does not inform the plugin about the sourcekitd path it was
 /// loaded from.
 @_cdecl("sourcekitd_plugin_initialize")
 public func sourcekitd_plugin_initialize(_ params: sourcekitd_api_plugin_initialize_params_t) {
-  #if canImport(Darwin)
-  var dlInfo = Dl_info()
-  dladdr(#dsohandle, &dlInfo)
-  let path = String(cString: dlInfo.dli_fname)
-  let clientPluginDylibUrl = URL(fileURLWithPath: path, isDirectory: false)
-  var url = clientPluginDylibUrl
-  while url.pathExtension != "framework" && url.lastPathComponent != "/" {
-    url.deleteLastPathComponent()
-  }
-  url =
-    url
-    .deletingLastPathComponent()
-    .appendingPathComponent("sourcekitd.framework")
-    .appendingPathComponent("sourcekitd")
-  if !FileManager.default.fileExists(at: url),
-    let clientPluginDylibUrlRealpath = try? clientPluginDylibUrl.realpath.filePath,
-    let sourcekitdPath = ProcessInfo.processInfo.environment[
-      "SOURCEKIT_LSP_PLUGIN_SOURCEKITD_PATH_\(clientPluginDylibUrlRealpath)"
-    ]
-  {
-    // When using a SourceKit plugin from the build directory, we can't find sourcekitd relative to the plugin.
-    // Respect the sourcekitd path that was passed to us via an environment variable from
-    // `SourceKitD.getOrCreate`.
-    url = URL(fileURLWithPath: sourcekitdPath)
-  }
-  try! url.filePath.withCString { sourcekitdPath in
-    sourcekitd_plugin_initialize_2(params, sourcekitdPath)
-  }
-  #else
-  fatalError("sourcekitd_plugin_initialize is not supported on non-Darwin platforms")
-  #endif
+  fatalError("sourcekitd_plugin_initialize has been removed in favor of sourcekitd_plugin_initialize_2")
 }
 
 @_cdecl("sourcekitd_plugin_initialize_2")

--- a/Sources/SwiftSourceKitPlugin/Plugin.swift
+++ b/Sources/SwiftSourceKitPlugin/Plugin.swift
@@ -157,41 +157,11 @@ final class RequestHandler: Sendable {
   }
 }
 
-#if compiler(>=6.3)
-#warning("Remove sourcekitd_plugin_initialize when we no longer support toolchains that call it")
-#endif
-
 /// Legacy plugin initialization logic in which sourcekitd does not inform the plugin about the sourcekitd path it was
 /// loaded from.
 @_cdecl("sourcekitd_plugin_initialize")
 public func sourcekitd_plugin_initialize(_ params: sourcekitd_api_plugin_initialize_params_t) {
-  #if canImport(Darwin)
-  var dlInfo = Dl_info()
-  dladdr(#dsohandle, &dlInfo)
-  let path = String(cString: dlInfo.dli_fname)
-  var url = URL(fileURLWithPath: path, isDirectory: false)
-  while url.pathExtension != "framework" && url.lastPathComponent != "/" {
-    url.deleteLastPathComponent()
-  }
-  url =
-    url
-    .deletingLastPathComponent()
-    .appendingPathComponent("sourcekitd.framework")
-    .appendingPathComponent("sourcekitd")
-  if FileManager.default.fileExists(at: url) {
-    try! url.filePath.withCString { sourcekitdPath in
-      sourcekitd_plugin_initialize_2(params, sourcekitdPath)
-    }
-  } else {
-    // When using a SourceKit plugin from the build directory, we can't find sourcekitd relative to the plugin.
-    // Since sourcekitd_plugin_initialize is only called on Darwin from Xcode toolchains, we know that we are getting
-    // called from an XPC sourcekitd. Thus, all sourcekitd symbols that we need should be loaded in the current process
-    // already and we can use `RTLD_DEFAULT` for the sourcekitd library.
-    sourcekitd_plugin_initialize_2(params, "SOURCEKIT_LSP_PLUGIN_PARENT_LIBRARY_RTLD_DEFAULT")
-  }
-  #else
-  fatalError("sourcekitd_plugin_initialize is not supported on non-Darwin platforms")
-  #endif
+  fatalError("sourcekitd_plugin_initialize has been removed in favor of sourcekitd_plugin_initialize_2")
 }
 
 #if canImport(Darwin)


### PR DESCRIPTION
Swift 6.2 has been released, so we no longer need to support building and testing SourceKit-LSP using Swift 6.1