### PR TITLE
Use `activeProcessorCount` instead of `processorCount` in short-lived use-cases

### DIFF
--- a/Sources/CompletionScoring/Text/CandidateBatch.swift
+++ b/Sources/CompletionScoring/Text/CandidateBatch.swift
@@ -440,7 +440,7 @@ extension Pattern {
     compactScratchArea(capacity: Self.totalCandidates(batches: batches)) { matchesScratchArea in
       let scoringWorkloads = ScoringWorkload.workloads(
         for: batches,
-        parallelism: ProcessInfo.processInfo.processorCount
+        parallelism: ProcessInfo.processInfo.activeProcessorCount
       )
       // `nonisolated(unsafe)` is fine because every iteration accesses a distinct index of the buffer.
       nonisolated(unsafe) let matchesScratchArea = matchesScratchArea

--- a/Sources/CompletionScoring/Text/ScoredMatchSelector.swift
+++ b/Sources/CompletionScoring/Text/ScoredMatchSelector.swift
@@ -28,7 +28,7 @@ package class ScoredMatchSelector {
   package init(batches: [CandidateBatch]) {
     let scoringWorkloads = ScoringWorkload.workloads(
       for: batches,
-      parallelism: ProcessInfo.processInfo.processorCount
+      parallelism: ProcessInfo.processInfo.activeProcessorCount
     )
     threadWorkloads = scoringWorkloads.map { scoringWorkload in
       ThreadWorkload(allBatches: batches, slices: scoringWorkload.slices)

--- a/Sources/CompletionScoring/Utilities/SwiftExtensions.swift
+++ b/Sources/CompletionScoring/Utilities/SwiftExtensions.swift
@@ -303,8 +303,8 @@ extension ContiguousZeroBasedIndexedCollection {
     // extra jobs should let the performance cores pull a disproportionate amount of work items. More fine
     // granularity also helps if the work items aren't all the same difficulty, for the same reason.
 
-    // Defensive against `processorCount` failing
-    let sliceCount = Swift.min(Swift.max(ProcessInfo.processInfo.processorCount * 32, 1), count)
+    // Defensive against `activeProcessorCount` failing
+    let sliceCount = Swift.min(Swift.max(ProcessInfo.processInfo.activeProcessorCount * 32, 1), count)
     let count = self.count
     DispatchQueue.concurrentPerform(iterations: sliceCount) { sliceIndex in
       precondition(sliceCount >= 1)

--- a/Sources/SemanticIndex/TaskScheduler.swift
+++ b/Sources/SemanticIndex/TaskScheduler.swift
@@ -644,14 +644,6 @@ package actor TaskScheduler<TaskDescription: TaskDescriptionProtocol> {
   }
 }
 
-extension TaskScheduler {
-  package static var forTesting: TaskScheduler {
-    return .init(maxConcurrentTasksByPriority: [
-      (.low, ProcessInfo.processInfo.processorCount)
-    ])
-  }
-}
-
 // MARK: - Collection utilities
 
 fileprivate extension Collection where Element: Comparable {

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -138,6 +138,9 @@ package actor SourceKitLSPServer {
     isIndexingPaused: Bool,
     options: SourceKitLSPOptions
   ) -> [(priority: TaskPriority, maxConcurrentTasks: Int)] {
+    // Use `processorCount` instead of `activeProcessorCount` here because `activeProcessorCount` may be decreased due
+    // to thermal throttling. We don't want to consistently limit the concurrent indexing tasks if SourceKit-LSP was
+    // launched during a period of thermal throttling.
     let processorCount = ProcessInfo.processInfo.processorCount
     let lowPriorityCores =
       if isIndexingPaused {

--- a/Sources/SourceKitLSP/SyntacticTestIndex.swift
+++ b/Sources/SourceKitLSP/SyntacticTestIndex.swift
@@ -110,7 +110,7 @@ actor SyntacticTestIndex {
       // in O(number of pending tasks), since we need to scan for dependency edges to add, which would make scanning files
       // be O(number of files).
       // Over-subscribe the processor count in case one batch finishes more quickly than another.
-      let batches = testFiles.partition(intoNumberOfBatches: ProcessInfo.processInfo.processorCount * 4)
+      let batches = testFiles.partition(intoNumberOfBatches: ProcessInfo.processInfo.activeProcessorCount * 4)
       await batches.concurrentForEach { filesInBatch in
         for uri in filesInBatch {
           await self.rescanFileAssumingOnQueue(uri)
@@ -194,7 +194,7 @@ actor SyntacticTestIndex {
     // in O(number of pending tasks), since we need to scan for dependency edges to add, which would make scanning files
     // be O(number of files).
     // Over-subscribe the processor count in case one batch finishes more quickly than another.
-    let batches = uris.partition(intoNumberOfBatches: ProcessInfo.processInfo.processorCount * 4)
+    let batches = uris.partition(intoNumberOfBatches: ProcessInfo.processInfo.activeProcessorCount * 4)
     for batch in batches {
       self.indexingQueue.async(priority: .low, metadata: .index(Set(batch))) {
         for uri in batch {

--- a/Sources/SwiftExtensions/AsyncUtils.swift
+++ b/Sources/SwiftExtensions/AsyncUtils.swift
@@ -135,7 +135,7 @@ package func withCancellableCheckedThrowingContinuation<Handle: Sendable, Result
 extension Collection where Self: Sendable, Element: Sendable {
   /// Transforms all elements in the collection concurrently and returns the transformed collection.
   package func concurrentMap<TransformedElement: Sendable>(
-    maxConcurrentTasks: Int = ProcessInfo.processInfo.processorCount,
+    maxConcurrentTasks: Int = ProcessInfo.processInfo.activeProcessorCount,
     _ transform: @escaping @Sendable (Element) async -> TransformedElement
   ) async -> [TransformedElement] {
     let indexedResults = await withTaskGroup(of: (index: Int, element: TransformedElement).self) { taskGroup in


### PR DESCRIPTION
According to https://developer.apple.com/documentation/foundation/processinfo/activeprocessorcount

> Whereas the processorCount property reports the number of advertised processing cores, the activeProcessorCount property reflects the actual number of active processing cores on the system. There are a number of different factors that may cause a core to not be active, including boot arguments, thermal throttling, or a manufacturing defect.

For short-lived workloads like `concurrentMap` we want to parallelize across the number of cores that are currently active, so use `activeProcessorCount` instead. The only case where we want to continue using `processorCount` is the computation of concurrent tasks for `TaskScheduler` because the value is stored for the lifetime of the SourceKit-LSP process and we don’t want to limit parallelism if SourceKit-LSP was launched during a time of thermal throttling.

I stumbled across this while working on #2302