### PR TITLE
Do not block SourceKit-LSP functionality when a build server takes long to initialize

### DIFF
--- a/Sources/DocumentationLanguageService/DoccDocumentationHandler.swift
+++ b/Sources/DocumentationLanguageService/DoccDocumentationHandler.swift
@@ -101,7 +101,7 @@ extension DocumentationLanguageService {
     }
     guard let moduleName, symbolName == moduleName else {
       // This is a symbol extension page. Find the symbol so that we can include it in the request.
-      guard let index = workspace.index(checkedFor: .deletedFiles) else {
+      guard let index = await workspace.index(checkedFor: .deletedFiles) else {
         throw ResponseError.requestFailed(doccDocumentationError: .indexNotAvailable)
       }
       return try await sourceKitLSPServer.withOnDiskDocumentManager { onDiskDocumentManager in
@@ -206,7 +206,7 @@ extension DocumentationLanguageService {
       return nil
     }
     let catalogIndex = try await documentationManager.catalogIndex(for: catalogURL)
-    guard let index = workspace.index(checkedFor: .deletedFiles) else {
+    guard let index = await workspace.index(checkedFor: .deletedFiles) else {
       return nil
     }
     let symbolInformation = try await index.doccSymbolInformation(

--- a/Sources/SourceKitLSP/IndexProgressManager.swift
+++ b/Sources/SourceKitLSP/IndexProgressManager.swift
@@ -83,7 +83,7 @@ actor IndexProgressManager {
       return
     }
     var status = IndexProgressStatus.upToDate
-    for indexManager in await sourceKitLSPServer.workspaces.compactMap({ $0.semanticIndexManager }) {
+    for indexManager in await sourceKitLSPServer.workspaces.asyncCompactMap({ await $0.semanticIndexManager }) {
       status = status.merging(with: await indexManager.progressStatus)
     }
 

--- a/Sources/SourceKitLSP/Rename.swift
+++ b/Sources/SourceKitLSP/Rename.swift
@@ -290,7 +290,7 @@ extension SourceKitLSPServer {
     // location. This way we are still able to rename occurrences in files where eg. only one line has been modified but
     // all the line:column locations of occurrences are still up-to-date.
     // This should match the check level in prepareRename.
-    guard let usr = renameResult.usr, let index = workspace.index(checkedFor: .deletedFiles) else {
+    guard let usr = renameResult.usr, let index = await workspace.index(checkedFor: .deletedFiles) else {
       // We don't have enough information to perform a cross-file rename.
       return renameResult.edits
     }
@@ -442,7 +442,7 @@ extension SourceKitLSPServer {
     var prepareRenameResult = languageServicePrepareRename.prepareRename
 
     guard
-      let index = workspace.index(checkedFor: .deletedFiles),
+      let index = await workspace.index(checkedFor: .deletedFiles),
       let usr = languageServicePrepareRename.usr,
       let oldName = try await self.getCrossLanguageName(forUsr: usr, workspace: workspace, index: index),
       var definitionName = oldName.definitionName

--- a/Sources/SourceKitLSP/TestDiscovery.swift
+++ b/Sources/SourceKitLSP/TestDiscovery.swift
@@ -207,7 +207,7 @@ extension SourceKitLSPServer {
     //  - For all files that don't have any in-memory modifications, include swift-testing tests from the syntactic test
     //    index.
     //  - All files that have in-memory modifications are syntactically scanned for tests here.
-    let index = workspace.index(checkedFor: .inMemoryModifiedFiles(documentManager))
+    let index = await workspace.index(checkedFor: .inMemoryModifiedFiles(documentManager))
 
     // TODO: Remove this workaround once https://github.com/swiftlang/swift/issues/75600 is fixed
     func documentManagerHasInMemoryModifications(_ uri: DocumentURI) -> Bool {
@@ -252,7 +252,7 @@ extension SourceKitLSPServer {
     )
     let filesWithTestsFromSemanticIndex = Set(testsFromSemanticIndex.map(\.testItem.location.uri))
 
-    let indexOnlyDiscardingDeletedFiles = workspace.index(checkedFor: .deletedFiles)
+    let indexOnlyDiscardingDeletedFiles = await workspace.index(checkedFor: .deletedFiles)
 
     let syntacticTestsToInclude =
       testsFromSyntacticIndex
@@ -334,7 +334,7 @@ extension SourceKitLSPServer {
     let indexCheckLevel: IndexCheckLevel =
       syntacticTests == nil ? .deletedFiles : .inMemoryModifiedFiles(documentManager)
 
-    if let index = workspace.index(checkedFor: indexCheckLevel) {
+    if let index = await workspace.index(checkedFor: indexCheckLevel) {
       var syntacticSwiftTestingTests: [AnnotatedTestItem] {
         syntacticTests?.filter { $0.testItem.style == TestStyle.swiftTesting } ?? []
       }

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -138,7 +138,7 @@ package actor SwiftLanguageService: LanguageService, Sendable {
   let syntaxTreeManager = SyntaxTreeManager()
 
   /// The `semanticIndexManager` of the workspace this language service was created for.
-  private let semanticIndexManager: SemanticIndexManager?
+  private let semanticIndexManagerTask: Task<SemanticIndexManager?, Never>
 
   nonisolated var keys: sourcekitd_api_keys { return sourcekitd.keys }
   nonisolated var requests: sourcekitd_api_requests { return sourcekitd.requests }
@@ -228,7 +228,7 @@ package actor SwiftLanguageService: LanguageService, Sendable {
     }
     self.sourcekitd = try await SourceKitD.getOrCreate(dylibPath: sourcekitd, pluginPaths: pluginPaths)
     self.capabilityRegistry = workspace.capabilityRegistry
-    self.semanticIndexManager = workspace.semanticIndexManager
+    self.semanticIndexManagerTask = workspace.semanticIndexManagerTask
     self.hooks = hooks
     self.state = .connected
     self.options = options
@@ -1084,7 +1084,7 @@ extension SwiftLanguageService {
       case .macroExpansion, nil: break
       }
 
-      await semanticIndexManager?.prepareFileForEditorFunctionality(
+      await semanticIndexManagerTask.value?.prepareFileForEditorFunctionality(
         req.textDocument.uri.buildSettingsFile
       )
       let snapshot = try await self.latestSnapshot(for: req.textDocument.uri)

--- a/Sources/SwiftLanguageService/TestDiscovery.swift
+++ b/Sources/SwiftLanguageService/TestDiscovery.swift
@@ -33,7 +33,7 @@ extension SwiftLanguageService {
       return nil
     }
     let snapshot = try documentManager.latestSnapshot(uri)
-    let semanticSymbols = workspace.index(checkedFor: .deletedFiles)?.symbols(inFilePath: snapshot.uri.pseudoPath)
+    let semanticSymbols = await workspace.index(checkedFor: .deletedFiles)?.symbols(inFilePath: snapshot.uri.pseudoPath)
     let xctestSymbols = await SyntacticSwiftXCTestScanner.findTestSymbols(
       in: snapshot,
       syntaxTreeManager: syntaxTreeManager

--- a/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
+++ b/Tests/BuildServerIntegrationTests/SwiftPMBuildServerTests.swift
@@ -153,7 +153,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -219,7 +220,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -290,7 +292,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(swiftPM: options),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -335,7 +338,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -376,7 +380,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -438,7 +443,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -510,7 +516,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -570,7 +577,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -654,7 +662,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -714,7 +723,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -799,7 +809,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -842,7 +853,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -920,7 +932,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
 
@@ -1047,7 +1060,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
       let settings = await buildServerManager.buildSettingsInferredFromMainFile(
@@ -1081,7 +1095,8 @@ struct SwiftPMBuildServerTests {
         toolchainRegistry: .forTesting,
         options: SourceKitLSPOptions(),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       await buildServerManager.waitForUpToDateBuildGraph()
       let settings = await buildServerManager.buildSettingsInferredFromMainFile(

--- a/Tests/SwiftSourceKitPluginTests/PluginSwiftPMTestProject.swift
+++ b/Tests/SwiftSourceKitPluginTests/PluginSwiftPMTestProject.swift
@@ -41,7 +41,8 @@ final class PluginSwiftPMTestProject {
         toolchainRegistry: .forTesting,
         options: try .testDefault(backgroundIndexing: false),
         connectionToClient: DummyBuildServerManagerConnectionToClient(),
-        buildServerHooks: BuildServerHooks()
+        buildServerHooks: BuildServerHooks(),
+        createMainFilesProvider: { _, _ in nil }
       )
       _buildServerManager = buildServerManager
       return buildServerManager


### PR DESCRIPTION
We previously waited for the initialization response from the build server during the creation of a `Workspace` so that we could create a `SemanticIndexManager` with the index store path etc. that was returned by the `build/initialize` response. This caused all functionality (including syntactic) of SourceKit-LSP to be blocked until the build server was initialized.

Change the computation of the `SemanticIndexManager` and related types to happen in the background so that we can provide functionality that doesn’t rely on the build server immediately.

Fixes #2304