### PR TITLE
Adjust test to reflect _Concurrency module hiding

### DIFF
--- a/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
+++ b/Tests/SourceKitLSPTests/SwiftInterfaceTests.swift
@@ -104,7 +104,7 @@ final class SwiftInterfaceTests: XCTestCase {
       uri: project.fileURI,
       position: project.positions["3️⃣"],
       testClient: project.testClient,
-      swiftInterfaceFile: "_Concurrency.swiftinterface",
+      swiftInterfaceFile: "Swift.swiftinterface",
       linePrefix: "@inlinable public func withTaskGroup"
     )
   }


### PR DESCRIPTION
swiftlang/swift#84358 makes the `_Concurrency` module behave like a cross-import overlay of `Swift`. This changes downstream behavior in SourceKit-LSP. Update a test to reflect that change.