### PR TITLE
Enable `InferIsolatedConformances` and `NonisolatedNonsendingByDefault`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,8 @@ var globalSwiftSettings: [SwiftSetting] {
   var result: [SwiftSetting] = [
     .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
+    .enableUpcomingFeature("InferIsolatedConformances"),
+    .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
   ]
   if noSwiftPMDependency {
     result += [.define("NO_SWIFTPM_DEPENDENCY")]

--- a/Sources/SKLogging/LoggingScope.swift
+++ b/Sources/SKLogging/LoggingScope.swift
@@ -54,7 +54,7 @@ package func withLoggingSubsystemAndScope<Result>(
 package func withLoggingSubsystemAndScope<Result>(
   subsystem: String,
   scope: String?,
-  @_inheritActorContext _ operation: @Sendable () async throws -> Result
+  @_inheritActorContext _ operation: @Sendable @concurrent () async throws -> Result
 ) async rethrows -> Result {
   return try await LoggingScope.$_subsystem.withValue(subsystem) {
     return try await LoggingScope.$_scope.withValue(scope, operation: operation)
@@ -84,7 +84,7 @@ package func withLoggingScope<Result>(
 /// - SeeAlso: ``withLoggingScope(_:_:)-6qtga``
 package func withLoggingScope<Result>(
   _ scope: String,
-  @_inheritActorContext _ operation: @Sendable () async throws -> Result
+  @_inheritActorContext _ operation: @Sendable @concurrent () async throws -> Result
 ) async rethrows -> Result {
   return try await LoggingScope.$_scope.withValue(
     scope,

--- a/Sources/SKLogging/OrLog.swift
+++ b/Sources/SKLogging/OrLog.swift
@@ -41,7 +41,7 @@ package func orLog<R>(
 package func orLog<R>(
   _ prefix: @autoclosure () -> String,
   level: LogLevel = .error,
-  @_inheritActorContext _ block: @Sendable () async throws -> R?
+  _ block: () async throws -> R?
 ) async -> R? {
   do {
     return try await block()

--- a/Sources/SKTestSupport/Utils.swift
+++ b/Sources/SKTestSupport/Utils.swift
@@ -98,7 +98,7 @@ package func testScratchDir(testName: String = #function) throws -> URL {
 /// The temporary directory will be deleted at the end of `directory` unless the
 /// `SOURCEKIT_LSP_KEEP_TEST_SCRATCH_DIR` environment variable is set.
 package func withTestScratchDir<T>(
-  @_inheritActorContext _ body: @Sendable (URL) async throws -> T,
+  _ body: (URL) async throws -> T,
   testName: String = #function
 ) async throws -> T {
   let scratchDirectory = try testScratchDir(testName: testName)

--- a/Sources/SwiftExtensions/AsyncUtils.swift
+++ b/Sources/SwiftExtensions/AsyncUtils.swift
@@ -24,7 +24,7 @@ package actor RefCountedCancellableTask<Success: Sendable> {
   /// Whether the task has been cancelled.
   package private(set) var isCancelled: Bool = false
 
-  package init(priority: TaskPriority? = nil, operation: @escaping @Sendable () async throws -> Success) {
+  package init(priority: TaskPriority? = nil, operation: @escaping @Sendable @concurrent () async throws -> Success) {
     self.task = Task(priority: priority, operation: operation)
   }
 

--- a/Sources/SwiftExtensions/Sequence+AsyncMap.swift
+++ b/Sources/SwiftExtensions/Sequence+AsyncMap.swift
@@ -13,7 +13,7 @@
 extension Sequence {
   /// Just like `Sequence.map` but allows an `async` transform function.
   package func asyncMap<T>(
-    @_inheritActorContext _ transform: @Sendable (Element) async throws -> T
+    _ transform: (Element) async throws -> T
   ) async rethrows -> [T] {
     var result: [T] = []
     result.reserveCapacity(self.underestimatedCount)
@@ -27,7 +27,7 @@ extension Sequence {
 
   /// Just like `Sequence.flatMap` but allows an `async` transform function.
   package func asyncFlatMap<SegmentOfResult: Sequence>(
-    @_inheritActorContext _ transform: @Sendable (Element) async throws -> SegmentOfResult
+    _ transform: (Element) async throws -> SegmentOfResult
   ) async rethrows -> [SegmentOfResult.Element] {
     var result: [SegmentOfResult.Element] = []
     result.reserveCapacity(self.underestimatedCount)
@@ -41,7 +41,7 @@ extension Sequence {
 
   /// Just like `Sequence.compactMap` but allows an `async` transform function.
   package func asyncCompactMap<T>(
-    @_inheritActorContext _ transform: @Sendable (Element) async throws -> T?
+    _ transform: (Element) async throws -> T?
   ) async rethrows -> [T] {
     var result: [T] = []
 
@@ -56,7 +56,7 @@ extension Sequence {
 
   /// Just like `Sequence.map` but allows an `async` transform function.
   package func asyncFilter(
-    @_inheritActorContext _ predicate: @Sendable (Element) async throws -> Bool
+    _ predicate: (Element) async throws -> Bool
   ) async rethrows -> [Element] {
     var result: [Element] = []
 
@@ -70,9 +70,7 @@ extension Sequence {
   }
 
   /// Just like `Sequence.first` but allows an `async` predicate function.
-  package func asyncFirst(
-    @_inheritActorContext where predicate: @Sendable (Element) async throws -> Bool
-  ) async rethrows -> Element? {
+  package func asyncFirst(where predicate: (Element) async throws -> Bool) async rethrows -> Element? {
     for element in self {
       if try await predicate(element) {
         return element
@@ -84,7 +82,7 @@ extension Sequence {
 
   /// Just like `Sequence.contains` but allows an `async` predicate function.
   package func asyncContains(
-    @_inheritActorContext where predicate: @Sendable (Element) async throws -> Bool
+    where predicate: (Element) async throws -> Bool
   ) async rethrows -> Bool {
     return try await asyncFirst(where: predicate) != nil
   }


### PR DESCRIPTION
This allows us to easily get rid of some `@_inheritActorContext`. The others seem to be a little more tricky and I haven’t spent too much time at trying to figure out how to remove the attribute from those.