### PR TITLE
Add go-to-definition for symbols in doc comments, Markdown and Tutorial files

### DIFF
--- a/Sources/DocumentationLanguageService/DocCSymbolInformation.swift
+++ b/Sources/DocumentationLanguageService/DocCSymbolInformation.swift
@@ -38,10 +38,11 @@ struct DocCSymbolInformation {
   }
 
   func matches(_ link: DocCSymbolLink) -> Bool {
-    guard link.components.count == components.count else {
+    guard link.components.count <= components.count else {
       return false
     }
-    return zip(link.components, components).allSatisfy { linkComponent, symbolComponent in
+    let matchingSuffix = components.suffix(link.components.count)
+    return zip(link.components, matchingSuffix).allSatisfy { linkComponent, symbolComponent in
       linkComponent.name == symbolComponent.name && symbolComponent.information.matches(linkComponent.disambiguation)
     }
   }

--- a/Sources/DocumentationLanguageService/DocCSymbolInformation.swift
+++ b/Sources/DocumentationLanguageService/DocCSymbolInformation.swift
@@ -38,6 +38,15 @@ struct DocCSymbolInformation {
   }
 
   func matches(_ link: DocCSymbolLink) -> Bool {
+    guard link.components.count == components.count else {
+      return false
+    }
+    return zip(link.components, components).allSatisfy { linkComponent, symbolComponent in
+      linkComponent.name == symbolComponent.name && symbolComponent.information.matches(linkComponent.disambiguation)
+    }
+  }
+
+  func matchesAsSuffix(_ link: DocCSymbolLink) -> Bool {
     guard link.components.count <= components.count else {
       return false
     }

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -10,12 +10,17 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BuildServerIntegration
 import Foundation
 import IndexStoreDB
 @_spi(SourceKitLSP) package import LanguageServerProtocol
+import Markdown
+@_spi(SourceKitLSP) import SKLogging
 package import SKOptions
+import SemanticIndex
 package import SourceKitLSP
 import SwiftExtensions
+import SwiftParser
 package import SwiftSyntax
 package import ToolchainRegistry
 
@@ -36,7 +41,8 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
 
   package static var experimentalCapabilities: [String: LSPAny] {
     return [
-      DoccDocumentationRequest.method: ["version": 1]
+      DoccDocumentationRequest.method: ["version": 1],
+      "definitionProvider": .bool(true),
     ]
   }
 
@@ -48,7 +54,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     workspace: Workspace
   ) async throws {
     self.sourceKitLSPServer = sourceKitLSPServer
-    self.documentationManager = DocCDocumentationManager(buildServerManager: workspace.buildServerManager)
+    self.documentationManager = DocCDocumentationManager(buildServerManager: workspace.buildServerManager);
   }
 
   package nonisolated func canHandle(toolchain: Toolchain) -> Bool {
@@ -99,5 +105,319 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     edits: [SwiftSyntax.SourceEdit]
   ) async {
     // The DocumentationLanguageService does not do anything with document events
+  }
+
+  package func definition(_ req: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
+    let snapshot = try self.documentManager.latestSnapshot(req.textDocument.uri)
+    let clickedSymbol: String?
+    switch snapshot.language {
+    case .swift:
+      clickedSymbol = extractSymbolFromDocComment(snapshot: snapshot, at: req.position)
+    case .markdown, .tutorial:
+      clickedSymbol = extractSymbolFromText(snapshot.text, at: req.position)
+    default:
+      return nil
+    }
+
+    guard let clickedSymbol else {
+      logger.debug("No symbol link found at the cursor position")
+      return nil
+    }
+
+    guard let symbolLink = DocCSymbolLink(linkString: clickedSymbol) else {
+      logger.debug("Failed to parse DocC symbol link from '\(clickedSymbol)'")
+      return nil
+    }
+
+    guard let sourceKitLSPServer else {
+      logger.debug("sourceKit-LSP server could not be resolved")
+      return nil
+    }
+
+    guard let workspace = await sourceKitLSPServer.workspaceForDocument(uri: req.textDocument.uri) else {
+      logger.debug("No workspace found for document \(req.textDocument.uri)")
+      return nil
+    }
+
+    guard let index = await workspace.index(checkedFor: .deletedFiles) else {
+      logger.debug("No index available for workspace")
+      return nil
+    }
+
+    let occurrence = try await sourceKitLSPServer.withOnDiskDocumentManager { onDiskDocumentManager in
+      try await index.primaryDefinitionOrDeclarationOccurrence(
+        ofDocCSymbolLink: symbolLink,
+        fetchSymbolGraph: { location in
+          guard let uri = location.uri else { return nil }
+          return try await workspace.primaryLanguageService(
+            for: uri,
+            workspace.buildServerManager.defaultLanguageInCanonicalTarget(for: uri)
+          ).symbolGraph(forOnDiskContentsAt: location, in: workspace, manager: onDiskDocumentManager)
+        }
+      )
+    }
+
+    guard let targetLocation = occurrence?.location.lspLocation else {
+      logger.debug("No definition occurrence found in the index for symbol link '\(clickedSymbol)'")
+      return nil
+    }
+    return .locations([targetLocation])
+  }
+
+  /// Walks the Markdown/DocC AST looking for symbol link
+  /// that contains a given source position.
+  private struct SymbolLocator: MarkupWalker {
+    let target: Markdown.SourceLocation
+    var found: String?
+
+    init(target: Markdown.SourceLocation) {
+      self.target = target
+    }
+
+    private func contains(_ range: Markdown.SourceRange?) -> Bool {
+      guard let range else { return false }
+      return range.lowerBound <= target && target < range.upperBound
+    }
+
+    mutating func visitSymbolLink(_ symbolLink: SymbolLink) {
+      guard
+        found == nil,
+        contains(symbolLink.range),
+        let destination = symbolLink.destination,
+        let range = symbolLink.range
+      else {
+        return
+      }
+      // Symbol links are delimited by two backticks (``Foo/bar``),
+      // so the destination starts two columns past the start of the link.
+      let destinationStartColumn = range.lowerBound.column + 2
+      let relativeColumn = target.column - destinationStartColumn
+      guard relativeColumn >= 0 else {
+        return
+      }
+      let components = destination.split(separator: "/")
+      var currentLength = 0
+
+      for (index, component) in components.enumerated() {
+        let end = currentLength + component.utf8.count
+        if relativeColumn < end {
+          found = components[0...index].joined(separator: "/")
+          return
+        }
+        currentLength = end + 1  // Skip '/'
+      }
+      found = destination
+    }
+
+    mutating func defaultVisit(_ markup: any Markup) {
+      guard found == nil else { return }
+      descendInto(markup)
+    }
+  }
+
+  private func extractSymbolFromText(_ text: String, at position: Position) -> String? {
+    let lines = text.components(separatedBy: "\n")
+    var column = position.utf16index + 1
+    if position.line < lines.count {
+      column = utf8Offset(inLine: lines[position.line], forUTF16Offset: position.utf16index) + 1
+    }
+    // LSP positions are 0-based; swift-markdown SourceLocation is 1-based.
+    let target = Markdown.SourceLocation(
+      line: position.line + 1,
+      column: column,
+      source: nil
+    )
+
+    let document = Markdown.Document(parsing: text, options: [.parseSymbolLinks, .parseBlockDirectives])
+    var locator = SymbolLocator(target: target)
+    locator.visit(document)
+
+    guard let symbol = locator.found, !symbol.isEmpty else {
+      return nil
+    }
+    return symbol
+  }
+
+  private struct DocCCommentLine {
+    let text: String
+    let startLine: Int
+    let startColumn: Int
+  }
+
+  private enum DocTriviaGroup {
+    case lines(lines: [DocCCommentLine])
+    case block(text: String, startLine: Int, startColumn: Int)
+  }
+
+  /// Converts a UTF-16 offset within `line` into the corresponding UTF-8 byte offset.
+  /// Needed because DocumentSnapshot/LSP positions are UTF-16-based but
+  /// Markdown.SourceLocation.column is UTF-8-byte-based.
+  private func utf8Offset(inLine line: String, forUTF16Offset utf16Offset: Int) -> Int {
+    let utf16View = line.utf16
+    guard
+      let utf16Index = utf16View.index(utf16View.startIndex, offsetBy: utf16Offset, limitedBy: utf16View.endIndex),
+      let stringIndex = utf16Index.samePosition(in: line)
+    else {
+      return line.utf8.count
+    }
+    return line.utf8.distance(from: line.startIndex, to: stringIndex)
+  }
+
+  private func docCommentGroups(
+    in trivia: Trivia,
+    tokenStart: AbsolutePosition,
+    snapshot: DocumentSnapshot
+  ) -> [DocTriviaGroup] {
+    var groups: [DocTriviaGroup] = []
+    var pendingLines: [DocCCommentLine] = []
+    var offset = tokenStart.utf8Offset
+    var newlinesSinceLastDoc = 0
+
+    func flushPendingLines() {
+      guard !pendingLines.isEmpty else { return }
+      groups.append(.lines(lines: pendingLines))
+      pendingLines.removeAll()
+    }
+
+    for piece in trivia.pieces {
+      defer { offset += piece.sourceLength.utf8Length }
+      switch piece {
+      case .docLineComment(let text):
+        if newlinesSinceLastDoc > 1 { flushPendingLines() }
+        let position = snapshot.positionOf(utf8Offset: offset)
+        pendingLines.append(DocCCommentLine(text: text, startLine: position.line, startColumn: position.utf16index))
+        newlinesSinceLastDoc = 0
+      case .docBlockComment(let text):
+        flushPendingLines()
+        let position = snapshot.positionOf(utf8Offset: offset)
+        groups.append(.block(text: text, startLine: position.line, startColumn: position.utf16index))
+        newlinesSinceLastDoc = 0
+      case .newlines(let n), .carriageReturns(let n), .carriageReturnLineFeeds(let n):
+        newlinesSinceLastDoc += n
+      case .spaces, .tabs:
+        break
+      default:
+        flushPendingLines()
+        newlinesSinceLastDoc = 0
+      }
+    }
+    flushPendingLines()
+    return groups
+  }
+
+  private struct StrippedLine {
+    let text: String
+    let strippedPrefixCount: Int
+  }
+
+  /// Strips `///` and any leading whitespace from each line comment piece.
+  private func stripLineCommentDelimiters(
+    _ lines: [DocCCommentLine]
+  ) -> [StrippedLine] {
+    return lines.map { line in
+      var text = Substring(line.text)
+      var stripped = 0
+
+      if text.hasPrefix("///") {
+        text.removeFirst(3)
+        stripped += 3
+      }
+      let beforeIndent = text.utf16.count
+      let trimmed = text.drop { $0 == " " || $0 == "\t" }
+      stripped += beforeIndent - trimmed.utf16.count
+      text = trimmed
+      return StrippedLine(text: String(text), strippedPrefixCount: stripped)
+    }
+  }
+  /// Strips `/**`, `*/`, and per-line leading `*`/whitespace from a block comment.
+  private func stripBlockCommentDelimiters(_ text: String) -> [StrippedLine] {
+    let lines = text.components(separatedBy: "\n")
+    return lines.enumerated().map { index, rawLine in
+      var line = Substring(rawLine)
+      var stripped = 0
+
+      if index == 0, line.hasPrefix("/**") {
+        line.removeFirst(3)
+        stripped += 3
+      }
+      if index == lines.count - 1, line.hasSuffix("*/") {
+        line.removeLast(2)
+      }
+      let beforeStar = line.utf16.count
+      var afterStar = line.drop { $0 == " " || $0 == "\t" }
+      if afterStar.hasPrefix("*") {
+        afterStar.removeFirst()
+        if afterStar.hasPrefix(" ") { afterStar.removeFirst() }
+        stripped += beforeStar - afterStar.utf16.count
+        line = afterStar
+      }
+      let beforeIndent = line.utf16.count
+      let trimmed = line.drop { $0 == " " || $0 == "\t" }
+      stripped += beforeIndent - trimmed.utf16.count
+      line = trimmed
+      return StrippedLine(text: String(line), strippedPrefixCount: stripped)
+    }
+  }
+
+  private func resolveTarget(
+    for group: DocTriviaGroup,
+    cursorPosition: Position
+  ) -> (strippedLines: [StrippedLine], lineIndex: Int, targetColumn: Int)? {
+    switch group {
+    case .lines(let lines):
+      guard let lineIndex = lines.firstIndex(where: { $0.startLine == cursorPosition.line }) else {
+        return nil
+      }
+      let strippedLines = stripLineCommentDelimiters(lines)
+      let rawLine = lines[lineIndex].text
+      let relativeUTF16 = cursorPosition.utf16index - lines[lineIndex].startColumn
+      let utf8Rel = utf8Offset(inLine: rawLine, forUTF16Offset: relativeUTF16)
+      let targetColumn = max(1, utf8Rel - strippedLines[lineIndex].strippedPrefixCount + 1)
+
+      return (strippedLines, lineIndex, targetColumn)
+
+    case .block(let text, let startLine, let startColumn):
+      let strippedLines = stripBlockCommentDelimiters(text)
+      let lineIndex = cursorPosition.line - startLine
+      guard strippedLines.indices.contains(lineIndex) else {
+        return nil
+      }
+
+      let rawLines = text.components(separatedBy: "\n")
+      let rawLine = rawLines[lineIndex]
+      let columnBase = lineIndex == 0 ? startColumn : 0
+      let relativeUTF16 = cursorPosition.utf16index - columnBase
+      let utf8Rel = utf8Offset(inLine: rawLine, forUTF16Offset: relativeUTF16)
+      let targetColumn = max(1, utf8Rel - strippedLines[lineIndex].strippedPrefixCount + 1)
+
+      return (strippedLines, lineIndex, targetColumn)
+    }
+  }
+
+  private func extractSymbolFromDocComment(snapshot: DocumentSnapshot, at position: Position) -> String? {
+    let sourceFile = SwiftParser.Parser.parse(source: snapshot.text)
+    let absolutePosition = snapshot.absolutePosition(of: position)
+
+    guard let token = sourceFile.token(at: absolutePosition) else {
+      return nil
+    }
+
+    let cursorPosition = snapshot.positionOf(utf8Offset: absolutePosition.utf8Offset)
+    let groups = docCommentGroups(in: token.leadingTrivia, tokenStart: token.position, snapshot: snapshot)
+
+    for group in groups {
+      guard let (strippedLines, lineIndex, targetColumn) = resolveTarget(for: group, cursorPosition: cursorPosition)
+      else {
+        continue
+      }
+
+      let combinedText = strippedLines.map(\.text).joined(separator: "\n")
+      let target = Markdown.SourceLocation(line: lineIndex + 1, column: targetColumn, source: nil)
+      let document = Markdown.Document(parsing: combinedText, options: [.parseSymbolLinks])
+      var locator = SymbolLocator(target: target)
+      locator.visit(document)
+      return locator.found
+    }
+    return nil
   }
 }

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -163,8 +163,10 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     return .locations([targetLocation])
   }
 
-  /// Walks the Markdown/DocC AST looking for symbol link
-  /// that contains a given source position.
+  /// Walks the Markdown/DocC AST looking for a symbol link that contains a
+  /// given source position, and sets `found` to the link's destination
+  /// truncated to the component under the cursor (e.g. `Foo/bar/baz` with
+  /// the cursor on `bar` sets `found` to `"Foo/bar"`), not the full destination.
   private struct SymbolLocator: MarkupWalker {
     let target: Markdown.SourceLocation
     var found: String?
@@ -239,13 +241,12 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
 
   private struct DocCCommentLine {
     let text: String
-    let startLine: Int
-    let startColumn: Int
+    let start: Position
   }
 
   private enum DocTriviaGroup {
-    case lines(lines: [DocCCommentLine])
-    case block(text: String, startLine: Int, startColumn: Int)
+    case lines([DocCCommentLine])
+    case block(text: String, start: Position)
   }
 
   /// Converts a UTF-16 offset within `line` into the corresponding UTF-8 byte offset.
@@ -274,7 +275,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
 
     func flushPendingLines() {
       guard !pendingLines.isEmpty else { return }
-      groups.append(.lines(lines: pendingLines))
+      groups.append(.lines(pendingLines))
       pendingLines.removeAll()
     }
 
@@ -284,12 +285,12 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
       case .docLineComment(let text):
         if newlinesSinceLastDoc > 1 { flushPendingLines() }
         let position = snapshot.positionOf(utf8Offset: offset)
-        pendingLines.append(DocCCommentLine(text: text, startLine: position.line, startColumn: position.utf16index))
+        pendingLines.append(DocCCommentLine(text: text, start: position))
         newlinesSinceLastDoc = 0
       case .docBlockComment(let text):
         flushPendingLines()
         let position = snapshot.positionOf(utf8Offset: offset)
-        groups.append(.block(text: text, startLine: position.line, startColumn: position.utf16index))
+        groups.append(.block(text: text, start: position))
         newlinesSinceLastDoc = 0
       case .newlines(let n), .carriageReturns(let n), .carriageReturnLineFeeds(let n):
         newlinesSinceLastDoc += n
@@ -303,7 +304,10 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     flushPendingLines()
     return groups
   }
-
+  
+  /// A line of documentation text after stripping its comment delimiters/prefix.
+  /// `strippedPrefixCount` is the number of UTF-16 code units removed from the
+  /// beginning of the original line to produce `text`.
   private struct StrippedLine {
     let text: String
     let strippedPrefixCount: Int
@@ -328,6 +332,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
       return StrippedLine(text: String(text), strippedPrefixCount: stripped)
     }
   }
+
   /// Strips `/**`, `*/`, and per-line leading `*`/whitespace from a block comment.
   private func stripBlockCommentDelimiters(_ text: String) -> [StrippedLine] {
     let lines = text.components(separatedBy: "\n")
@@ -361,59 +366,49 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
   private func resolveTarget(
     for group: DocTriviaGroup,
     cursorPosition: Position
-  ) -> (strippedLines: [StrippedLine], lineIndex: Int, targetColumn: Int)? {
+  ) -> (strippedLines: [StrippedLine], target: Position)? {
     switch group {
     case .lines(let lines):
-      guard let lineIndex = lines.firstIndex(where: { $0.startLine == cursorPosition.line }) else {
+      guard let lineIndex = lines.firstIndex(where: { $0.start.line == cursorPosition.line }) else {
         return nil
       }
       let strippedLines = stripLineCommentDelimiters(lines)
-      let rawLine = lines[lineIndex].text
-      let relativeUTF16 = cursorPosition.utf16index - lines[lineIndex].startColumn
-      let utf8Rel = utf8Offset(inLine: rawLine, forUTF16Offset: relativeUTF16)
-      let targetColumn = max(1, utf8Rel - strippedLines[lineIndex].strippedPrefixCount + 1)
+      let relativeUTF16 = cursorPosition.utf16index - lines[lineIndex].start.utf16index
+      let localColumn = max(0, relativeUTF16 - strippedLines[lineIndex].strippedPrefixCount)
+      return (strippedLines, Position(line: lineIndex, utf16index: localColumn))
 
-      return (strippedLines, lineIndex, targetColumn)
-
-    case .block(let text, let startLine, let startColumn):
+    case .block(let text, let start):
       let strippedLines = stripBlockCommentDelimiters(text)
-      let lineIndex = cursorPosition.line - startLine
-      guard strippedLines.indices.contains(lineIndex) else {
-        return nil
-      }
-
-      let rawLines = text.components(separatedBy: "\n")
-      let rawLine = rawLines[lineIndex]
-      let columnBase = lineIndex == 0 ? startColumn : 0
+      let lineIndex = cursorPosition.line - start.line
+      guard strippedLines.indices.contains(lineIndex) else { return nil }
+      let columnBase = lineIndex == 0 ? start.utf16index : 0
       let relativeUTF16 = cursorPosition.utf16index - columnBase
-      let utf8Rel = utf8Offset(inLine: rawLine, forUTF16Offset: relativeUTF16)
-      let targetColumn = max(1, utf8Rel - strippedLines[lineIndex].strippedPrefixCount + 1)
-
-      return (strippedLines, lineIndex, targetColumn)
+      let localColumn = max(0, relativeUTF16 - strippedLines[lineIndex].strippedPrefixCount)
+      return (strippedLines, Position(line: lineIndex, utf16index: localColumn))
     }
   }
 
   private func extractSymbolFromDocComment(snapshot: DocumentSnapshot, at position: Position) -> String? {
     let sourceFile = SwiftParser.Parser.parse(source: snapshot.text)
     let absolutePosition = snapshot.absolutePosition(of: position)
+    guard let token = sourceFile.token(at: absolutePosition) else { return nil }
 
-    guard let token = sourceFile.token(at: absolutePosition) else {
-      return nil
-    }
+    let leadingGroups = docCommentGroups(in: token.leadingTrivia, tokenStart: token.position, snapshot: snapshot)
+    let trailingGroups = docCommentGroups(
+      in: token.trailingTrivia,
+      tokenStart: token.endPositionBeforeTrailingTrivia,
+      snapshot: snapshot
+    )
 
-    let cursorPosition = snapshot.positionOf(utf8Offset: absolutePosition.utf8Offset)
-    let groups = docCommentGroups(in: token.leadingTrivia, tokenStart: token.position, snapshot: snapshot)
-
-    for group in groups {
-      guard let (strippedLines, lineIndex, targetColumn) = resolveTarget(for: group, cursorPosition: cursorPosition)
-      else {
-        continue
-      }
+    for group in leadingGroups + trailingGroups {
+      guard let (strippedLines, target) = resolveTarget(for: group, cursorPosition: position) else { continue }
 
       let combinedText = strippedLines.map(\.text).joined(separator: "\n")
-      let target = Markdown.SourceLocation(line: lineIndex + 1, column: targetColumn, source: nil)
+      let utf8Column = utf8Offset(inLine: strippedLines[target.line].text, forUTF16Offset: target.utf16index) + 1
+      let markdownTarget = Markdown.SourceLocation(line: target.line + 1, column: utf8Column, source: nil)
+
       let document = Markdown.Document(parsing: combinedText, options: [.parseSymbolLinks])
-      var locator = SymbolLocator(target: target)
+      var locator = SymbolLocator(target: markdownTarget)
       locator.visit(document)
       return locator.found
     }

--- a/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
+++ b/Sources/DocumentationLanguageService/DocumentationLanguageService.swift
@@ -41,8 +41,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
 
   package static var experimentalCapabilities: [String: LSPAny] {
     return [
-      DoccDocumentationRequest.method: ["version": 1],
-      "definitionProvider": .bool(true),
+      DoccDocumentationRequest.method: ["version": 1]
     ]
   }
 
@@ -54,7 +53,7 @@ package actor DocumentationLanguageService: LanguageService, Sendable {
     workspace: Workspace
   ) async throws {
     self.sourceKitLSPServer = sourceKitLSPServer
-    self.documentationManager = DocCDocumentationManager(buildServerManager: workspace.buildServerManager);
+    self.documentationManager = DocCDocumentationManager(buildServerManager: workspace.buildServerManager)
   }
 
   package nonisolated func canHandle(toolchain: Toolchain) -> Bool {

--- a/Sources/DocumentationLanguageService/IndexStoreDB+Extensions.swift
+++ b/Sources/DocumentationLanguageService/IndexStoreDB+Extensions.swift
@@ -40,7 +40,7 @@ extension CheckedIndex {
     var result: [SymbolOccurrence] = []
     for occurrence in topLevelSymbolOccurrences {
       let info = try await doccSymbolInformation(ofUSR: occurrence.symbol.usr, fetchSymbolGraph: fetchSymbolGraph)
-      if info.matches(symbolLink) {
+      if info.matchesAsSuffix(symbolLink) {
         result.append(occurrence)
       }
     }

--- a/Sources/SourceKitLSP/LanguageService.swift
+++ b/Sources/SourceKitLSP/LanguageService.swift
@@ -99,6 +99,13 @@ package struct GeneratedInterfaceDetails: ResponseType, Hashable {
   }
 }
 
+/// Thrown by a language service's request handler to indicate that this
+/// service isn't the right one for the current request context, and the
+/// next language service should be tried instead.
+package struct FallThroughToNextLanguageService: Error {
+  package init() {}
+}
+
 /// Provides language specific functionality to sourcekit-lsp from a specific toolchain.
 ///
 /// For example, we may have a language service that provides semantic functionality for c-family using a clangd server,

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -392,7 +392,7 @@ package actor SourceKitLSPServer {
       @Sendable @escaping (
         RequestType, Workspace, any LanguageService
       ) async throws ->
-      RequestType.Response?
+      RequestType.Response
   ) async {
     await request.reply {
       let request = request.params
@@ -404,14 +404,26 @@ package actor SourceKitLSPServer {
       if languageServices.isEmpty {
         throw ResponseError.unknown("No language service for '\(request.textDocument.uri)' found")
       }
-      // Return the results from the first language service that doesn't throw a `requestNotImplemented` error.
-      for languageService in languageServices {
+      // Return the results from the first language service that produces a non-nil response.
+      // A language service can opt out of handling this request for the given service by throwing
+      // `ResponseError.requestNotImplemented` (it never implements this method) or
+      // `FallThroughToNextLanguageService` (it implements the method, but isn't the right service
+      // for this particular request), in which case the next language service is tried.
+      for (index, languageService) in languageServices.enumerated() {
         do {
-          guard let response = try await requestHandler(request, workspace, languageService) else {
-            continue
-          }
-          return response
+          return try await requestHandler(request, workspace, languageService)
         } catch let error as ResponseError where error.code == .requestNotImplemented {
+          continue
+        } catch is FallThroughToNextLanguageService {
+          if index + 1 < languageServices.count {
+            logger.debug(
+              "\(type(of: languageService)) is not the right service for \(type(of: request).method); falling through to \(type(of: languageServices[index + 1]))"
+            )
+          } else {
+            logger.debug(
+              "\(type(of: languageService)) is not the right service for \(type(of: request).method); no further language services to try"
+            )
+          }
           continue
         }
       }
@@ -1969,7 +1981,7 @@ extension SourceKitLSPServer {
     workspace: Workspace,
     languageService: any LanguageService
   ) async throws -> LocationsOrLocationLinksResponse? {
-    var indexBasedResponse: [Location] = []
+    let indexBasedResponse: [Location]
     do {
       indexBasedResponse = try await indexBasedDefinition(req, workspace: workspace, languageService: languageService)
     } catch {
@@ -1990,12 +2002,14 @@ extension SourceKitLSPServer {
       } catch let error as ResponseError where error.code == .requestNotImplemented {
         // Signal to handleRequest's loop to try the next language service
         throw error
+      } catch is FallThroughToNextLanguageService {
+        // Signal to handleRequest's loop to try the next language service
+        throw FallThroughToNextLanguageService()
       } catch {
         logger.info("Fallback definition request failed: \(error.forLogging)")
         return nil
       }
     }
-
     let remappedLocations = indexBasedResponse.adjusted(for: copiedFileMap)
     return .locations(remappedLocations)
   }

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -392,7 +392,7 @@ package actor SourceKitLSPServer {
       @Sendable @escaping (
         RequestType, Workspace, any LanguageService
       ) async throws ->
-      RequestType.Response
+      RequestType.Response?
   ) async {
     await request.reply {
       let request = request.params
@@ -407,7 +407,10 @@ package actor SourceKitLSPServer {
       // Return the results from the first language service that doesn't throw a `requestNotImplemented` error.
       for languageService in languageServices {
         do {
-          return try await requestHandler(request, workspace, languageService)
+          guard let response = try await requestHandler(request, workspace, languageService) else {
+            continue
+          }
+          return response
         } catch let error as ResponseError where error.code == .requestNotImplemented {
           continue
         }
@@ -1966,7 +1969,13 @@ extension SourceKitLSPServer {
     workspace: Workspace,
     languageService: any LanguageService
   ) async throws -> LocationsOrLocationLinksResponse? {
-    let indexBasedResponse = try await indexBasedDefinition(req, workspace: workspace, languageService: languageService)
+    var indexBasedResponse: [Location] = []
+    do {
+      indexBasedResponse = try await indexBasedDefinition(req, workspace: workspace, languageService: languageService)
+    } catch {
+      logger.info("indexBasedDefinition failed: \(error.forLogging)")
+      indexBasedResponse = []
+    }
     let copiedFileMap = await workspace.buildServerManager.cachedCopiedFileMap
     // If we're unable to handle the definition request using our index, see if the
     // language service can handle it (e.g. clangd can provide AST based definitions).
@@ -1975,11 +1984,18 @@ extension SourceKitLSPServer {
     // `SwiftLanguageService` will always respond with `unsupported method`. Thus, only log such a failure instead of
     // returning it to the client.
     if indexBasedResponse.isEmpty {
-      return await orLog("Fallback definition request", level: .info) {
+      do {
         let result = try await languageService.definition(req)
         return result?.adjusted(for: copiedFileMap)
+      } catch let error as ResponseError where error.code == .requestNotImplemented {
+        // Signal to handleRequest's loop to try the next language service
+        throw error
+      } catch {
+        logger.info("Fallback definition request failed: \(error.forLogging)")
+        return nil
       }
     }
+
     let remappedLocations = indexBasedResponse.adjusted(for: copiedFileMap)
     return .locations(remappedLocations)
   }

--- a/Sources/SourceKitLSP/SourceKitLSPServer.swift
+++ b/Sources/SourceKitLSP/SourceKitLSPServer.swift
@@ -2002,9 +2002,9 @@ extension SourceKitLSPServer {
       } catch let error as ResponseError where error.code == .requestNotImplemented {
         // Signal to handleRequest's loop to try the next language service
         throw error
-      } catch is FallThroughToNextLanguageService {
+      } catch let error as FallThroughToNextLanguageService {
         // Signal to handleRequest's loop to try the next language service
-        throw FallThroughToNextLanguageService()
+        throw error
       } catch {
         logger.info("Fallback definition request failed: \(error.forLogging)")
         return nil

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -795,6 +795,32 @@ extension SwiftLanguageService {
   // MARK: - Language features
 
   package func definition(_ request: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
+
+    let snapshot = try await latestSnapshot(for: request.textDocument.uri)
+    let tree = await syntaxTreeManager.syntaxTree(for: snapshot)
+    let absolutePosition = snapshot.absolutePosition(of: request.position)
+
+    if let token = tree.token(at: absolutePosition) {
+      var offset = token.position.utf8Offset
+      var isInDocComment = false
+
+      for piece in token.leadingTrivia.pieces {
+        let pieceLength = piece.sourceLength.utf8Length
+        switch piece {
+        case .docLineComment, .docBlockComment:
+          if absolutePosition.utf8Offset >= offset && absolutePosition.utf8Offset < offset + pieceLength {
+            isInDocComment = true
+          }
+        default:
+          break
+        }
+        offset += pieceLength
+      }
+
+      if isInDocComment {
+        return nil
+      }
+    }
     throw ResponseError.unknown("unsupported method")
   }
 

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -795,7 +795,6 @@ extension SwiftLanguageService {
   // MARK: - Language features
 
   package func definition(_ request: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
-
     let snapshot = try await latestSnapshot(for: request.textDocument.uri)
     let tree = await syntaxTreeManager.syntaxTree(for: snapshot)
     let absolutePosition = snapshot.absolutePosition(of: request.position)

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -794,27 +794,38 @@ extension SwiftLanguageService {
 
   // MARK: - Language features
 
+  /// Whether `position` falls within a `docLineComment` or `docBlockComment` piece of `trivia`,
+  /// which starts at `triviaStart`.
+  private func trivia(
+    _ trivia: Trivia,
+    startingAt triviaStart: AbsolutePosition,
+    contains position: AbsolutePosition
+  ) -> Bool {
+    var offset = triviaStart.utf8Offset
+    for piece in trivia.pieces {
+      let pieceLength = piece.sourceLength.utf8Length
+      switch piece {
+      case .docLineComment, .docBlockComment:
+        if position.utf8Offset >= offset && position.utf8Offset < offset + pieceLength {
+          return true
+        }
+      default:
+        break
+      }
+      offset += pieceLength
+    }
+    return false
+  }
+
   package func definition(_ request: DefinitionRequest) async throws -> LocationsOrLocationLinksResponse? {
     let snapshot = try await latestSnapshot(for: request.textDocument.uri)
     let tree = await syntaxTreeManager.syntaxTree(for: snapshot)
     let absolutePosition = snapshot.absolutePosition(of: request.position)
 
     if let token = tree.token(at: absolutePosition) {
-      var offset = token.position.utf8Offset
-      var isInDocComment = false
-
-      for piece in token.leadingTrivia.pieces {
-        let pieceLength = piece.sourceLength.utf8Length
-        switch piece {
-        case .docLineComment, .docBlockComment:
-          if absolutePosition.utf8Offset >= offset && absolutePosition.utf8Offset < offset + pieceLength {
-            isInDocComment = true
-          }
-        default:
-          break
-        }
-        offset += pieceLength
-      }
+      let isInDocComment =
+        trivia(token.leadingTrivia, startingAt: token.position, contains: absolutePosition)
+        || trivia(token.trailingTrivia, startingAt: token.endPositionBeforeTrailingTrivia, contains: absolutePosition)
 
       if isInDocComment {
         throw FallThroughToNextLanguageService()

--- a/Sources/SwiftLanguageService/SwiftLanguageService.swift
+++ b/Sources/SwiftLanguageService/SwiftLanguageService.swift
@@ -818,7 +818,7 @@ extension SwiftLanguageService {
       }
 
       if isInDocComment {
-        return nil
+        throw FallThroughToNextLanguageService()
       }
     }
     throw ResponseError.unknown("unsupported method")

--- a/Tests/SourceKitLSPTests/DocCDefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DocCDefinitionTests.swift
@@ -12,15 +12,13 @@
 
 @_spi(SourceKitLSP) import LanguageServerProtocol
 import SKTestSupport
-import Testing
+import XCTest
 
-@Suite(.serialized)
-struct DocCDefinitionTests {
+final class DocCDefinitionTests: XCTestCase {
 
   // MARK: Line comments (`///`)
 
-  @Test
-  func jumpToDefinitionFromLineCommentSymbolLink() async throws {
+  func testJumpToDefinitionFromLineCommentSymbolLink() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct 1️⃣Foo {}
@@ -33,16 +31,16 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    #expect(
-      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
   /// Two `///` comment groups separated by a blank line are parsed as two separate
   /// `DocTriviaGroup.lines` groups. Clicking in the second group should still resolve,
   /// unaffected by the unrelated first group.
-  @Test
-  func jumpToDefinitionIgnoresUnrelatedLineCommentGroup() async throws {
+  func testJumpToDefinitionIgnoresUnrelatedLineCommentGroup() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct 1️⃣Foo {}
@@ -58,15 +56,15 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    #expect(
-      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
   // MARK: Block comments (`/** ... */`)
 
-  @Test
-  func jumpToDefinitionFromBlockCommentSymbolLink() async throws {
+  func testJumpToDefinitionFromBlockCommentSymbolLink() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct 1️⃣Foo {}
@@ -81,14 +79,14 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    #expect(
-      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
   /// Symbol link on the same line as the opening `/**`.
-  @Test
-  func jumpToDefinitionFromSingleLineBlockCommentSymbolLink() async throws {
+  func testJumpToDefinitionFromSingleLineBlockCommentSymbolLink() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct 1️⃣Foo {}
@@ -101,16 +99,16 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    #expect(
-      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
   // MARK: Nested / multi-component links (``Foo/bar()``)
 
   /// Clicking the parent component of a nested link resolves to the parent symbol.
-  @Test
-  func jumpToDefinitionFromNestedSymbolLinkParentComponent() async throws {
+  func testJumpToDefinitionFromNestedSymbolLinkParentComponent() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct 1️⃣Foo {
@@ -125,14 +123,14 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    #expect(
-      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
   /// Clicking the child component of a nested link resolves to the child symbol.
-  @Test
-  func jumpToDefinitionFromNestedSymbolLinkChildComponent() async throws {
+  func testJumpToDefinitionFromNestedSymbolLinkChildComponent() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct Foo {
@@ -150,15 +148,15 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    #expect(
-      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
   // MARK: Negative cases
 
-  @Test
-  func definitionIsNilWhenNotOnSymbolLink() async throws {
+  func testJumpToDefinitionIsNilWhenNotOnSymbolLink() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct Foo {}
@@ -171,11 +169,10 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
     )
-    #expect(response == nil)
+    XCTAssertNil(response)
   }
 
-  @Test
-  func definitionIsNilForUnresolvedSymbolLink() async throws {
+  func testJumpToDefinitionIsNilForUnresolvedSymbolLink() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       /// See ``1️⃣DoesNotExist``
@@ -186,13 +183,12 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
     )
-    #expect(response == nil)
+    XCTAssertNil(response)
   }
 
   /// The cursor sitting in a plain (non-doc) comment should not be treated as a doc-comment
   /// symbol link at all.
-  @Test
-  func definitionIsNilInNonDocComment() async throws {
+  func testJumpToDefinitionIsNilInNonDocComment() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct Foo {}
@@ -205,13 +201,12 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
     )
-    #expect(response == nil)
+    XCTAssertNil(response)
   }
 
   /// Invoking the action somewhere that isn't a symbol link at all (e.g. plain code, not
   /// inside any comment) should return nil.
-  @Test
-  func definitionIsNilWhenNotOnAnySymbol() async throws {
+  func testJumpToDefinitionIsNilWhenNotOnAnySymbol() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct Foo {}
@@ -223,13 +218,12 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
     )
-    #expect(response == nil)
+    XCTAssertNil(response)
   }
 
-  // MARK: DocC catalog files (tutorials and makdown)
+  // MARK: DocC catalog files (tutorials and markdown)
 
-  @Test
-  func gotoDefinitionInDocCTutorialFile() async throws {
+  func testJumpToDefinitionInDocCTutorialFile() async throws {
     let project = try await SwiftPMTestProject(
       files: [
         "MyLibrary/MyFile.swift": """
@@ -251,13 +245,13 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(tutorialURI), position: tutorialPositions["2️⃣"])
     )
-    #expect(
-      response == .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "MyFile.swift")])
+    XCTAssertEqual(
+      response,
+      .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "MyFile.swift")])
     )
   }
 
-  @Test
-  func gotoDefinitionInDocCMarkdownFile() async throws {
+  func testJumpToDefinitionInDocCMarkdownFile() async throws {
     let project = try await SwiftPMTestProject(
       files: [
         "MyLibrary/MyFile.swift": """
@@ -277,8 +271,9 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(overviewURI), position: overviewPositions["2️⃣"])
     )
-    #expect(
-      response == .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "MyFile.swift")])
+    XCTAssertEqual(
+      response,
+      .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "MyFile.swift")])
     )
   }
 
@@ -286,8 +281,7 @@ struct DocCDefinitionTests {
 
   /// The doc comment lives in one file, the symbol it links to is defined in another file
   /// (same target).
-  @Test
-  func gotoDefinitionAcrossFilesInSameModule() async throws {
+  func testJumpToDefinitionAcrossFilesInSameModule() async throws {
     let project = try await SwiftPMTestProject(
       files: [
         "MyLibrary/Foo.swift": """
@@ -306,15 +300,15 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(barURI), position: barPositions["2️⃣"])
     )
-    #expect(
-      response == .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "Foo.swift")])
+    XCTAssertEqual(
+      response,
+      .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "Foo.swift")])
     )
   }
 
   /// The doc comment lives in one target, the symbol it links to is defined in a different
   /// target that the first one depends on.
-  @Test
-  func gotoDefinitionAcrossModules() async throws {
+  func testJumpToDefinitionAcrossModules() async throws {
     let project = try await SwiftPMTestProject(
       files: [
         "OtherLibrary/Foo.swift": """
@@ -348,8 +342,9 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(barURI), position: barPositions["2️⃣"])
     )
-    #expect(
-      response == .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "Foo.swift")])
+    XCTAssertEqual(
+      response,
+      .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "Foo.swift")])
     )
   }
 
@@ -357,16 +352,15 @@ struct DocCDefinitionTests {
 
   /// A symbol link that includes parameter/return disambiguation should resolve to the
   /// specific overload, not just the first symbol with a matching base name.
-  @Test
-  func gotoDefinitionDisambiguatesOverloads() async throws {
+  func testJumpToDefinitionDisambiguatesOverloads() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct Foo {
-        public func bar(x: Int) {}
-        public func 1️⃣bar() {}
+       public func bar(x: Int) {}
+        public func 1️⃣bar(x: String) {}
       }
 
-      /// See ``Foo/2️⃣bar()``
+      /// See ``Foo/2️⃣bar(x:)-(String)``
       public func useFoo() {}
       """
     )
@@ -374,8 +368,9 @@ struct DocCDefinitionTests {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    #expect(
-      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
@@ -383,8 +378,7 @@ struct DocCDefinitionTests {
 
   /// A symbol link using an explicit disambiguation suffix (e.g. a hash or kind suffix)
   /// should still resolve to the correct symbol.
-  @Test
-  func gotoDefinitionResolvesKindDisambiguatedLink() async throws {
+  func testJumpToDefinitionResolvesKindDisambiguatedLink() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct Foo {
@@ -400,15 +394,17 @@ struct DocCDefinitionTests {
     let staticResponse = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["3️⃣"])
     )
-    #expect(
-      staticResponse == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    XCTAssertEqual(
+      staticResponse,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
 
     let instanceResponse = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["4️⃣"])
     )
-    #expect(
-      instanceResponse == .locations([Location(uri: project.fileURI, range: Range(project.positions["2️⃣"]))])
+    XCTAssertEqual(
+      instanceResponse,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["2️⃣"]))])
     )
   }
 }

--- a/Tests/SourceKitLSPTests/DocCDefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DocCDefinitionTests.swift
@@ -12,13 +12,15 @@
 
 @_spi(SourceKitLSP) import LanguageServerProtocol
 import SKTestSupport
-import XCTest
+import Testing
 
-final class DocumentationDefinitionTests: SourceKitLSPTestCase {
+@Suite(.serialized)
+struct DocCDefinitionTests {
 
   // MARK: Line comments (`///`)
 
-  func testJumpToDefinitionFromLineCommentSymbolLink() async throws {
+  @Test
+  func jumpToDefinitionFromLineCommentSymbolLink() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct 1️⃣Foo {}
@@ -31,16 +33,16 @@ final class DocumentationDefinitionTests: SourceKitLSPTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    XCTAssertEqual(
-      response,
-      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    #expect(
+      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
   /// Two `///` comment groups separated by a blank line are parsed as two separate
   /// `DocTriviaGroup.lines` groups. Clicking in the second group should still resolve,
   /// unaffected by the unrelated first group.
-  func testJumpToDefinitionIgnoresUnrelatedLineCommentGroup() async throws {
+  @Test
+  func jumpToDefinitionIgnoresUnrelatedLineCommentGroup() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct 1️⃣Foo {}
@@ -56,15 +58,15 @@ final class DocumentationDefinitionTests: SourceKitLSPTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    XCTAssertEqual(
-      response,
-      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    #expect(
+      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
   // MARK: Block comments (`/** ... */`)
 
-  func testJumpToDefinitionFromBlockCommentSymbolLink() async throws {
+  @Test
+  func jumpToDefinitionFromBlockCommentSymbolLink() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct 1️⃣Foo {}
@@ -79,14 +81,14 @@ final class DocumentationDefinitionTests: SourceKitLSPTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    XCTAssertEqual(
-      response,
-      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    #expect(
+      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
   /// Symbol link on the same line as the opening `/**`.
-  func testJumpToDefinitionFromSingleLineBlockCommentSymbolLink() async throws {
+  @Test
+  func jumpToDefinitionFromSingleLineBlockCommentSymbolLink() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct 1️⃣Foo {}
@@ -99,16 +101,16 @@ final class DocumentationDefinitionTests: SourceKitLSPTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    XCTAssertEqual(
-      response,
-      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    #expect(
+      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
   // MARK: Nested / multi-component links (``Foo/bar()``)
 
   /// Clicking the parent component of a nested link resolves to the parent symbol.
-  func testJumpToDefinitionFromNestedSymbolLinkParentComponent() async throws {
+  @Test
+  func jumpToDefinitionFromNestedSymbolLinkParentComponent() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct 1️⃣Foo {
@@ -123,17 +125,244 @@ final class DocumentationDefinitionTests: SourceKitLSPTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    XCTAssertEqual(
-      response,
-      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    #expect(
+      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
   /// Clicking the child component of a nested link resolves to the child symbol.
-  func testJumpToDefinitionFromNestedSymbolLinkChildComponent() async throws {
+  @Test
+  func jumpToDefinitionFromNestedSymbolLinkChildComponent() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
       public struct Foo {
+        public func 1️⃣bar() {}
+      }
+      public struct Link {
+        public func bar() {}
+      }
+
+      /// See ``Foo/2️⃣bar()``
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    #expect(
+      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  // MARK: Negative cases
+
+  @Test
+  func definitionIsNilWhenNotOnSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct Foo {}
+
+      /// This 1️⃣comment has no symbol link.
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
+    )
+    #expect(response == nil)
+  }
+
+  @Test
+  func definitionIsNilForUnresolvedSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      /// See ``1️⃣DoesNotExist``
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
+    )
+    #expect(response == nil)
+  }
+
+  /// The cursor sitting in a plain (non-doc) comment should not be treated as a doc-comment
+  /// symbol link at all.
+  @Test
+  func definitionIsNilInNonDocComment() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct Foo {}
+
+      // This is a regular comment mentioning 1️⃣Foo, not a doc comment.
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
+    )
+    #expect(response == nil)
+  }
+
+  /// Invoking the action somewhere that isn't a symbol link at all (e.g. plain code, not
+  /// inside any comment) should return nil.
+  @Test
+  func definitionIsNilWhenNotOnAnySymbol() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct Foo {}
+
+      public func 1️⃣ useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
+    )
+    #expect(response == nil)
+  }
+
+  // MARK: DocC catalog files (tutorials and makdown)
+
+  @Test
+  func gotoDefinitionInDocCTutorialFile() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyLibrary/MyFile.swift": """
+        public struct 1️⃣Foo {}
+        """,
+        "MyLibrary/MyLibrary.docc/MyTutorial.tutorial": """
+        @Tutorial(time: 30) {
+          @Intro(title: "My Custom Tutorial") {
+            See ``2️⃣Foo`` for more information.
+          }
+        }
+        """,
+      ],
+      enableBackgroundIndexing: true
+    )
+
+    let (tutorialURI, tutorialPositions) = try project.openDocument("MyTutorial.tutorial")
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(tutorialURI), position: tutorialPositions["2️⃣"])
+    )
+    #expect(
+      response == .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "MyFile.swift")])
+    )
+  }
+
+  @Test
+  func gotoDefinitionInDocCMarkdownFile() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyLibrary/MyFile.swift": """
+        public struct 1️⃣Foo {}
+        """,
+        "MyLibrary/MyLibrary.docc/Overview.md": """
+        # Overview
+
+        See ``2️⃣Foo`` for more information.
+        """,
+      ],
+      enableBackgroundIndexing: true
+    )
+
+    let (overviewURI, overviewPositions) = try project.openDocument("Overview.md")
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(overviewURI), position: overviewPositions["2️⃣"])
+    )
+    #expect(
+      response == .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "MyFile.swift")])
+    )
+  }
+
+  // MARK: Cross-file / cross-module
+
+  /// The doc comment lives in one file, the symbol it links to is defined in another file
+  /// (same target).
+  @Test
+  func gotoDefinitionAcrossFilesInSameModule() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "MyLibrary/Foo.swift": """
+        public struct 1️⃣Foo {}
+        """,
+        "MyLibrary/Bar.swift": """
+        /// See ``2️⃣Foo``
+        public func useFoo() {}
+        """,
+      ],
+      enableBackgroundIndexing: true
+    )
+
+    let (barURI, barPositions) = try project.openDocument("Bar.swift")
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(barURI), position: barPositions["2️⃣"])
+    )
+    #expect(
+      response == .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "Foo.swift")])
+    )
+  }
+
+  /// The doc comment lives in one target, the symbol it links to is defined in a different
+  /// target that the first one depends on.
+  @Test
+  func gotoDefinitionAcrossModules() async throws {
+    let project = try await SwiftPMTestProject(
+      files: [
+        "OtherLibrary/Foo.swift": """
+        public struct 1️⃣Foo {}
+        """,
+        "MyLibrary/Bar.swift": """
+        import OtherLibrary
+
+        /// See ``2️⃣Foo``
+        public func useFoo() {}
+        """,
+      ],
+      manifest: """
+        // swift-tools-version: 5.10
+
+        import PackageDescription
+
+        let package = Package(
+          name: "MyLibrary",
+          targets: [
+            .target(name: "OtherLibrary"),
+            .target(name: "MyLibrary", dependencies: ["OtherLibrary"]),
+          ]
+        )
+        """,
+      enableBackgroundIndexing: true
+    )
+
+    let (barURI, barPositions) = try project.openDocument("Bar.swift")
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(barURI), position: barPositions["2️⃣"])
+    )
+    #expect(
+      response == .locations([try project.location(from: "1️⃣", to: "1️⃣", in: "Foo.swift")])
+    )
+  }
+
+  // MARK: Overload disambiguation
+
+  /// A symbol link that includes parameter/return disambiguation should resolve to the
+  /// specific overload, not just the first symbol with a matching base name.
+  @Test
+  func gotoDefinitionDisambiguatesOverloads() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct Foo {
+        public func bar(x: Int) {}
         public func 1️⃣bar() {}
       }
 
@@ -145,43 +374,41 @@ final class DocumentationDefinitionTests: SourceKitLSPTestCase {
     let response = try await project.testClient.send(
       DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
     )
-    XCTAssertEqual(
-      response,
-      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    #expect(
+      response == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
   }
 
-  // MARK: Negative cases
+  // MARK: Suffix disambiguation
 
-  func testDefinitionIsNilWhenNotOnSymbolLink() async throws {
+  /// A symbol link using an explicit disambiguation suffix (e.g. a hash or kind suffix)
+  /// should still resolve to the correct symbol.
+  @Test
+  func gotoDefinitionResolvesKindDisambiguatedLink() async throws {
     let project = try await IndexedSingleSwiftFileTestProject(
       """
-      public struct Foo {}
+      public struct Foo {
+        public static var 1️⃣bar: Int = 0
+        public var 2️⃣bar: Int = 0
+      }
 
-      /// This 1️⃣comment has no symbol link.
+      /// See ``Foo/3️⃣bar-swift.type.property`` and ``Foo/4️⃣bar-swift.property``
       public func useFoo() {}
       """
     )
 
-    await assertThrowsError(
-      try await project.testClient.send(
-        DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
-      )
+    let staticResponse = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["3️⃣"])
     )
-  }
-
-  func testDefinitionIsNilForUnresolvedSymbolLink() async throws {
-    let project = try await IndexedSingleSwiftFileTestProject(
-      """
-      /// See ``1️⃣DoesNotExist``
-      public func useFoo() {}
-      """
+    #expect(
+      staticResponse == .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
     )
 
-    await assertThrowsError(
-      try await project.testClient.send(
-        DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
-      )
+    let instanceResponse = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["4️⃣"])
+    )
+    #expect(
+      instanceResponse == .locations([Location(uri: project.fileURI, range: Range(project.positions["2️⃣"]))])
     )
   }
 }

--- a/Tests/SourceKitLSPTests/DocCDefinitionTests.swift
+++ b/Tests/SourceKitLSPTests/DocCDefinitionTests.swift
@@ -1,0 +1,187 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2025 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(SourceKitLSP) import LanguageServerProtocol
+import SKTestSupport
+import XCTest
+
+final class DocumentationDefinitionTests: SourceKitLSPTestCase {
+
+  // MARK: Line comments (`///`)
+
+  func testJumpToDefinitionFromLineCommentSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct 1️⃣Foo {}
+
+      /// See ``2️⃣Foo``
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  /// Two `///` comment groups separated by a blank line are parsed as two separate
+  /// `DocTriviaGroup.lines` groups. Clicking in the second group should still resolve,
+  /// unaffected by the unrelated first group.
+  func testJumpToDefinitionIgnoresUnrelatedLineCommentGroup() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct 1️⃣Foo {}
+      public struct Bar {}
+
+      /// Unrelated comment mentioning ``Bar``, detached by a blank line below.
+
+      /// See ``2️⃣Foo`` here instead.
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  // MARK: Block comments (`/** ... */`)
+
+  func testJumpToDefinitionFromBlockCommentSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct 1️⃣Foo {}
+
+      /**
+       See ``2️⃣Foo`` for more information.
+       */
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  /// Symbol link on the same line as the opening `/**`.
+  func testJumpToDefinitionFromSingleLineBlockCommentSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct 1️⃣Foo {}
+
+      /** See ``2️⃣Foo`` for more information. */
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  // MARK: Nested / multi-component links (``Foo/bar()``)
+
+  /// Clicking the parent component of a nested link resolves to the parent symbol.
+  func testJumpToDefinitionFromNestedSymbolLinkParentComponent() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct 1️⃣Foo {
+        public func bar() {}
+      }
+
+      /// See ``2️⃣Foo/bar()``
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  /// Clicking the child component of a nested link resolves to the child symbol.
+  func testJumpToDefinitionFromNestedSymbolLinkChildComponent() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct Foo {
+        public func 1️⃣bar() {}
+      }
+
+      /// See ``Foo/2️⃣bar()``
+      public func useFoo() {}
+      """
+    )
+
+    let response = try await project.testClient.send(
+      DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["2️⃣"])
+    )
+    XCTAssertEqual(
+      response,
+      .locations([Location(uri: project.fileURI, range: Range(project.positions["1️⃣"]))])
+    )
+  }
+
+  // MARK: Negative cases
+
+  func testDefinitionIsNilWhenNotOnSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      public struct Foo {}
+
+      /// This 1️⃣comment has no symbol link.
+      public func useFoo() {}
+      """
+    )
+
+    await assertThrowsError(
+      try await project.testClient.send(
+        DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
+      )
+    )
+  }
+
+  func testDefinitionIsNilForUnresolvedSymbolLink() async throws {
+    let project = try await IndexedSingleSwiftFileTestProject(
+      """
+      /// See ``1️⃣DoesNotExist``
+      public func useFoo() {}
+      """
+    )
+
+    await assertThrowsError(
+      try await project.testClient.send(
+        DefinitionRequest(textDocument: TextDocumentIdentifier(project.fileURI), position: project.positions["1️⃣"])
+      )
+    )
+  }
+}


### PR DESCRIPTION
This PR introduces go-to-definition support for Markdown and Tutorial files along with symbols referenced in documentation comments in Swift files.

To enable this functionality, symbol graphs are now emitted during both the initial build and background indexing. The generated symbol graph data is then used to resolve symbols referenced in documentation files and navigate to their corresponding source definitions.

### Changes
- Emit symbol graphs during the initial build.
- Emit symbol graphs during background indexing.
- Add go-to-definition support for Markdown and Tutorial files using the generated symbol graph data. 
- Add go-to-definition support for symbols  referenced in documentation comments in Swift files. 

### User Impact
Users can now invoke go-to-definition on symbols referenced in Markdown and Tutorial files, as well as Swift documentation comments, and navigate to the corresponding source definition.
