### PR TITLE
Enable SwiftPM BSP by default when using 6.5 toolchains

### DIFF
--- a/Sources/BuildServerIntegration/BuildServerManager.swift
+++ b/Sources/BuildServerIntegration/BuildServerManager.swift
@@ -289,14 +289,17 @@ private extension BuildServerSpec {
         selectedBuildSystem = .swiftbuild
       case (.native, _):
         selectedBuildSystem = .native
-      // If there is no explicit preference and we're background indexing, default to native
-      // for now.
+      // If there is no explicit preference and we're background indexing, use the toolchain version to pick a default.
       case (nil, true):
-        selectedBuildSystem = .native
+        selectedBuildSystem = await SwiftPMBuildSystem.defaultBuildSystem(toolchainRegistry: toolchainRegistry)
       // If there is no explicit preference and we're not background indexing, we should
       // attempt to match the user's manually intiated builds to maximize compatibility.
       case (nil, false):
-        selectedBuildSystem = inferredBuildSystem ?? .native
+        if let inferredBuildSystem {
+          selectedBuildSystem = inferredBuildSystem
+        } else {
+          selectedBuildSystem = await SwiftPMBuildSystem.defaultBuildSystem(toolchainRegistry: toolchainRegistry)
+        }
       }
       // Choose the appropiate adapter based on the build system we just selected.
       switch selectedBuildSystem {
@@ -2122,5 +2125,15 @@ private extension OnBuildLogMessageNotification {
     case nil:
       return nil
     }
+  }
+}
+
+extension SwiftPMBuildSystem {
+  package static func defaultBuildSystem(toolchainRegistry: ToolchainRegistry) async -> SwiftPMBuildSystem {
+    let toolchain = await toolchainRegistry.preferredToolchain(containing: [\.swift])
+    guard let swiftVersion = try? await toolchain?.swiftVersion, swiftVersion >= SwiftVersion(6, 5) else {
+      return .native
+    }
+    return .swiftbuild
   }
 }

--- a/Sources/SKTestSupport/SwiftPMTestProject.swift
+++ b/Sources/SKTestSupport/SwiftPMTestProject.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import BuildServerIntegration
 package import Foundation
 @_spi(SourceKitLSP) package import LanguageServerProtocol
 @_spi(SourceKitLSP) import SKLogging
@@ -241,9 +242,15 @@ package class SwiftPMTestProject: MultiFileTestProject {
   /// Build a SwiftPM package package manifest is located in the directory at `path`.
   package static func build(
     at path: URL,
-    buildSystem: SwiftPMBuildSystem = .native,
+    buildSystem: SwiftPMBuildSystem? = nil,
     extraArguments: [String] = []
   ) async throws {
+    let resolvedBuildSystem: SwiftPMBuildSystem
+    if let buildSystem {
+      resolvedBuildSystem = buildSystem
+    } else {
+      resolvedBuildSystem = await SwiftPMBuildSystem.defaultBuildSystem(toolchainRegistry: ToolchainRegistry.forTesting)
+    }
     guard let swift = await ToolchainRegistry.forTesting.default?.swift else {
       throw Error.swiftNotFound
     }
@@ -255,7 +262,7 @@ package class SwiftPMTestProject: MultiFileTestProject {
         "--build-tests",
         "-Xswiftc", "-index-ignore-system-modules",
         "-Xcc", "-index-ignore-system-symbols",
-        "--build-system", buildSystem.rawValue,
+        "--build-system", resolvedBuildSystem.rawValue,
       ] + extraArguments
     if let globalModuleCache = try globalModuleCache {
       arguments += [

--- a/Tests/SourceKitLSPTests/WorkspaceTests.swift
+++ b/Tests/SourceKitLSPTests/WorkspaceTests.swift
@@ -1394,11 +1394,10 @@ final class WorkspaceTests: SourceKitLSPTestCase {
         workspace: DocumentURI(project.scratchDirectory)
       )
     )
-    if project.testClient.server.options.swiftPMOrDefault.buildSystem == .swiftbuild {
-      XCTAssertEqual(outputPaths.outputPaths.map { $0.suffix(7) }.sorted(), ["FileA.o", "FileB.o"])
-    } else {
-      XCTAssertEqual(outputPaths.outputPaths.map { $0.suffix(13) }.sorted(), ["FileA.swift.o", "FileB.swift.o"])
-    }
+    XCTAssertTrue(
+      outputPaths.outputPaths.map { $0.suffix(7) }.sorted() == ["FileA.o", "FileB.o"]
+        || outputPaths.outputPaths.map { $0.suffix(13) }.sorted() == ["FileA.swift.o", "FileB.swift.o"]
+    )
   }
 
   func testOrphanedClangLanguageServiceShutdown() async throws {


### PR DESCRIPTION
Default to the SwiftPM BSP backend for compiler args, etc. when using a 6.5 toolchain.