### PR TITLE
Unblock new dependency of XCTest on Swift Testing for Windows

### DIFF
--- a/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
+++ b/Sources/SKTestSupport/IndexedSingleSwiftFileTestProject.swift
@@ -114,7 +114,7 @@ package struct IndexedSingleSwiftFileTestProject {
     if let sdk = defaultSDKPath {
       compilerArguments += ["-sdk", sdk]
 
-      // The following are needed so we can import XCTest
+      // The following are needed so we can import XCTest and Swift Testing.
       let sdkUrl = URL(fileURLWithPath: sdk)
       #if os(Windows)
       let platform = sdkUrl.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
@@ -131,6 +131,23 @@ package struct IndexedSingleSwiftFileTestProject {
           "windows"
         )
       compilerArguments += ["-I", try xctestModuleDir.filePath]
+
+      // Test files that only import XCTest still depend on Swift Testing for
+      // interoperability support.
+      if let swiftTestingVersion = info.defaults.swiftTestingVersion {
+        let swiftTestingModuleDir =
+          platform
+          .appending(
+            components: "Developer",
+            "Library",
+            "Testing-\(swiftTestingVersion)",
+            "usr",
+            "lib",
+            "swift",
+            "windows"
+          )
+        compilerArguments += ["-I", try swiftTestingModuleDir.filePath]
+      }
       #else
       let usrLibDir =
         sdkUrl


### PR DESCRIPTION
Update compiler args for a test to include the Testing module alongside the XCTest module.

XCTest requires a Swift Testing dependency when built in the toolchain: https://github.com/swiftlang/swift-corelibs-xctest/pull/549

On Windows, the test "IndexedSingleSwiftFileTestProject" manually constructs the compilation flags in a way that previously only included the XCTest module, causing a test failure in the PR that adds the Swift Testing dependency.