### PR TITLE
Fix raw string literal delimiter minimization

### DIFF
--- a/Sources/SwiftSyntaxCodeActions/FormatRawStringLiteral.swift
+++ b/Sources/SwiftSyntaxCodeActions/FormatRawStringLiteral.swift
@@ -96,7 +96,7 @@ private extension StringLiteralExprSyntax {
       hashCount == 0
       ? self.closingQuote.with(\.trailingTrivia, closingPounds?.trailingTrivia ?? self.closingQuote.trailingTrivia)
       : self.closingQuote.with(\.trailingTrivia, [])
-    
+
     let segments = StringLiteralSegmentListSyntax(
       self.segments.map { segment in
         if case let .expressionSegment(expressionSegment) = segment {

--- a/Sources/SwiftSyntaxCodeActions/FormatRawStringLiteral.swift
+++ b/Sources/SwiftSyntaxCodeActions/FormatRawStringLiteral.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftParser
 import SwiftRefactor
 package import SwiftSyntax
 
@@ -51,18 +52,91 @@ package struct FormatRawStringLiteral: SyntaxRefactoringProvider {
       }
     }
 
-    guard maximumHashes > 0 else {
-      return
-        lit
-        .with(\.openingPounds, lit.openingPounds?.with(\.tokenKind, .rawStringPoundDelimiter("")))
-        .with(\.closingPounds, lit.closingPounds?.with(\.tokenKind, .rawStringPoundDelimiter("")))
+    let originalHashCount = lit.openingPounds?.text.count ?? 0
+    let maximumCandidateHashCount = max(maximumHashes + 1, originalHashCount)
+
+    for hashCount in 0...maximumCandidateHashCount {
+      let candidate = lit.withHashDelimiterCount(hashCount)
+      if candidate.isValidReplacement(for: lit) {
+        return candidate
+      }
     }
 
-    let delimiters = String(repeating: "#", count: maximumHashes + 1)
+    return lit
+  }
+}
+
+private extension StringLiteralExprSyntax {
+  func withHashDelimiterCount(_ hashCount: Int) -> StringLiteralExprSyntax {
+    let delimiters = String(repeating: "#", count: hashCount)
+    let openingPounds = self.openingPounds
+    let closingPounds = self.closingPounds
+    let candidateOpeningPounds =
+      hashCount == 0
+      ? nil
+      : TokenSyntax.rawStringPoundDelimiter(
+        delimiters,
+        leadingTrivia: openingPounds?.leadingTrivia ?? self.openingQuote.leadingTrivia
+      )
+
+    let candidateClosingPounds =
+      hashCount == 0
+      ? nil
+      : TokenSyntax.rawStringPoundDelimiter(
+        delimiters,
+        trailingTrivia: closingPounds?.trailingTrivia ?? self.closingQuote.trailingTrivia
+      )
+
+    let candidateOpeningQuote =
+      hashCount == 0
+      ? self.openingQuote.with(\.leadingTrivia, openingPounds?.leadingTrivia ?? self.openingQuote.leadingTrivia)
+      : self.openingQuote.with(\.leadingTrivia, [])
+
+    let candidateClosingQuote =
+      hashCount == 0
+      ? self.closingQuote.with(\.trailingTrivia, closingPounds?.trailingTrivia ?? self.closingQuote.trailingTrivia)
+      : self.closingQuote.with(\.trailingTrivia, [])
+    
+    let segments = StringLiteralSegmentListSyntax(
+      self.segments.map { segment in
+        if case let .expressionSegment(expressionSegment) = segment {
+          let candidatePounds =
+            hashCount == 0
+            ? nil
+            : TokenSyntax.rawStringPoundDelimiter(
+              delimiters,
+              leadingTrivia: expressionSegment.pounds?.leadingTrivia ?? [],
+              trailingTrivia: expressionSegment.pounds?.trailingTrivia ?? []
+            )
+          return .expressionSegment(expressionSegment.with(\.pounds, candidatePounds))
+        }
+        return segment
+      }
+    )
+
     return
-      lit
-      .with(\.openingPounds, lit.openingPounds?.with(\.tokenKind, .rawStringPoundDelimiter(delimiters)))
-      .with(\.closingPounds, lit.closingPounds?.with(\.tokenKind, .rawStringPoundDelimiter(delimiters)))
+      self
+      .with(\.openingPounds, candidateOpeningPounds)
+      .with(\.openingQuote, candidateOpeningQuote)
+      .with(\.segments, segments)
+      .with(\.closingQuote, candidateClosingQuote)
+      .with(\.closingPounds, candidateClosingPounds)
+  }
+
+  func isValidReplacement(for original: StringLiteralExprSyntax) -> Bool {
+    let source = self.description
+    var parser = Parser(source)
+    let parsedExpr = ExprSyntax.parse(from: &parser)
+
+    guard !parsedExpr.hasError, parsedExpr.description == source else {
+      return false
+    }
+
+    guard let parsedLiteral = parsedExpr.as(StringLiteralExprSyntax.self) else {
+      return false
+    }
+
+    return parsedLiteral.representedLiteralValue == original.representedLiteralValue
   }
 }
 

--- a/Tests/SourceKitLSPTests/CodeActionTests.swift
+++ b/Tests/SourceKitLSPTests/CodeActionTests.swift
@@ -1138,9 +1138,7 @@ final class CodeActionTests: SourceKitLSPTestCase {
               uri: [
                 TextEdit(
                   range: positions["1️⃣"]..<positions["3️⃣"],
-                  newText: ##"""
-                    ##"Hello \#(name)"##
-                    """##
+                  newText: "\"Hello \\(name)\""
                 )
               ]
             ]

--- a/Tests/SwiftSyntaxCodeActionsTests/FormatRawStringLiteralTests.swift
+++ b/Tests/SwiftSyntaxCodeActionsTests/FormatRawStringLiteralTests.swift
@@ -21,16 +21,22 @@ final class FormatRawStringLiteralTests: XCTestCase {
   func testDelimiterPlacement() throws {
     let tests = [
       (#line, literal: #" "Hello World" "#, expectation: #" "Hello World" "#),
-      (#line, literal: ##" #"Hello World" "##, expectation: #" "Hello World" "#),
+      (#line, literal: ##" #"Hello World" "##, expectation: ##" #"Hello World" "##),
       (#line, literal: ##" #"Hello World"# "##, expectation: #" "Hello World" "#),
       (#line, literal: #####" "####" "#####, expectation: #####" "####" "#####),
-      (#line, literal: #####" #"####"# "#####, expectation: ######" #####"####"##### "######),
-      (#line, literal: #####" #"\####(hello)"# "#####, expectation: ######" #####"\####(hello)"##### "######),
+      (#line, literal: #####" #"####"# "#####, expectation: #####" "####" "#####),
+      (#line, literal: #####" #"\####(hello)"# "#####, expectation: #####" ####"\####(hello)"#### "#####),
       (
         #line, literal: #######" #"###### \####(hello) ##"# "#######,
-        expectation: ########" #######"###### \####(hello) ##"####### "########
+        expectation: #########" ####"###### \####(hello) ##"#### "#########
       ),
-      (#line, literal: ########" #######"hello \(world) "####### "########, expectation: #" "hello \(world) " "#),
+      (#line, literal: ########" #######"hello \(world) "####### "########, expectation: ##" #"hello \(world) "# "##),
+      (#line, literal: ##" #""# "##, expectation: #" "" "#),
+      (#line, literal: #####" #"#"# "#####, expectation: #####" "#" "#####),
+      (#line, literal: ######" #"###"# "######, expectation: ######" "###" "######),
+      (#line, literal: ####" ###"Plain"### "####, expectation: #" "Plain" "#),
+      (#line, literal: ####" ###"Quote"Here"### "####, expectation: ##" #"Quote"Here"# "##),
+      (#line, literal: ###"##"""##"###, expectation: ##"#"""#"##),
     ]
 
     for (line, literal, expectation) in tests {
@@ -43,6 +49,33 @@ final class FormatRawStringLiteralTests: XCTestCase {
         expected: expectation,
         line: UInt(line)
       )
+    }
+  }
+
+  func testMinimizationPreservesParsedStringSemantics() throws {
+    let tests = [
+      (#line, literal: ##"#"""#"##, expectation: ##"#"""#"##),
+      (#line, literal: ##"#"He says "Hi""#"##, expectation: ##"#"He says "Hi""#"##),
+      (#line, literal: ##"#"C:\Users"#"##, expectation: ##"#"C:\Users"#"##),
+      (#line, literal: ##"#"6 times 7 is \#(6 * 7)."#"##, expectation: #""6 times 7 is \(6 * 7).""#),
+      (#line, literal: ####"###"Line1\###nLine2"###"####, expectation: ####"##"Line1\###nLine2"##"####),
+      (#line, literal: ###"##"Hello"##"###, expectation: #""Hello""#),
+      (#line, literal: ####"###"Hello ## world"###"####, expectation: ##""Hello ## world""##),
+    ]
+
+    for (line, literalSource, expectationSource) in tests {
+      let literal = try XCTUnwrap(
+        StringLiteralExprSyntax.parseWithoutDiagnostics(from: literalSource),
+        line: UInt(line)
+      )
+
+      let candidate = FormatRawStringLiteral.refactor(syntax: literal, in: ())
+      assertStringsEqualWithDiff(candidate.description, expectationSource, line: UInt(line))
+      var parser = Parser(candidate.description)
+      let parsedCandidate = ExprSyntax.parse(from: &parser)
+      XCTAssertFalse(parsedCandidate.hasError, line: UInt(line))
+      XCTAssertNotNil(parsedCandidate.as(StringLiteralExprSyntax.self), line: UInt(line))
+      XCTAssertEqual(candidate.representedLiteralValue, literal.representedLiteralValue, line: UInt(line))
     }
   }
 }


### PR DESCRIPTION
Fixes #2465 

Fix raw string literal minimization semantics. Ensure the raw string delimiter refactoring only applies transformations that remain syntactically valid and preserve the original representedLiteralValue, including nested quotes, backslashes, interpolations, and escape sequences. Add regression tests covering these cases.